### PR TITLE
Avoid redundant manual dereferences 

### DIFF
--- a/v2/api/alertsmanagement/v1api20210401/smart_detector_alert_rule_types_gen.go
+++ b/v2/api/alertsmanagement/v1api20210401/smart_detector_alert_rule_types_gen.go
@@ -335,7 +335,7 @@ func (rule *SmartDetectorAlertRule_Spec) ConvertToARM(resolved genruntime.Conver
 		result.Properties = &arm.AlertRuleProperties{}
 	}
 	if rule.ActionGroups != nil {
-		actionGroups_ARM, err := (*rule.ActionGroups).ConvertToARM(resolved)
+		actionGroups_ARM, err := rule.ActionGroups.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -347,7 +347,7 @@ func (rule *SmartDetectorAlertRule_Spec) ConvertToARM(resolved genruntime.Conver
 		result.Properties.Description = &description
 	}
 	if rule.Detector != nil {
-		detector_ARM, err := (*rule.Detector).ConvertToARM(resolved)
+		detector_ARM, err := rule.Detector.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -378,7 +378,7 @@ func (rule *SmartDetectorAlertRule_Spec) ConvertToARM(resolved genruntime.Conver
 		result.Properties.State = &state
 	}
 	if rule.Throttling != nil {
-		throttling_ARM, err := (*rule.Throttling).ConvertToARM(resolved)
+		throttling_ARM, err := rule.Throttling.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/alertsmanagement/v1api20230301/prometheus_rule_group_types_gen.go
+++ b/v2/api/alertsmanagement/v1api20230301/prometheus_rule_group_types_gen.go
@@ -1219,7 +1219,7 @@ func (rule *PrometheusRule) ConvertToARM(resolved genruntime.ConvertToARMResolve
 
 	// Set property "ResolveConfiguration":
 	if rule.ResolveConfiguration != nil {
-		resolveConfiguration_ARM, err := (*rule.ResolveConfiguration).ConvertToARM(resolved)
+		resolveConfiguration_ARM, err := rule.ResolveConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/apimanagement/v1api20220801/api_types_gen.go
+++ b/v2/api/apimanagement/v1api20220801/api_types_gen.go
@@ -421,7 +421,7 @@ func (api *Api_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetail
 		result.Properties.ApiVersionDescription = &apiVersionDescription
 	}
 	if api.ApiVersionSet != nil {
-		apiVersionSet_ARM, err := (*api.ApiVersionSet).ConvertToARM(resolved)
+		apiVersionSet_ARM, err := api.ApiVersionSet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -437,7 +437,7 @@ func (api *Api_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetail
 		result.Properties.ApiVersionSetId = &apiVersionSetId
 	}
 	if api.AuthenticationSettings != nil {
-		authenticationSettings_ARM, err := (*api.AuthenticationSettings).ConvertToARM(resolved)
+		authenticationSettings_ARM, err := api.AuthenticationSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -445,7 +445,7 @@ func (api *Api_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetail
 		result.Properties.AuthenticationSettings = &authenticationSettings
 	}
 	if api.Contact != nil {
-		contact_ARM, err := (*api.Contact).ConvertToARM(resolved)
+		contact_ARM, err := api.Contact.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -471,7 +471,7 @@ func (api *Api_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetail
 		result.Properties.IsCurrent = &isCurrent
 	}
 	if api.License != nil {
-		license_ARM, err := (*api.License).ConvertToARM(resolved)
+		license_ARM, err := api.License.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -500,7 +500,7 @@ func (api *Api_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetail
 		result.Properties.SourceApiId = &sourceApiId
 	}
 	if api.SubscriptionKeyParameterNames != nil {
-		subscriptionKeyParameterNames_ARM, err := (*api.SubscriptionKeyParameterNames).ConvertToARM(resolved)
+		subscriptionKeyParameterNames_ARM, err := api.SubscriptionKeyParameterNames.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -532,7 +532,7 @@ func (api *Api_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetail
 		result.Properties.Value = &value
 	}
 	if api.WsdlSelector != nil {
-		wsdlSelector_ARM, err := (*api.WsdlSelector).ConvertToARM(resolved)
+		wsdlSelector_ARM, err := api.WsdlSelector.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3320,7 +3320,7 @@ func (contract *AuthenticationSettingsContract) ConvertToARM(resolved genruntime
 
 	// Set property "OAuth2":
 	if contract.OAuth2 != nil {
-		oAuth2_ARM, err := (*contract.OAuth2).ConvertToARM(resolved)
+		oAuth2_ARM, err := contract.OAuth2.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3339,7 +3339,7 @@ func (contract *AuthenticationSettingsContract) ConvertToARM(resolved genruntime
 
 	// Set property "Openid":
 	if contract.Openid != nil {
-		openid_ARM, err := (*contract.Openid).ConvertToARM(resolved)
+		openid_ARM, err := contract.Openid.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/apimanagement/v1api20220801/authorization_provider_types_gen.go
+++ b/v2/api/apimanagement/v1api20220801/authorization_provider_types_gen.go
@@ -303,7 +303,7 @@ func (provider *AuthorizationProvider_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties.IdentityProvider = &identityProvider
 	}
 	if provider.Oauth2 != nil {
-		oauth2_ARM, err := (*provider.Oauth2).ConvertToARM(resolved)
+		oauth2_ARM, err := provider.Oauth2.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -812,7 +812,7 @@ func (settings *AuthorizationProviderOAuth2Settings) ConvertToARM(resolved genru
 
 	// Set property "GrantTypes":
 	if settings.GrantTypes != nil {
-		grantTypes_ARM, err := (*settings.GrantTypes).ConvertToARM(resolved)
+		grantTypes_ARM, err := settings.GrantTypes.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/apimanagement/v1api20220801/backend_types_gen.go
+++ b/v2/api/apimanagement/v1api20220801/backend_types_gen.go
@@ -326,7 +326,7 @@ func (backend *Backend_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties = &arm.BackendContractProperties{}
 	}
 	if backend.Credentials != nil {
-		credentials_ARM, err := (*backend.Credentials).ConvertToARM(resolved)
+		credentials_ARM, err := backend.Credentials.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -338,7 +338,7 @@ func (backend *Backend_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.Description = &description
 	}
 	if backend.Properties != nil {
-		properties_ARM, err := (*backend.Properties).ConvertToARM(resolved)
+		properties_ARM, err := backend.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -352,7 +352,7 @@ func (backend *Backend_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.Protocol = &protocol
 	}
 	if backend.Proxy != nil {
-		proxy_ARM, err := (*backend.Proxy).ConvertToARM(resolved)
+		proxy_ARM, err := backend.Proxy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -372,7 +372,7 @@ func (backend *Backend_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.Title = &title
 	}
 	if backend.Tls != nil {
-		tls_ARM, err := (*backend.Tls).ConvertToARM(resolved)
+		tls_ARM, err := backend.Tls.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1342,7 +1342,7 @@ func (contract *BackendCredentialsContract) ConvertToARM(resolved genruntime.Con
 
 	// Set property "Authorization":
 	if contract.Authorization != nil {
-		authorization_ARM, err := (*contract.Authorization).ConvertToARM(resolved)
+		authorization_ARM, err := contract.Authorization.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1922,7 +1922,7 @@ func (properties *BackendProperties) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "ServiceFabricCluster":
 	if properties.ServiceFabricCluster != nil {
-		serviceFabricCluster_ARM, err := (*properties.ServiceFabricCluster).ConvertToARM(resolved)
+		serviceFabricCluster_ARM, err := properties.ServiceFabricCluster.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/apimanagement/v1api20220801/named_value_types_gen.go
+++ b/v2/api/apimanagement/v1api20220801/named_value_types_gen.go
@@ -312,7 +312,7 @@ func (value *NamedValue_Spec) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.Properties.DisplayName = &displayName
 	}
 	if value.KeyVault != nil {
-		keyVault_ARM, err := (*value.KeyVault).ConvertToARM(resolved)
+		keyVault_ARM, err := value.KeyVault.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/apimanagement/v1api20220801/service_types_gen.go
+++ b/v2/api/apimanagement/v1api20220801/service_types_gen.go
@@ -377,7 +377,7 @@ func (service *Service_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Identity":
 	if service.Identity != nil {
-		identity_ARM, err := (*service.Identity).ConvertToARM(resolved)
+		identity_ARM, err := service.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -421,7 +421,7 @@ func (service *Service_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.AdditionalLocations = append(result.Properties.AdditionalLocations, *item_ARM.(*arm.AdditionalLocation))
 	}
 	if service.ApiVersionConstraint != nil {
-		apiVersionConstraint_ARM, err := (*service.ApiVersionConstraint).ConvertToARM(resolved)
+		apiVersionConstraint_ARM, err := service.ApiVersionConstraint.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -493,7 +493,7 @@ func (service *Service_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.Restore = &restore
 	}
 	if service.VirtualNetworkConfiguration != nil {
-		virtualNetworkConfiguration_ARM, err := (*service.VirtualNetworkConfiguration).ConvertToARM(resolved)
+		virtualNetworkConfiguration_ARM, err := service.VirtualNetworkConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -509,7 +509,7 @@ func (service *Service_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Sku":
 	if service.Sku != nil {
-		sku_ARM, err := (*service.Sku).ConvertToARM(resolved)
+		sku_ARM, err := service.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2677,7 +2677,7 @@ func (location *AdditionalLocation) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Sku":
 	if location.Sku != nil {
-		sku_ARM, err := (*location.Sku).ConvertToARM(resolved)
+		sku_ARM, err := location.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2687,7 +2687,7 @@ func (location *AdditionalLocation) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "VirtualNetworkConfiguration":
 	if location.VirtualNetworkConfiguration != nil {
-		virtualNetworkConfiguration_ARM, err := (*location.VirtualNetworkConfiguration).ConvertToARM(resolved)
+		virtualNetworkConfiguration_ARM, err := location.VirtualNetworkConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4089,7 +4089,7 @@ func (configuration *CertificateConfiguration) ConvertToARM(resolved genruntime.
 
 	// Set property "Certificate":
 	if configuration.Certificate != nil {
-		certificate_ARM, err := (*configuration.Certificate).ConvertToARM(resolved)
+		certificate_ARM, err := configuration.Certificate.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4467,7 +4467,7 @@ func (configuration *HostnameConfiguration) ConvertToARM(resolved genruntime.Con
 
 	// Set property "Certificate":
 	if configuration.Certificate != nil {
-		certificate_ARM, err := (*configuration.Certificate).ConvertToARM(resolved)
+		certificate_ARM, err := configuration.Certificate.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/apimanagement/v1api20230501preview/api_types_gen.go
+++ b/v2/api/apimanagement/v1api20230501preview/api_types_gen.go
@@ -425,7 +425,7 @@ func (api *Api_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetail
 		result.Properties.ApiVersionDescription = &apiVersionDescription
 	}
 	if api.ApiVersionSet != nil {
-		apiVersionSet_ARM, err := (*api.ApiVersionSet).ConvertToARM(resolved)
+		apiVersionSet_ARM, err := api.ApiVersionSet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -441,7 +441,7 @@ func (api *Api_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetail
 		result.Properties.ApiVersionSetId = &apiVersionSetId
 	}
 	if api.AuthenticationSettings != nil {
-		authenticationSettings_ARM, err := (*api.AuthenticationSettings).ConvertToARM(resolved)
+		authenticationSettings_ARM, err := api.AuthenticationSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -449,7 +449,7 @@ func (api *Api_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetail
 		result.Properties.AuthenticationSettings = &authenticationSettings
 	}
 	if api.Contact != nil {
-		contact_ARM, err := (*api.Contact).ConvertToARM(resolved)
+		contact_ARM, err := api.Contact.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -475,7 +475,7 @@ func (api *Api_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetail
 		result.Properties.IsCurrent = &isCurrent
 	}
 	if api.License != nil {
-		license_ARM, err := (*api.License).ConvertToARM(resolved)
+		license_ARM, err := api.License.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -504,7 +504,7 @@ func (api *Api_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetail
 		result.Properties.SourceApiId = &sourceApiId
 	}
 	if api.SubscriptionKeyParameterNames != nil {
-		subscriptionKeyParameterNames_ARM, err := (*api.SubscriptionKeyParameterNames).ConvertToARM(resolved)
+		subscriptionKeyParameterNames_ARM, err := api.SubscriptionKeyParameterNames.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -536,7 +536,7 @@ func (api *Api_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetail
 		result.Properties.Value = &value
 	}
 	if api.WsdlSelector != nil {
-		wsdlSelector_ARM, err := (*api.WsdlSelector).ConvertToARM(resolved)
+		wsdlSelector_ARM, err := api.WsdlSelector.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3150,7 +3150,7 @@ func (contract *AuthenticationSettingsContract) ConvertToARM(resolved genruntime
 
 	// Set property "OAuth2":
 	if contract.OAuth2 != nil {
-		oAuth2_ARM, err := (*contract.OAuth2).ConvertToARM(resolved)
+		oAuth2_ARM, err := contract.OAuth2.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3169,7 +3169,7 @@ func (contract *AuthenticationSettingsContract) ConvertToARM(resolved genruntime
 
 	// Set property "Openid":
 	if contract.Openid != nil {
-		openid_ARM, err := (*contract.Openid).ConvertToARM(resolved)
+		openid_ARM, err := contract.Openid.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/apimanagement/v1api20230501preview/authorization_provider_types_gen.go
+++ b/v2/api/apimanagement/v1api20230501preview/authorization_provider_types_gen.go
@@ -306,7 +306,7 @@ func (provider *AuthorizationProvider_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties.IdentityProvider = &identityProvider
 	}
 	if provider.Oauth2 != nil {
-		oauth2_ARM, err := (*provider.Oauth2).ConvertToARM(resolved)
+		oauth2_ARM, err := provider.Oauth2.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -790,7 +790,7 @@ func (settings *AuthorizationProviderOAuth2Settings) ConvertToARM(resolved genru
 
 	// Set property "GrantTypes":
 	if settings.GrantTypes != nil {
-		grantTypes_ARM, err := (*settings.GrantTypes).ConvertToARM(resolved)
+		grantTypes_ARM, err := settings.GrantTypes.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/apimanagement/v1api20230501preview/backend_types_gen.go
+++ b/v2/api/apimanagement/v1api20230501preview/backend_types_gen.go
@@ -341,7 +341,7 @@ func (backend *Backend_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties = &arm.BackendContractProperties{}
 	}
 	if backend.CircuitBreaker != nil {
-		circuitBreaker_ARM, err := (*backend.CircuitBreaker).ConvertToARM(resolved)
+		circuitBreaker_ARM, err := backend.CircuitBreaker.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -349,7 +349,7 @@ func (backend *Backend_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.CircuitBreaker = &circuitBreaker
 	}
 	if backend.Credentials != nil {
-		credentials_ARM, err := (*backend.Credentials).ConvertToARM(resolved)
+		credentials_ARM, err := backend.Credentials.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -361,7 +361,7 @@ func (backend *Backend_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.Description = &description
 	}
 	if backend.Pool != nil {
-		pool_ARM, err := (*backend.Pool).ConvertToARM(resolved)
+		pool_ARM, err := backend.Pool.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -369,7 +369,7 @@ func (backend *Backend_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.Pool = &pool
 	}
 	if backend.Properties != nil {
-		properties_ARM, err := (*backend.Properties).ConvertToARM(resolved)
+		properties_ARM, err := backend.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -383,7 +383,7 @@ func (backend *Backend_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.Protocol = &protocol
 	}
 	if backend.Proxy != nil {
-		proxy_ARM, err := (*backend.Proxy).ConvertToARM(resolved)
+		proxy_ARM, err := backend.Proxy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -403,7 +403,7 @@ func (backend *Backend_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.Title = &title
 	}
 	if backend.Tls != nil {
-		tls_ARM, err := (*backend.Tls).ConvertToARM(resolved)
+		tls_ARM, err := backend.Tls.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1748,7 +1748,7 @@ func (contract *BackendCredentialsContract) ConvertToARM(resolved genruntime.Con
 
 	// Set property "Authorization":
 	if contract.Authorization != nil {
-		authorization_ARM, err := (*contract.Authorization).ConvertToARM(resolved)
+		authorization_ARM, err := contract.Authorization.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2482,7 +2482,7 @@ func (properties *BackendProperties) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "ServiceFabricCluster":
 	if properties.ServiceFabricCluster != nil {
-		serviceFabricCluster_ARM, err := (*properties.ServiceFabricCluster).ConvertToARM(resolved)
+		serviceFabricCluster_ARM, err := properties.ServiceFabricCluster.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3790,7 +3790,7 @@ func (rule *CircuitBreakerRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "FailureCondition":
 	if rule.FailureCondition != nil {
-		failureCondition_ARM, err := (*rule.FailureCondition).ConvertToARM(resolved)
+		failureCondition_ARM, err := rule.FailureCondition.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/apimanagement/v1api20230501preview/named_value_types_gen.go
+++ b/v2/api/apimanagement/v1api20230501preview/named_value_types_gen.go
@@ -315,7 +315,7 @@ func (value *NamedValue_Spec) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.Properties.DisplayName = &displayName
 	}
 	if value.KeyVault != nil {
-		keyVault_ARM, err := (*value.KeyVault).ConvertToARM(resolved)
+		keyVault_ARM, err := value.KeyVault.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/apimanagement/v1api20230501preview/service_types_gen.go
+++ b/v2/api/apimanagement/v1api20230501preview/service_types_gen.go
@@ -389,7 +389,7 @@ func (service *Service_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Identity":
 	if service.Identity != nil {
-		identity_ARM, err := (*service.Identity).ConvertToARM(resolved)
+		identity_ARM, err := service.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -436,7 +436,7 @@ func (service *Service_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.AdditionalLocations = append(result.Properties.AdditionalLocations, *item_ARM.(*arm.AdditionalLocation))
 	}
 	if service.ApiVersionConstraint != nil {
-		apiVersionConstraint_ARM, err := (*service.ApiVersionConstraint).ConvertToARM(resolved)
+		apiVersionConstraint_ARM, err := service.ApiVersionConstraint.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -451,7 +451,7 @@ func (service *Service_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.Certificates = append(result.Properties.Certificates, *item_ARM.(*arm.CertificateConfiguration))
 	}
 	if service.ConfigurationApi != nil {
-		configurationApi_ARM, err := (*service.ConfigurationApi).ConvertToARM(resolved)
+		configurationApi_ARM, err := service.ConfigurationApi.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -528,7 +528,7 @@ func (service *Service_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.Restore = &restore
 	}
 	if service.VirtualNetworkConfiguration != nil {
-		virtualNetworkConfiguration_ARM, err := (*service.VirtualNetworkConfiguration).ConvertToARM(resolved)
+		virtualNetworkConfiguration_ARM, err := service.VirtualNetworkConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -544,7 +544,7 @@ func (service *Service_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Sku":
 	if service.Sku != nil {
-		sku_ARM, err := (*service.Sku).ConvertToARM(resolved)
+		sku_ARM, err := service.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2723,7 +2723,7 @@ func (location *AdditionalLocation) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Sku":
 	if location.Sku != nil {
-		sku_ARM, err := (*location.Sku).ConvertToARM(resolved)
+		sku_ARM, err := location.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2733,7 +2733,7 @@ func (location *AdditionalLocation) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "VirtualNetworkConfiguration":
 	if location.VirtualNetworkConfiguration != nil {
-		virtualNetworkConfiguration_ARM, err := (*location.VirtualNetworkConfiguration).ConvertToARM(resolved)
+		virtualNetworkConfiguration_ARM, err := location.VirtualNetworkConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4075,7 +4075,7 @@ func (configuration *CertificateConfiguration) ConvertToARM(resolved genruntime.
 
 	// Set property "Certificate":
 	if configuration.Certificate != nil {
-		certificate_ARM, err := (*configuration.Certificate).ConvertToARM(resolved)
+		certificate_ARM, err := configuration.Certificate.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4588,7 +4588,7 @@ func (configuration *HostnameConfiguration) ConvertToARM(resolved genruntime.Con
 
 	// Set property "Certificate":
 	if configuration.Certificate != nil {
-		certificate_ARM, err := (*configuration.Certificate).ConvertToARM(resolved)
+		certificate_ARM, err := configuration.Certificate.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/app/v1api20240301/auth_config_types_gen.go
+++ b/v2/api/app/v1api20240301/auth_config_types_gen.go
@@ -314,7 +314,7 @@ func (config *AuthConfig_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties = &arm.ContainerApps_AuthConfig_Properties_Spec{}
 	}
 	if config.EncryptionSettings != nil {
-		encryptionSettings_ARM, err := (*config.EncryptionSettings).ConvertToARM(resolved)
+		encryptionSettings_ARM, err := config.EncryptionSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -322,7 +322,7 @@ func (config *AuthConfig_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.EncryptionSettings = &encryptionSettings
 	}
 	if config.GlobalValidation != nil {
-		globalValidation_ARM, err := (*config.GlobalValidation).ConvertToARM(resolved)
+		globalValidation_ARM, err := config.GlobalValidation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -330,7 +330,7 @@ func (config *AuthConfig_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.GlobalValidation = &globalValidation
 	}
 	if config.HttpSettings != nil {
-		httpSettings_ARM, err := (*config.HttpSettings).ConvertToARM(resolved)
+		httpSettings_ARM, err := config.HttpSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -338,7 +338,7 @@ func (config *AuthConfig_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.HttpSettings = &httpSettings
 	}
 	if config.IdentityProviders != nil {
-		identityProviders_ARM, err := (*config.IdentityProviders).ConvertToARM(resolved)
+		identityProviders_ARM, err := config.IdentityProviders.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -346,7 +346,7 @@ func (config *AuthConfig_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.IdentityProviders = &identityProviders
 	}
 	if config.Login != nil {
-		login_ARM, err := (*config.Login).ConvertToARM(resolved)
+		login_ARM, err := config.Login.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -354,7 +354,7 @@ func (config *AuthConfig_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.Login = &login
 	}
 	if config.Platform != nil {
-		platform_ARM, err := (*config.Platform).ConvertToARM(resolved)
+		platform_ARM, err := config.Platform.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1916,7 +1916,7 @@ func (settings *HttpSettings) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "ForwardProxy":
 	if settings.ForwardProxy != nil {
-		forwardProxy_ARM, err := (*settings.ForwardProxy).ConvertToARM(resolved)
+		forwardProxy_ARM, err := settings.ForwardProxy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1932,7 +1932,7 @@ func (settings *HttpSettings) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "Routes":
 	if settings.Routes != nil {
-		routes_ARM, err := (*settings.Routes).ConvertToARM(resolved)
+		routes_ARM, err := settings.Routes.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2260,7 +2260,7 @@ func (providers *IdentityProviders) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Apple":
 	if providers.Apple != nil {
-		apple_ARM, err := (*providers.Apple).ConvertToARM(resolved)
+		apple_ARM, err := providers.Apple.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2270,7 +2270,7 @@ func (providers *IdentityProviders) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "AzureActiveDirectory":
 	if providers.AzureActiveDirectory != nil {
-		azureActiveDirectory_ARM, err := (*providers.AzureActiveDirectory).ConvertToARM(resolved)
+		azureActiveDirectory_ARM, err := providers.AzureActiveDirectory.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2280,7 +2280,7 @@ func (providers *IdentityProviders) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "AzureStaticWebApps":
 	if providers.AzureStaticWebApps != nil {
-		azureStaticWebApps_ARM, err := (*providers.AzureStaticWebApps).ConvertToARM(resolved)
+		azureStaticWebApps_ARM, err := providers.AzureStaticWebApps.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2302,7 +2302,7 @@ func (providers *IdentityProviders) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Facebook":
 	if providers.Facebook != nil {
-		facebook_ARM, err := (*providers.Facebook).ConvertToARM(resolved)
+		facebook_ARM, err := providers.Facebook.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2312,7 +2312,7 @@ func (providers *IdentityProviders) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "GitHub":
 	if providers.GitHub != nil {
-		gitHub_ARM, err := (*providers.GitHub).ConvertToARM(resolved)
+		gitHub_ARM, err := providers.GitHub.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2322,7 +2322,7 @@ func (providers *IdentityProviders) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Google":
 	if providers.Google != nil {
-		google_ARM, err := (*providers.Google).ConvertToARM(resolved)
+		google_ARM, err := providers.Google.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2332,7 +2332,7 @@ func (providers *IdentityProviders) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Twitter":
 	if providers.Twitter != nil {
-		twitter_ARM, err := (*providers.Twitter).ConvertToARM(resolved)
+		twitter_ARM, err := providers.Twitter.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3080,7 +3080,7 @@ func (login *Login) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 
 	// Set property "CookieExpiration":
 	if login.CookieExpiration != nil {
-		cookieExpiration_ARM, err := (*login.CookieExpiration).ConvertToARM(resolved)
+		cookieExpiration_ARM, err := login.CookieExpiration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3090,7 +3090,7 @@ func (login *Login) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 
 	// Set property "Nonce":
 	if login.Nonce != nil {
-		nonce_ARM, err := (*login.Nonce).ConvertToARM(resolved)
+		nonce_ARM, err := login.Nonce.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3106,7 +3106,7 @@ func (login *Login) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 
 	// Set property "Routes":
 	if login.Routes != nil {
-		routes_ARM, err := (*login.Routes).ConvertToARM(resolved)
+		routes_ARM, err := login.Routes.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3116,7 +3116,7 @@ func (login *Login) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 
 	// Set property "TokenStore":
 	if login.TokenStore != nil {
-		tokenStore_ARM, err := (*login.TokenStore).ConvertToARM(resolved)
+		tokenStore_ARM, err := login.TokenStore.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3767,7 +3767,7 @@ func (apple *Apple) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 
 	// Set property "Login":
 	if apple.Login != nil {
-		login_ARM, err := (*apple.Login).ConvertToARM(resolved)
+		login_ARM, err := apple.Login.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3777,7 +3777,7 @@ func (apple *Apple) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 
 	// Set property "Registration":
 	if apple.Registration != nil {
-		registration_ARM, err := (*apple.Registration).ConvertToARM(resolved)
+		registration_ARM, err := apple.Registration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4109,7 +4109,7 @@ func (directory *AzureActiveDirectory) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "Login":
 	if directory.Login != nil {
-		login_ARM, err := (*directory.Login).ConvertToARM(resolved)
+		login_ARM, err := directory.Login.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4119,7 +4119,7 @@ func (directory *AzureActiveDirectory) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "Registration":
 	if directory.Registration != nil {
-		registration_ARM, err := (*directory.Registration).ConvertToARM(resolved)
+		registration_ARM, err := directory.Registration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4129,7 +4129,7 @@ func (directory *AzureActiveDirectory) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "Validation":
 	if directory.Validation != nil {
-		validation_ARM, err := (*directory.Validation).ConvertToARM(resolved)
+		validation_ARM, err := directory.Validation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4566,7 +4566,7 @@ func (apps *AzureStaticWebApps) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "Registration":
 	if apps.Registration != nil {
-		registration_ARM, err := (*apps.Registration).ConvertToARM(resolved)
+		registration_ARM, err := apps.Registration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5006,7 +5006,7 @@ func (provider *CustomOpenIdConnectProvider) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Login":
 	if provider.Login != nil {
-		login_ARM, err := (*provider.Login).ConvertToARM(resolved)
+		login_ARM, err := provider.Login.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5016,7 +5016,7 @@ func (provider *CustomOpenIdConnectProvider) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Registration":
 	if provider.Registration != nil {
-		registration_ARM, err := (*provider.Registration).ConvertToARM(resolved)
+		registration_ARM, err := provider.Registration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5341,7 +5341,7 @@ func (facebook *Facebook) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "Login":
 	if facebook.Login != nil {
-		login_ARM, err := (*facebook.Login).ConvertToARM(resolved)
+		login_ARM, err := facebook.Login.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5351,7 +5351,7 @@ func (facebook *Facebook) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "Registration":
 	if facebook.Registration != nil {
-		registration_ARM, err := (*facebook.Registration).ConvertToARM(resolved)
+		registration_ARM, err := facebook.Registration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5928,7 +5928,7 @@ func (gitHub *GitHub) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 
 	// Set property "Login":
 	if gitHub.Login != nil {
-		login_ARM, err := (*gitHub.Login).ConvertToARM(resolved)
+		login_ARM, err := gitHub.Login.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5938,7 +5938,7 @@ func (gitHub *GitHub) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 
 	// Set property "Registration":
 	if gitHub.Registration != nil {
-		registration_ARM, err := (*gitHub.Registration).ConvertToARM(resolved)
+		registration_ARM, err := gitHub.Registration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6293,7 +6293,7 @@ func (google *Google) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 
 	// Set property "Login":
 	if google.Login != nil {
-		login_ARM, err := (*google.Login).ConvertToARM(resolved)
+		login_ARM, err := google.Login.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6303,7 +6303,7 @@ func (google *Google) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 
 	// Set property "Registration":
 	if google.Registration != nil {
-		registration_ARM, err := (*google.Registration).ConvertToARM(resolved)
+		registration_ARM, err := google.Registration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6313,7 +6313,7 @@ func (google *Google) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 
 	// Set property "Validation":
 	if google.Validation != nil {
-		validation_ARM, err := (*google.Validation).ConvertToARM(resolved)
+		validation_ARM, err := google.Validation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7190,7 +7190,7 @@ func (store *TokenStore) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 
 	// Set property "AzureBlobStorage":
 	if store.AzureBlobStorage != nil {
-		azureBlobStorage_ARM, err := (*store.AzureBlobStorage).ConvertToARM(resolved)
+		azureBlobStorage_ARM, err := store.AzureBlobStorage.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7492,7 +7492,7 @@ func (twitter *Twitter) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 
 	// Set property "Registration":
 	if twitter.Registration != nil {
-		registration_ARM, err := (*twitter.Registration).ConvertToARM(resolved)
+		registration_ARM, err := twitter.Registration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8731,7 +8731,7 @@ func (validation *AzureActiveDirectoryValidation) ConvertToARM(resolved genrunti
 
 	// Set property "DefaultAuthorizationPolicy":
 	if validation.DefaultAuthorizationPolicy != nil {
-		defaultAuthorizationPolicy_ARM, err := (*validation.DefaultAuthorizationPolicy).ConvertToARM(resolved)
+		defaultAuthorizationPolicy_ARM, err := validation.DefaultAuthorizationPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8741,7 +8741,7 @@ func (validation *AzureActiveDirectoryValidation) ConvertToARM(resolved genrunti
 
 	// Set property "JwtClaimChecks":
 	if validation.JwtClaimChecks != nil {
-		jwtClaimChecks_ARM, err := (*validation.JwtClaimChecks).ConvertToARM(resolved)
+		jwtClaimChecks_ARM, err := validation.JwtClaimChecks.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9818,7 +9818,7 @@ func (registration *OpenIdConnectRegistration) ConvertToARM(resolved genruntime.
 
 	// Set property "ClientCredential":
 	if registration.ClientCredential != nil {
-		clientCredential_ARM, err := (*registration.ClientCredential).ConvertToARM(resolved)
+		clientCredential_ARM, err := registration.ClientCredential.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9834,7 +9834,7 @@ func (registration *OpenIdConnectRegistration) ConvertToARM(resolved genruntime.
 
 	// Set property "OpenIdConnectConfiguration":
 	if registration.OpenIdConnectConfiguration != nil {
-		openIdConnectConfiguration_ARM, err := (*registration.OpenIdConnectConfiguration).ConvertToARM(resolved)
+		openIdConnectConfiguration_ARM, err := registration.OpenIdConnectConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10300,7 +10300,7 @@ func (policy *DefaultAuthorizationPolicy) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "AllowedPrincipals":
 	if policy.AllowedPrincipals != nil {
-		allowedPrincipals_ARM, err := (*policy.AllowedPrincipals).ConvertToARM(resolved)
+		allowedPrincipals_ARM, err := policy.AllowedPrincipals.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/app/v1api20240301/container_app_types_gen.go
+++ b/v2/api/app/v1api20240301/container_app_types_gen.go
@@ -336,7 +336,7 @@ func (containerApp *ContainerApp_Spec) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "ExtendedLocation":
 	if containerApp.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*containerApp.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := containerApp.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -346,7 +346,7 @@ func (containerApp *ContainerApp_Spec) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "Identity":
 	if containerApp.Identity != nil {
-		identity_ARM, err := (*containerApp.Identity).ConvertToARM(resolved)
+		identity_ARM, err := containerApp.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -382,7 +382,7 @@ func (containerApp *ContainerApp_Spec) ConvertToARM(resolved genruntime.ConvertT
 		result.Properties = &arm.ContainerApp_Properties_Spec{}
 	}
 	if containerApp.Configuration != nil {
-		configuration_ARM, err := (*containerApp.Configuration).ConvertToARM(resolved)
+		configuration_ARM, err := containerApp.Configuration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -406,7 +406,7 @@ func (containerApp *ContainerApp_Spec) ConvertToARM(resolved genruntime.ConvertT
 		result.Properties.ManagedEnvironmentId = &managedEnvironmentId
 	}
 	if containerApp.Template != nil {
-		template_ARM, err := (*containerApp.Template).ConvertToARM(resolved)
+		template_ARM, err := containerApp.Template.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1462,7 +1462,7 @@ func (configuration *Configuration) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Dapr":
 	if configuration.Dapr != nil {
-		dapr_ARM, err := (*configuration.Dapr).ConvertToARM(resolved)
+		dapr_ARM, err := configuration.Dapr.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1472,7 +1472,7 @@ func (configuration *Configuration) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Ingress":
 	if configuration.Ingress != nil {
-		ingress_ARM, err := (*configuration.Ingress).ConvertToARM(resolved)
+		ingress_ARM, err := configuration.Ingress.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1506,7 +1506,7 @@ func (configuration *Configuration) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Service":
 	if configuration.Service != nil {
-		service_ARM, err := (*configuration.Service).ConvertToARM(resolved)
+		service_ARM, err := configuration.Service.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2796,7 +2796,7 @@ func (template *Template) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "Scale":
 	if template.Scale != nil {
-		scale_ARM, err := (*template.Scale).ConvertToARM(resolved)
+		scale_ARM, err := template.Scale.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3492,7 +3492,7 @@ func (container *BaseContainer) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "Resources":
 	if container.Resources != nil {
-		resources_ARM, err := (*container.Resources).ConvertToARM(resolved)
+		resources_ARM, err := container.Resources.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4066,7 +4066,7 @@ func (container *Container) ConvertToARM(resolved genruntime.ConvertToARMResolve
 
 	// Set property "Resources":
 	if container.Resources != nil {
-		resources_ARM, err := (*container.Resources).ConvertToARM(resolved)
+		resources_ARM, err := container.Resources.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5276,7 +5276,7 @@ func (ingress *Ingress) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 
 	// Set property "CorsPolicy":
 	if ingress.CorsPolicy != nil {
-		corsPolicy_ARM, err := (*ingress.CorsPolicy).ConvertToARM(resolved)
+		corsPolicy_ARM, err := ingress.CorsPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5316,7 +5316,7 @@ func (ingress *Ingress) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 
 	// Set property "StickySessions":
 	if ingress.StickySessions != nil {
-		stickySessions_ARM, err := (*ingress.StickySessions).ConvertToARM(resolved)
+		stickySessions_ARM, err := ingress.StickySessions.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7902,7 +7902,7 @@ func (probe *ContainerAppProbe) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "HttpGet":
 	if probe.HttpGet != nil {
-		httpGet_ARM, err := (*probe.HttpGet).ConvertToARM(resolved)
+		httpGet_ARM, err := probe.HttpGet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7930,7 +7930,7 @@ func (probe *ContainerAppProbe) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "TcpSocket":
 	if probe.TcpSocket != nil {
-		tcpSocket_ARM, err := (*probe.TcpSocket).ConvertToARM(resolved)
+		tcpSocket_ARM, err := probe.TcpSocket.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10206,7 +10206,7 @@ func (rule *ScaleRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 
 	// Set property "AzureQueue":
 	if rule.AzureQueue != nil {
-		azureQueue_ARM, err := (*rule.AzureQueue).ConvertToARM(resolved)
+		azureQueue_ARM, err := rule.AzureQueue.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10216,7 +10216,7 @@ func (rule *ScaleRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 
 	// Set property "Custom":
 	if rule.Custom != nil {
-		custom_ARM, err := (*rule.Custom).ConvertToARM(resolved)
+		custom_ARM, err := rule.Custom.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10226,7 +10226,7 @@ func (rule *ScaleRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 
 	// Set property "Http":
 	if rule.Http != nil {
-		http_ARM, err := (*rule.Http).ConvertToARM(resolved)
+		http_ARM, err := rule.Http.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10242,7 +10242,7 @@ func (rule *ScaleRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 
 	// Set property "Tcp":
 	if rule.Tcp != nil {
-		tcp_ARM, err := (*rule.Tcp).ConvertToARM(resolved)
+		tcp_ARM, err := rule.Tcp.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/app/v1api20240301/job_types_gen.go
+++ b/v2/api/app/v1api20240301/job_types_gen.go
@@ -299,7 +299,7 @@ func (job *Job_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetail
 
 	// Set property "Identity":
 	if job.Identity != nil {
-		identity_ARM, err := (*job.Identity).ConvertToARM(resolved)
+		identity_ARM, err := job.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -324,7 +324,7 @@ func (job *Job_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetail
 		result.Properties = &arm.Job_Properties_Spec{}
 	}
 	if job.Configuration != nil {
-		configuration_ARM, err := (*job.Configuration).ConvertToARM(resolved)
+		configuration_ARM, err := job.Configuration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -340,7 +340,7 @@ func (job *Job_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetail
 		result.Properties.EnvironmentId = &environmentId
 	}
 	if job.Template != nil {
-		template_ARM, err := (*job.Template).ConvertToARM(resolved)
+		template_ARM, err := job.Template.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1194,7 +1194,7 @@ func (configuration *JobConfiguration) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "EventTriggerConfig":
 	if configuration.EventTriggerConfig != nil {
-		eventTriggerConfig_ARM, err := (*configuration.EventTriggerConfig).ConvertToARM(resolved)
+		eventTriggerConfig_ARM, err := configuration.EventTriggerConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1204,7 +1204,7 @@ func (configuration *JobConfiguration) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "ManualTriggerConfig":
 	if configuration.ManualTriggerConfig != nil {
-		manualTriggerConfig_ARM, err := (*configuration.ManualTriggerConfig).ConvertToARM(resolved)
+		manualTriggerConfig_ARM, err := configuration.ManualTriggerConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1235,7 +1235,7 @@ func (configuration *JobConfiguration) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "ScheduleTriggerConfig":
 	if configuration.ScheduleTriggerConfig != nil {
-		scheduleTriggerConfig_ARM, err := (*configuration.ScheduleTriggerConfig).ConvertToARM(resolved)
+		scheduleTriggerConfig_ARM, err := configuration.ScheduleTriggerConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2418,7 +2418,7 @@ func (config *JobConfiguration_EventTriggerConfig) ConvertToARM(resolved genrunt
 
 	// Set property "Scale":
 	if config.Scale != nil {
-		scale_ARM, err := (*config.Scale).ConvertToARM(resolved)
+		scale_ARM, err := config.Scale.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/app/v1api20240301/managed_environment_types_gen.go
+++ b/v2/api/app/v1api20240301/managed_environment_types_gen.go
@@ -347,7 +347,7 @@ func (environment *ManagedEnvironment_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties = &arm.ManagedEnvironment_Properties_Spec{}
 	}
 	if environment.AppLogsConfiguration != nil {
-		appLogsConfiguration_ARM, err := (*environment.AppLogsConfiguration).ConvertToARM(resolved)
+		appLogsConfiguration_ARM, err := environment.AppLogsConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -355,7 +355,7 @@ func (environment *ManagedEnvironment_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties.AppLogsConfiguration = &appLogsConfiguration
 	}
 	if environment.CustomDomainConfiguration != nil {
-		customDomainConfiguration_ARM, err := (*environment.CustomDomainConfiguration).ConvertToARM(resolved)
+		customDomainConfiguration_ARM, err := environment.CustomDomainConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -383,7 +383,7 @@ func (environment *ManagedEnvironment_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties.InfrastructureResourceGroup = &infrastructureResourceGroup
 	}
 	if environment.PeerAuthentication != nil {
-		peerAuthentication_ARM, err := (*environment.PeerAuthentication).ConvertToARM(resolved)
+		peerAuthentication_ARM, err := environment.PeerAuthentication.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -391,7 +391,7 @@ func (environment *ManagedEnvironment_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties.PeerAuthentication = &peerAuthentication
 	}
 	if environment.PeerTrafficConfiguration != nil {
-		peerTrafficConfiguration_ARM, err := (*environment.PeerTrafficConfiguration).ConvertToARM(resolved)
+		peerTrafficConfiguration_ARM, err := environment.PeerTrafficConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -399,7 +399,7 @@ func (environment *ManagedEnvironment_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties.PeerTrafficConfiguration = &peerTrafficConfiguration
 	}
 	if environment.VnetConfiguration != nil {
-		vnetConfiguration_ARM, err := (*environment.VnetConfiguration).ConvertToARM(resolved)
+		vnetConfiguration_ARM, err := environment.VnetConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1693,7 +1693,7 @@ func (configuration *AppLogsConfiguration) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "LogAnalyticsConfiguration":
 	if configuration.LogAnalyticsConfiguration != nil {
-		logAnalyticsConfiguration_ARM, err := (*configuration.LogAnalyticsConfiguration).ConvertToARM(resolved)
+		logAnalyticsConfiguration_ARM, err := configuration.LogAnalyticsConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2276,7 +2276,7 @@ func (authentication *ManagedEnvironment_Properties_PeerAuthentication_Spec) Con
 
 	// Set property "Mtls":
 	if authentication.Mtls != nil {
-		mtls_ARM, err := (*authentication.Mtls).ConvertToARM(resolved)
+		mtls_ARM, err := authentication.Mtls.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2457,7 +2457,7 @@ func (configuration *ManagedEnvironment_Properties_PeerTrafficConfiguration_Spec
 
 	// Set property "Encryption":
 	if configuration.Encryption != nil {
-		encryption_ARM, err := (*configuration.Encryption).ConvertToARM(resolved)
+		encryption_ARM, err := configuration.Encryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/app/v1api20250101/auth_config_types_gen.go
+++ b/v2/api/app/v1api20250101/auth_config_types_gen.go
@@ -311,7 +311,7 @@ func (config *AuthConfig_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties = &arm.ContainerApps_AuthConfig_Properties_Spec{}
 	}
 	if config.EncryptionSettings != nil {
-		encryptionSettings_ARM, err := (*config.EncryptionSettings).ConvertToARM(resolved)
+		encryptionSettings_ARM, err := config.EncryptionSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -319,7 +319,7 @@ func (config *AuthConfig_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.EncryptionSettings = &encryptionSettings
 	}
 	if config.GlobalValidation != nil {
-		globalValidation_ARM, err := (*config.GlobalValidation).ConvertToARM(resolved)
+		globalValidation_ARM, err := config.GlobalValidation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -327,7 +327,7 @@ func (config *AuthConfig_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.GlobalValidation = &globalValidation
 	}
 	if config.HttpSettings != nil {
-		httpSettings_ARM, err := (*config.HttpSettings).ConvertToARM(resolved)
+		httpSettings_ARM, err := config.HttpSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -335,7 +335,7 @@ func (config *AuthConfig_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.HttpSettings = &httpSettings
 	}
 	if config.IdentityProviders != nil {
-		identityProviders_ARM, err := (*config.IdentityProviders).ConvertToARM(resolved)
+		identityProviders_ARM, err := config.IdentityProviders.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -343,7 +343,7 @@ func (config *AuthConfig_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.IdentityProviders = &identityProviders
 	}
 	if config.Login != nil {
-		login_ARM, err := (*config.Login).ConvertToARM(resolved)
+		login_ARM, err := config.Login.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -351,7 +351,7 @@ func (config *AuthConfig_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.Login = &login
 	}
 	if config.Platform != nil {
-		platform_ARM, err := (*config.Platform).ConvertToARM(resolved)
+		platform_ARM, err := config.Platform.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2044,7 +2044,7 @@ func (settings *HttpSettings) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "ForwardProxy":
 	if settings.ForwardProxy != nil {
-		forwardProxy_ARM, err := (*settings.ForwardProxy).ConvertToARM(resolved)
+		forwardProxy_ARM, err := settings.ForwardProxy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2060,7 +2060,7 @@ func (settings *HttpSettings) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "Routes":
 	if settings.Routes != nil {
-		routes_ARM, err := (*settings.Routes).ConvertToARM(resolved)
+		routes_ARM, err := settings.Routes.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2427,7 +2427,7 @@ func (providers *IdentityProviders) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Apple":
 	if providers.Apple != nil {
-		apple_ARM, err := (*providers.Apple).ConvertToARM(resolved)
+		apple_ARM, err := providers.Apple.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2437,7 +2437,7 @@ func (providers *IdentityProviders) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "AzureActiveDirectory":
 	if providers.AzureActiveDirectory != nil {
-		azureActiveDirectory_ARM, err := (*providers.AzureActiveDirectory).ConvertToARM(resolved)
+		azureActiveDirectory_ARM, err := providers.AzureActiveDirectory.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2447,7 +2447,7 @@ func (providers *IdentityProviders) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "AzureStaticWebApps":
 	if providers.AzureStaticWebApps != nil {
-		azureStaticWebApps_ARM, err := (*providers.AzureStaticWebApps).ConvertToARM(resolved)
+		azureStaticWebApps_ARM, err := providers.AzureStaticWebApps.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2469,7 +2469,7 @@ func (providers *IdentityProviders) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Facebook":
 	if providers.Facebook != nil {
-		facebook_ARM, err := (*providers.Facebook).ConvertToARM(resolved)
+		facebook_ARM, err := providers.Facebook.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2479,7 +2479,7 @@ func (providers *IdentityProviders) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "GitHub":
 	if providers.GitHub != nil {
-		gitHub_ARM, err := (*providers.GitHub).ConvertToARM(resolved)
+		gitHub_ARM, err := providers.GitHub.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2489,7 +2489,7 @@ func (providers *IdentityProviders) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Google":
 	if providers.Google != nil {
-		google_ARM, err := (*providers.Google).ConvertToARM(resolved)
+		google_ARM, err := providers.Google.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2499,7 +2499,7 @@ func (providers *IdentityProviders) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Twitter":
 	if providers.Twitter != nil {
-		twitter_ARM, err := (*providers.Twitter).ConvertToARM(resolved)
+		twitter_ARM, err := providers.Twitter.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3356,7 +3356,7 @@ func (login *Login) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 
 	// Set property "CookieExpiration":
 	if login.CookieExpiration != nil {
-		cookieExpiration_ARM, err := (*login.CookieExpiration).ConvertToARM(resolved)
+		cookieExpiration_ARM, err := login.CookieExpiration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3366,7 +3366,7 @@ func (login *Login) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 
 	// Set property "Nonce":
 	if login.Nonce != nil {
-		nonce_ARM, err := (*login.Nonce).ConvertToARM(resolved)
+		nonce_ARM, err := login.Nonce.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3382,7 +3382,7 @@ func (login *Login) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 
 	// Set property "Routes":
 	if login.Routes != nil {
-		routes_ARM, err := (*login.Routes).ConvertToARM(resolved)
+		routes_ARM, err := login.Routes.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3392,7 +3392,7 @@ func (login *Login) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 
 	// Set property "TokenStore":
 	if login.TokenStore != nil {
-		tokenStore_ARM, err := (*login.TokenStore).ConvertToARM(resolved)
+		tokenStore_ARM, err := login.TokenStore.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4109,7 +4109,7 @@ func (apple *Apple) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 
 	// Set property "Login":
 	if apple.Login != nil {
-		login_ARM, err := (*apple.Login).ConvertToARM(resolved)
+		login_ARM, err := apple.Login.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4119,7 +4119,7 @@ func (apple *Apple) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 
 	// Set property "Registration":
 	if apple.Registration != nil {
-		registration_ARM, err := (*apple.Registration).ConvertToARM(resolved)
+		registration_ARM, err := apple.Registration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4490,7 +4490,7 @@ func (directory *AzureActiveDirectory) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "Login":
 	if directory.Login != nil {
-		login_ARM, err := (*directory.Login).ConvertToARM(resolved)
+		login_ARM, err := directory.Login.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4500,7 +4500,7 @@ func (directory *AzureActiveDirectory) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "Registration":
 	if directory.Registration != nil {
-		registration_ARM, err := (*directory.Registration).ConvertToARM(resolved)
+		registration_ARM, err := directory.Registration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4510,7 +4510,7 @@ func (directory *AzureActiveDirectory) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "Validation":
 	if directory.Validation != nil {
-		validation_ARM, err := (*directory.Validation).ConvertToARM(resolved)
+		validation_ARM, err := directory.Validation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5006,7 +5006,7 @@ func (apps *AzureStaticWebApps) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "Registration":
 	if apps.Registration != nil {
-		registration_ARM, err := (*apps.Registration).ConvertToARM(resolved)
+		registration_ARM, err := apps.Registration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5491,7 +5491,7 @@ func (provider *CustomOpenIdConnectProvider) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Login":
 	if provider.Login != nil {
-		login_ARM, err := (*provider.Login).ConvertToARM(resolved)
+		login_ARM, err := provider.Login.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5501,7 +5501,7 @@ func (provider *CustomOpenIdConnectProvider) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Registration":
 	if provider.Registration != nil {
-		registration_ARM, err := (*provider.Registration).ConvertToARM(resolved)
+		registration_ARM, err := provider.Registration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5865,7 +5865,7 @@ func (facebook *Facebook) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "Login":
 	if facebook.Login != nil {
-		login_ARM, err := (*facebook.Login).ConvertToARM(resolved)
+		login_ARM, err := facebook.Login.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5875,7 +5875,7 @@ func (facebook *Facebook) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "Registration":
 	if facebook.Registration != nil {
-		registration_ARM, err := (*facebook.Registration).ConvertToARM(resolved)
+		registration_ARM, err := facebook.Registration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6515,7 +6515,7 @@ func (gitHub *GitHub) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 
 	// Set property "Login":
 	if gitHub.Login != nil {
-		login_ARM, err := (*gitHub.Login).ConvertToARM(resolved)
+		login_ARM, err := gitHub.Login.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6525,7 +6525,7 @@ func (gitHub *GitHub) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 
 	// Set property "Registration":
 	if gitHub.Registration != nil {
-		registration_ARM, err := (*gitHub.Registration).ConvertToARM(resolved)
+		registration_ARM, err := gitHub.Registration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6919,7 +6919,7 @@ func (google *Google) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 
 	// Set property "Login":
 	if google.Login != nil {
-		login_ARM, err := (*google.Login).ConvertToARM(resolved)
+		login_ARM, err := google.Login.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6929,7 +6929,7 @@ func (google *Google) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 
 	// Set property "Registration":
 	if google.Registration != nil {
-		registration_ARM, err := (*google.Registration).ConvertToARM(resolved)
+		registration_ARM, err := google.Registration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6939,7 +6939,7 @@ func (google *Google) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 
 	// Set property "Validation":
 	if google.Validation != nil {
-		validation_ARM, err := (*google.Validation).ConvertToARM(resolved)
+		validation_ARM, err := google.Validation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7905,7 +7905,7 @@ func (store *TokenStore) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 
 	// Set property "AzureBlobStorage":
 	if store.AzureBlobStorage != nil {
-		azureBlobStorage_ARM, err := (*store.AzureBlobStorage).ConvertToARM(resolved)
+		azureBlobStorage_ARM, err := store.AzureBlobStorage.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8242,7 +8242,7 @@ func (twitter *Twitter) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 
 	// Set property "Registration":
 	if twitter.Registration != nil {
-		registration_ARM, err := (*twitter.Registration).ConvertToARM(resolved)
+		registration_ARM, err := twitter.Registration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9587,7 +9587,7 @@ func (validation *AzureActiveDirectoryValidation) ConvertToARM(resolved genrunti
 
 	// Set property "DefaultAuthorizationPolicy":
 	if validation.DefaultAuthorizationPolicy != nil {
-		defaultAuthorizationPolicy_ARM, err := (*validation.DefaultAuthorizationPolicy).ConvertToARM(resolved)
+		defaultAuthorizationPolicy_ARM, err := validation.DefaultAuthorizationPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9597,7 +9597,7 @@ func (validation *AzureActiveDirectoryValidation) ConvertToARM(resolved genrunti
 
 	// Set property "JwtClaimChecks":
 	if validation.JwtClaimChecks != nil {
-		jwtClaimChecks_ARM, err := (*validation.JwtClaimChecks).ConvertToARM(resolved)
+		jwtClaimChecks_ARM, err := validation.JwtClaimChecks.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10764,7 +10764,7 @@ func (registration *OpenIdConnectRegistration) ConvertToARM(resolved genruntime.
 
 	// Set property "ClientCredential":
 	if registration.ClientCredential != nil {
-		clientCredential_ARM, err := (*registration.ClientCredential).ConvertToARM(resolved)
+		clientCredential_ARM, err := registration.ClientCredential.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10780,7 +10780,7 @@ func (registration *OpenIdConnectRegistration) ConvertToARM(resolved genruntime.
 
 	// Set property "OpenIdConnectConfiguration":
 	if registration.OpenIdConnectConfiguration != nil {
-		openIdConnectConfiguration_ARM, err := (*registration.OpenIdConnectConfiguration).ConvertToARM(resolved)
+		openIdConnectConfiguration_ARM, err := registration.OpenIdConnectConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11293,7 +11293,7 @@ func (policy *DefaultAuthorizationPolicy) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "AllowedPrincipals":
 	if policy.AllowedPrincipals != nil {
-		allowedPrincipals_ARM, err := (*policy.AllowedPrincipals).ConvertToARM(resolved)
+		allowedPrincipals_ARM, err := policy.AllowedPrincipals.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/app/v1api20250101/container_app_types_gen.go
+++ b/v2/api/app/v1api20250101/container_app_types_gen.go
@@ -333,7 +333,7 @@ func (containerApp *ContainerApp_Spec) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "ExtendedLocation":
 	if containerApp.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*containerApp.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := containerApp.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -343,7 +343,7 @@ func (containerApp *ContainerApp_Spec) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "Identity":
 	if containerApp.Identity != nil {
-		identity_ARM, err := (*containerApp.Identity).ConvertToARM(resolved)
+		identity_ARM, err := containerApp.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -379,7 +379,7 @@ func (containerApp *ContainerApp_Spec) ConvertToARM(resolved genruntime.ConvertT
 		result.Properties = &arm.ContainerApp_Properties_Spec{}
 	}
 	if containerApp.Configuration != nil {
-		configuration_ARM, err := (*containerApp.Configuration).ConvertToARM(resolved)
+		configuration_ARM, err := containerApp.Configuration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -403,7 +403,7 @@ func (containerApp *ContainerApp_Spec) ConvertToARM(resolved genruntime.ConvertT
 		result.Properties.ManagedEnvironmentId = &managedEnvironmentId
 	}
 	if containerApp.Template != nil {
-		template_ARM, err := (*containerApp.Template).ConvertToARM(resolved)
+		template_ARM, err := containerApp.Template.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1577,7 +1577,7 @@ func (configuration *Configuration) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Dapr":
 	if configuration.Dapr != nil {
-		dapr_ARM, err := (*configuration.Dapr).ConvertToARM(resolved)
+		dapr_ARM, err := configuration.Dapr.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1596,7 +1596,7 @@ func (configuration *Configuration) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Ingress":
 	if configuration.Ingress != nil {
-		ingress_ARM, err := (*configuration.Ingress).ConvertToARM(resolved)
+		ingress_ARM, err := configuration.Ingress.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1621,7 +1621,7 @@ func (configuration *Configuration) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Runtime":
 	if configuration.Runtime != nil {
-		runtime_ARM, err := (*configuration.Runtime).ConvertToARM(resolved)
+		runtime_ARM, err := configuration.Runtime.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1640,7 +1640,7 @@ func (configuration *Configuration) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Service":
 	if configuration.Service != nil {
-		service_ARM, err := (*configuration.Service).ConvertToARM(resolved)
+		service_ARM, err := configuration.Service.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3283,7 +3283,7 @@ func (template *Template) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "Scale":
 	if template.Scale != nil {
-		scale_ARM, err := (*template.Scale).ConvertToARM(resolved)
+		scale_ARM, err := template.Scale.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4076,7 +4076,7 @@ func (container *BaseContainer) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "Resources":
 	if container.Resources != nil {
-		resources_ARM, err := (*container.Resources).ConvertToARM(resolved)
+		resources_ARM, err := container.Resources.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4717,7 +4717,7 @@ func (container *Container) ConvertToARM(resolved genruntime.ConvertToARMResolve
 
 	// Set property "Resources":
 	if container.Resources != nil {
-		resources_ARM, err := (*container.Resources).ConvertToARM(resolved)
+		resources_ARM, err := container.Resources.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6288,7 +6288,7 @@ func (ingress *Ingress) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 
 	// Set property "CorsPolicy":
 	if ingress.CorsPolicy != nil {
-		corsPolicy_ARM, err := (*ingress.CorsPolicy).ConvertToARM(resolved)
+		corsPolicy_ARM, err := ingress.CorsPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6328,7 +6328,7 @@ func (ingress *Ingress) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 
 	// Set property "StickySessions":
 	if ingress.StickySessions != nil {
-		stickySessions_ARM, err := (*ingress.StickySessions).ConvertToARM(resolved)
+		stickySessions_ARM, err := ingress.StickySessions.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7706,7 +7706,7 @@ func (runtime *Runtime) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 
 	// Set property "Java":
 	if runtime.Java != nil {
-		java_ARM, err := (*runtime.Java).ConvertToARM(resolved)
+		java_ARM, err := runtime.Java.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9467,7 +9467,7 @@ func (probe *ContainerAppProbe) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "HttpGet":
 	if probe.HttpGet != nil {
-		httpGet_ARM, err := (*probe.HttpGet).ConvertToARM(resolved)
+		httpGet_ARM, err := probe.HttpGet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9495,7 +9495,7 @@ func (probe *ContainerAppProbe) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "TcpSocket":
 	if probe.TcpSocket != nil {
-		tcpSocket_ARM, err := (*probe.TcpSocket).ConvertToARM(resolved)
+		tcpSocket_ARM, err := probe.TcpSocket.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12179,7 +12179,7 @@ func (rule *ScaleRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 
 	// Set property "AzureQueue":
 	if rule.AzureQueue != nil {
-		azureQueue_ARM, err := (*rule.AzureQueue).ConvertToARM(resolved)
+		azureQueue_ARM, err := rule.AzureQueue.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12189,7 +12189,7 @@ func (rule *ScaleRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 
 	// Set property "Custom":
 	if rule.Custom != nil {
-		custom_ARM, err := (*rule.Custom).ConvertToARM(resolved)
+		custom_ARM, err := rule.Custom.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12199,7 +12199,7 @@ func (rule *ScaleRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 
 	// Set property "Http":
 	if rule.Http != nil {
-		http_ARM, err := (*rule.Http).ConvertToARM(resolved)
+		http_ARM, err := rule.Http.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12215,7 +12215,7 @@ func (rule *ScaleRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 
 	// Set property "Tcp":
 	if rule.Tcp != nil {
-		tcp_ARM, err := (*rule.Tcp).ConvertToARM(resolved)
+		tcp_ARM, err := rule.Tcp.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/app/v1api20250101/job_types_gen.go
+++ b/v2/api/app/v1api20250101/job_types_gen.go
@@ -296,7 +296,7 @@ func (job *Job_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetail
 
 	// Set property "Identity":
 	if job.Identity != nil {
-		identity_ARM, err := (*job.Identity).ConvertToARM(resolved)
+		identity_ARM, err := job.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -321,7 +321,7 @@ func (job *Job_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetail
 		result.Properties = &arm.Job_Properties_Spec{}
 	}
 	if job.Configuration != nil {
-		configuration_ARM, err := (*job.Configuration).ConvertToARM(resolved)
+		configuration_ARM, err := job.Configuration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -337,7 +337,7 @@ func (job *Job_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetail
 		result.Properties.EnvironmentId = &environmentId
 	}
 	if job.Template != nil {
-		template_ARM, err := (*job.Template).ConvertToARM(resolved)
+		template_ARM, err := job.Template.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1255,7 +1255,7 @@ func (configuration *JobConfiguration) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "EventTriggerConfig":
 	if configuration.EventTriggerConfig != nil {
-		eventTriggerConfig_ARM, err := (*configuration.EventTriggerConfig).ConvertToARM(resolved)
+		eventTriggerConfig_ARM, err := configuration.EventTriggerConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1274,7 +1274,7 @@ func (configuration *JobConfiguration) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "ManualTriggerConfig":
 	if configuration.ManualTriggerConfig != nil {
-		manualTriggerConfig_ARM, err := (*configuration.ManualTriggerConfig).ConvertToARM(resolved)
+		manualTriggerConfig_ARM, err := configuration.ManualTriggerConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1305,7 +1305,7 @@ func (configuration *JobConfiguration) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "ScheduleTriggerConfig":
 	if configuration.ScheduleTriggerConfig != nil {
-		scheduleTriggerConfig_ARM, err := (*configuration.ScheduleTriggerConfig).ConvertToARM(resolved)
+		scheduleTriggerConfig_ARM, err := configuration.ScheduleTriggerConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2756,7 +2756,7 @@ func (config *JobConfiguration_EventTriggerConfig) ConvertToARM(resolved genrunt
 
 	// Set property "Scale":
 	if config.Scale != nil {
-		scale_ARM, err := (*config.Scale).ConvertToARM(resolved)
+		scale_ARM, err := config.Scale.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/app/v1api20250101/managed_environment_types_gen.go
+++ b/v2/api/app/v1api20250101/managed_environment_types_gen.go
@@ -321,7 +321,7 @@ func (environment *ManagedEnvironment_Spec) ConvertToARM(resolved genruntime.Con
 
 	// Set property "Identity":
 	if environment.Identity != nil {
-		identity_ARM, err := (*environment.Identity).ConvertToARM(resolved)
+		identity_ARM, err := environment.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -358,7 +358,7 @@ func (environment *ManagedEnvironment_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties = &arm.ManagedEnvironment_Properties_Spec{}
 	}
 	if environment.AppLogsConfiguration != nil {
-		appLogsConfiguration_ARM, err := (*environment.AppLogsConfiguration).ConvertToARM(resolved)
+		appLogsConfiguration_ARM, err := environment.AppLogsConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -366,7 +366,7 @@ func (environment *ManagedEnvironment_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties.AppLogsConfiguration = &appLogsConfiguration
 	}
 	if environment.CustomDomainConfiguration != nil {
-		customDomainConfiguration_ARM, err := (*environment.CustomDomainConfiguration).ConvertToARM(resolved)
+		customDomainConfiguration_ARM, err := environment.CustomDomainConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -394,7 +394,7 @@ func (environment *ManagedEnvironment_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties.InfrastructureResourceGroup = &infrastructureResourceGroup
 	}
 	if environment.PeerAuthentication != nil {
-		peerAuthentication_ARM, err := (*environment.PeerAuthentication).ConvertToARM(resolved)
+		peerAuthentication_ARM, err := environment.PeerAuthentication.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -402,7 +402,7 @@ func (environment *ManagedEnvironment_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties.PeerAuthentication = &peerAuthentication
 	}
 	if environment.PeerTrafficConfiguration != nil {
-		peerTrafficConfiguration_ARM, err := (*environment.PeerTrafficConfiguration).ConvertToARM(resolved)
+		peerTrafficConfiguration_ARM, err := environment.PeerTrafficConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -410,7 +410,7 @@ func (environment *ManagedEnvironment_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties.PeerTrafficConfiguration = &peerTrafficConfiguration
 	}
 	if environment.VnetConfiguration != nil {
-		vnetConfiguration_ARM, err := (*environment.VnetConfiguration).ConvertToARM(resolved)
+		vnetConfiguration_ARM, err := environment.VnetConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1895,7 +1895,7 @@ func (configuration *AppLogsConfiguration) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "LogAnalyticsConfiguration":
 	if configuration.LogAnalyticsConfiguration != nil {
-		logAnalyticsConfiguration_ARM, err := (*configuration.LogAnalyticsConfiguration).ConvertToARM(resolved)
+		logAnalyticsConfiguration_ARM, err := configuration.LogAnalyticsConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2137,7 +2137,7 @@ func (configuration *CustomDomainConfiguration) ConvertToARM(resolved genruntime
 
 	// Set property "CertificateKeyVaultProperties":
 	if configuration.CertificateKeyVaultProperties != nil {
-		certificateKeyVaultProperties_ARM, err := (*configuration.CertificateKeyVaultProperties).ConvertToARM(resolved)
+		certificateKeyVaultProperties_ARM, err := configuration.CertificateKeyVaultProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2608,7 +2608,7 @@ func (authentication *ManagedEnvironment_Properties_PeerAuthentication_Spec) Con
 
 	// Set property "Mtls":
 	if authentication.Mtls != nil {
-		mtls_ARM, err := (*authentication.Mtls).ConvertToARM(resolved)
+		mtls_ARM, err := authentication.Mtls.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2808,7 +2808,7 @@ func (configuration *ManagedEnvironment_Properties_PeerTrafficConfiguration_Spec
 
 	// Set property "Encryption":
 	if configuration.Encryption != nil {
-		encryption_ARM, err := (*configuration.Encryption).ConvertToARM(resolved)
+		encryption_ARM, err := configuration.Encryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/appconfiguration/v1api20220501/configuration_store_types_gen.go
+++ b/v2/api/appconfiguration/v1api20220501/configuration_store_types_gen.go
@@ -318,7 +318,7 @@ func (store *ConfigurationStore_Spec) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "Identity":
 	if store.Identity != nil {
-		identity_ARM, err := (*store.Identity).ConvertToARM(resolved)
+		identity_ARM, err := store.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -359,7 +359,7 @@ func (store *ConfigurationStore_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties.EnablePurgeProtection = &enablePurgeProtection
 	}
 	if store.Encryption != nil {
-		encryption_ARM, err := (*store.Encryption).ConvertToARM(resolved)
+		encryption_ARM, err := store.Encryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -379,7 +379,7 @@ func (store *ConfigurationStore_Spec) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "Sku":
 	if store.Sku != nil {
-		sku_ARM, err := (*store.Sku).ConvertToARM(resolved)
+		sku_ARM, err := store.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -389,7 +389,7 @@ func (store *ConfigurationStore_Spec) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "SystemData":
 	if store.SystemData != nil {
-		systemData_ARM, err := (*store.SystemData).ConvertToARM(resolved)
+		systemData_ARM, err := store.SystemData.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1769,7 +1769,7 @@ func (properties *EncryptionProperties) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "KeyVaultProperties":
 	if properties.KeyVaultProperties != nil {
-		keyVaultProperties_ARM, err := (*properties.KeyVaultProperties).ConvertToARM(resolved)
+		keyVaultProperties_ARM, err := properties.KeyVaultProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/batch/v1api20210101/batch_account_types_gen.go
+++ b/v2/api/batch/v1api20210101/batch_account_types_gen.go
@@ -309,7 +309,7 @@ func (account *BatchAccount_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "Identity":
 	if account.Identity != nil {
-		identity_ARM, err := (*account.Identity).ConvertToARM(resolved)
+		identity_ARM, err := account.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -335,7 +335,7 @@ func (account *BatchAccount_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Properties = &arm.BatchAccountCreateProperties{}
 	}
 	if account.AutoStorage != nil {
-		autoStorage_ARM, err := (*account.AutoStorage).ConvertToARM(resolved)
+		autoStorage_ARM, err := account.AutoStorage.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -343,7 +343,7 @@ func (account *BatchAccount_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Properties.AutoStorage = &autoStorage
 	}
 	if account.Encryption != nil {
-		encryption_ARM, err := (*account.Encryption).ConvertToARM(resolved)
+		encryption_ARM, err := account.Encryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -351,7 +351,7 @@ func (account *BatchAccount_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Properties.Encryption = &encryption
 	}
 	if account.KeyVaultReference != nil {
-		keyVaultReference_ARM, err := (*account.KeyVaultReference).ConvertToARM(resolved)
+		keyVaultReference_ARM, err := account.KeyVaultReference.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2167,7 +2167,7 @@ func (properties *EncryptionProperties) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "KeyVaultProperties":
 	if properties.KeyVaultProperties != nil {
-		keyVaultProperties_ARM, err := (*properties.KeyVaultProperties).ConvertToARM(resolved)
+		keyVaultProperties_ARM, err := properties.KeyVaultProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/cache/v1api20201201/redis_types_gen.go
+++ b/v2/api/cache/v1api20201201/redis_types_gen.go
@@ -377,7 +377,7 @@ func (redis *Redis_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.Properties.PublicNetworkAccess = &publicNetworkAccess
 	}
 	if redis.RedisConfiguration != nil {
-		redisConfiguration_ARM, err := (*redis.RedisConfiguration).ConvertToARM(resolved)
+		redisConfiguration_ARM, err := redis.RedisConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -401,7 +401,7 @@ func (redis *Redis_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.Properties.ShardCount = &shardCount
 	}
 	if redis.Sku != nil {
-		sku_ARM, err := (*redis.Sku).ConvertToARM(resolved)
+		sku_ARM, err := redis.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/cache/v1api20210301/redis_enterprise_database_types_gen.go
+++ b/v2/api/cache/v1api20210301/redis_enterprise_database_types_gen.go
@@ -331,7 +331,7 @@ func (database *RedisEnterpriseDatabase_Spec) ConvertToARM(resolved genruntime.C
 		result.Properties.Modules = append(result.Properties.Modules, *item_ARM.(*arm.Module))
 	}
 	if database.Persistence != nil {
-		persistence_ARM, err := (*database.Persistence).ConvertToARM(resolved)
+		persistence_ARM, err := database.Persistence.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/cache/v1api20210301/redis_enterprise_types_gen.go
+++ b/v2/api/cache/v1api20210301/redis_enterprise_types_gen.go
@@ -318,7 +318,7 @@ func (enterprise *RedisEnterprise_Spec) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "Sku":
 	if enterprise.Sku != nil {
-		sku_ARM, err := (*enterprise.Sku).ConvertToARM(resolved)
+		sku_ARM, err := enterprise.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/cache/v1api20230401/redis_types_gen.go
+++ b/v2/api/cache/v1api20230401/redis_types_gen.go
@@ -342,7 +342,7 @@ func (redis *Redis_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 
 	// Set property "Identity":
 	if redis.Identity != nil {
-		identity_ARM, err := (*redis.Identity).ConvertToARM(resolved)
+		identity_ARM, err := redis.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -391,7 +391,7 @@ func (redis *Redis_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.Properties.PublicNetworkAccess = &publicNetworkAccess
 	}
 	if redis.RedisConfiguration != nil {
-		redisConfiguration_ARM, err := (*redis.RedisConfiguration).ConvertToARM(resolved)
+		redisConfiguration_ARM, err := redis.RedisConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -415,7 +415,7 @@ func (redis *Redis_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.Properties.ShardCount = &shardCount
 	}
 	if redis.Sku != nil {
-		sku_ARM, err := (*redis.Sku).ConvertToARM(resolved)
+		sku_ARM, err := redis.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/cache/v1api20230701/redis_enterprise_database_types_gen.go
+++ b/v2/api/cache/v1api20230701/redis_enterprise_database_types_gen.go
@@ -328,7 +328,7 @@ func (database *RedisEnterpriseDatabase_Spec) ConvertToARM(resolved genruntime.C
 		result.Properties.EvictionPolicy = &evictionPolicy
 	}
 	if database.GeoReplication != nil {
-		geoReplication_ARM, err := (*database.GeoReplication).ConvertToARM(resolved)
+		geoReplication_ARM, err := database.GeoReplication.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -343,7 +343,7 @@ func (database *RedisEnterpriseDatabase_Spec) ConvertToARM(resolved genruntime.C
 		result.Properties.Modules = append(result.Properties.Modules, *item_ARM.(*arm.Module))
 	}
 	if database.Persistence != nil {
-		persistence_ARM, err := (*database.Persistence).ConvertToARM(resolved)
+		persistence_ARM, err := database.Persistence.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/cache/v1api20230701/redis_enterprise_types_gen.go
+++ b/v2/api/cache/v1api20230701/redis_enterprise_types_gen.go
@@ -318,7 +318,7 @@ func (enterprise *RedisEnterprise_Spec) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "Sku":
 	if enterprise.Sku != nil {
-		sku_ARM, err := (*enterprise.Sku).ConvertToARM(resolved)
+		sku_ARM, err := enterprise.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/cache/v1api20230801/redis_types_gen.go
+++ b/v2/api/cache/v1api20230801/redis_types_gen.go
@@ -343,7 +343,7 @@ func (redis *Redis_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 
 	// Set property "Identity":
 	if redis.Identity != nil {
-		identity_ARM, err := (*redis.Identity).ConvertToARM(resolved)
+		identity_ARM, err := redis.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -393,7 +393,7 @@ func (redis *Redis_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.Properties.PublicNetworkAccess = &publicNetworkAccess
 	}
 	if redis.RedisConfiguration != nil {
-		redisConfiguration_ARM, err := (*redis.RedisConfiguration).ConvertToARM(resolved)
+		redisConfiguration_ARM, err := redis.RedisConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -417,7 +417,7 @@ func (redis *Redis_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.Properties.ShardCount = &shardCount
 	}
 	if redis.Sku != nil {
-		sku_ARM, err := (*redis.Sku).ConvertToARM(resolved)
+		sku_ARM, err := redis.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/cache/v1api20250401/redis_enterprise_database_types_gen.go
+++ b/v2/api/cache/v1api20250401/redis_enterprise_database_types_gen.go
@@ -348,7 +348,7 @@ func (database *RedisEnterpriseDatabase_Spec) ConvertToARM(resolved genruntime.C
 		result.Properties.EvictionPolicy = &evictionPolicy
 	}
 	if database.GeoReplication != nil {
-		geoReplication_ARM, err := (*database.GeoReplication).ConvertToARM(resolved)
+		geoReplication_ARM, err := database.GeoReplication.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -363,7 +363,7 @@ func (database *RedisEnterpriseDatabase_Spec) ConvertToARM(resolved genruntime.C
 		result.Properties.Modules = append(result.Properties.Modules, *item_ARM.(*arm.Module))
 	}
 	if database.Persistence != nil {
-		persistence_ARM, err := (*database.Persistence).ConvertToARM(resolved)
+		persistence_ARM, err := database.Persistence.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/cache/v1api20250401/redis_enterprise_types_gen.go
+++ b/v2/api/cache/v1api20250401/redis_enterprise_types_gen.go
@@ -310,7 +310,7 @@ func (enterprise *RedisEnterprise_Spec) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "Identity":
 	if enterprise.Identity != nil {
-		identity_ARM, err := (*enterprise.Identity).ConvertToARM(resolved)
+		identity_ARM, err := enterprise.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -342,7 +342,7 @@ func (enterprise *RedisEnterprise_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Properties = &arm.ClusterProperties{}
 	}
 	if enterprise.Encryption != nil {
-		encryption_ARM, err := (*enterprise.Encryption).ConvertToARM(resolved)
+		encryption_ARM, err := enterprise.Encryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -364,7 +364,7 @@ func (enterprise *RedisEnterprise_Spec) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "Sku":
 	if enterprise.Sku != nil {
-		sku_ARM, err := (*enterprise.Sku).ConvertToARM(resolved)
+		sku_ARM, err := enterprise.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1452,7 +1452,7 @@ func (encryption *ClusterProperties_Encryption) ConvertToARM(resolved genruntime
 
 	// Set property "CustomerManagedKeyEncryption":
 	if encryption.CustomerManagedKeyEncryption != nil {
-		customerManagedKeyEncryption_ARM, err := (*encryption.CustomerManagedKeyEncryption).ConvertToARM(resolved)
+		customerManagedKeyEncryption_ARM, err := encryption.CustomerManagedKeyEncryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2529,7 +2529,7 @@ func (encryption *ClusterProperties_Encryption_CustomerManagedKeyEncryption) Con
 
 	// Set property "KeyEncryptionKeyIdentity":
 	if encryption.KeyEncryptionKeyIdentity != nil {
-		keyEncryptionKeyIdentity_ARM, err := (*encryption.KeyEncryptionKeyIdentity).ConvertToARM(resolved)
+		keyEncryptionKeyIdentity_ARM, err := encryption.KeyEncryptionKeyIdentity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/cdn/v1api20210601/profile_types_gen.go
+++ b/v2/api/cdn/v1api20210601/profile_types_gen.go
@@ -316,7 +316,7 @@ func (profile *Profile_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Sku":
 	if profile.Sku != nil {
-		sku_ARM, err := (*profile.Sku).ConvertToARM(resolved)
+		sku_ARM, err := profile.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/cdn/v1api20210601/profiles_endpoint_types_gen.go
+++ b/v2/api/cdn/v1api20210601/profiles_endpoint_types_gen.go
@@ -373,7 +373,7 @@ func (endpoint *ProfilesEndpoint_Spec) ConvertToARM(resolved genruntime.ConvertT
 		result.Properties.ContentTypesToCompress = append(result.Properties.ContentTypesToCompress, item)
 	}
 	if endpoint.DefaultOriginGroup != nil {
-		defaultOriginGroup_ARM, err := (*endpoint.DefaultOriginGroup).ConvertToARM(resolved)
+		defaultOriginGroup_ARM, err := endpoint.DefaultOriginGroup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -381,7 +381,7 @@ func (endpoint *ProfilesEndpoint_Spec) ConvertToARM(resolved genruntime.ConvertT
 		result.Properties.DefaultOriginGroup = &defaultOriginGroup
 	}
 	if endpoint.DeliveryPolicy != nil {
-		deliveryPolicy_ARM, err := (*endpoint.DeliveryPolicy).ConvertToARM(resolved)
+		deliveryPolicy_ARM, err := endpoint.DeliveryPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -453,7 +453,7 @@ func (endpoint *ProfilesEndpoint_Spec) ConvertToARM(resolved genruntime.ConvertT
 		result.Properties.UrlSigningKeys = append(result.Properties.UrlSigningKeys, *item_ARM.(*arm.UrlSigningKey))
 	}
 	if endpoint.WebApplicationFirewallPolicyLink != nil {
-		webApplicationFirewallPolicyLink_ARM, err := (*endpoint.WebApplicationFirewallPolicyLink).ConvertToARM(resolved)
+		webApplicationFirewallPolicyLink_ARM, err := endpoint.WebApplicationFirewallPolicyLink.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3111,7 +3111,7 @@ func (group *DeepCreatedOriginGroup) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties = &arm.DeepCreatedOriginGroupProperties{}
 	}
 	if group.HealthProbeSettings != nil {
-		healthProbeSettings_ARM, err := (*group.HealthProbeSettings).ConvertToARM(resolved)
+		healthProbeSettings_ARM, err := group.HealthProbeSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3126,7 +3126,7 @@ func (group *DeepCreatedOriginGroup) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.Origins = append(result.Properties.Origins, *item_ARM.(*arm.ResourceReference))
 	}
 	if group.ResponseBasedOriginErrorDetectionSettings != nil {
-		responseBasedOriginErrorDetectionSettings_ARM, err := (*group.ResponseBasedOriginErrorDetectionSettings).ConvertToARM(resolved)
+		responseBasedOriginErrorDetectionSettings_ARM, err := group.ResponseBasedOriginErrorDetectionSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4691,7 +4691,7 @@ func (signingKey *UrlSigningKey) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "KeySourceParameters":
 	if signingKey.KeySourceParameters != nil {
-		keySourceParameters_ARM, err := (*signingKey.KeySourceParameters).ConvertToARM(resolved)
+		keySourceParameters_ARM, err := signingKey.KeySourceParameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6471,7 +6471,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "CacheExpiration":
 	if action.CacheExpiration != nil {
-		cacheExpiration_ARM, err := (*action.CacheExpiration).ConvertToARM(resolved)
+		cacheExpiration_ARM, err := action.CacheExpiration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6481,7 +6481,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "CacheKeyQueryString":
 	if action.CacheKeyQueryString != nil {
-		cacheKeyQueryString_ARM, err := (*action.CacheKeyQueryString).ConvertToARM(resolved)
+		cacheKeyQueryString_ARM, err := action.CacheKeyQueryString.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6491,7 +6491,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "ModifyRequestHeader":
 	if action.ModifyRequestHeader != nil {
-		modifyRequestHeader_ARM, err := (*action.ModifyRequestHeader).ConvertToARM(resolved)
+		modifyRequestHeader_ARM, err := action.ModifyRequestHeader.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6501,7 +6501,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "ModifyResponseHeader":
 	if action.ModifyResponseHeader != nil {
-		modifyResponseHeader_ARM, err := (*action.ModifyResponseHeader).ConvertToARM(resolved)
+		modifyResponseHeader_ARM, err := action.ModifyResponseHeader.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6511,7 +6511,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "OriginGroupOverride":
 	if action.OriginGroupOverride != nil {
-		originGroupOverride_ARM, err := (*action.OriginGroupOverride).ConvertToARM(resolved)
+		originGroupOverride_ARM, err := action.OriginGroupOverride.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6521,7 +6521,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "RouteConfigurationOverride":
 	if action.RouteConfigurationOverride != nil {
-		routeConfigurationOverride_ARM, err := (*action.RouteConfigurationOverride).ConvertToARM(resolved)
+		routeConfigurationOverride_ARM, err := action.RouteConfigurationOverride.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6531,7 +6531,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "UrlRedirect":
 	if action.UrlRedirect != nil {
-		urlRedirect_ARM, err := (*action.UrlRedirect).ConvertToARM(resolved)
+		urlRedirect_ARM, err := action.UrlRedirect.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6541,7 +6541,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "UrlRewrite":
 	if action.UrlRewrite != nil {
-		urlRewrite_ARM, err := (*action.UrlRewrite).ConvertToARM(resolved)
+		urlRewrite_ARM, err := action.UrlRewrite.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6551,7 +6551,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "UrlSigning":
 	if action.UrlSigning != nil {
-		urlSigning_ARM, err := (*action.UrlSigning).ConvertToARM(resolved)
+		urlSigning_ARM, err := action.UrlSigning.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7487,7 +7487,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "ClientPort":
 	if condition.ClientPort != nil {
-		clientPort_ARM, err := (*condition.ClientPort).ConvertToARM(resolved)
+		clientPort_ARM, err := condition.ClientPort.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7497,7 +7497,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "Cookies":
 	if condition.Cookies != nil {
-		cookies_ARM, err := (*condition.Cookies).ConvertToARM(resolved)
+		cookies_ARM, err := condition.Cookies.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7507,7 +7507,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "HostName":
 	if condition.HostName != nil {
-		hostName_ARM, err := (*condition.HostName).ConvertToARM(resolved)
+		hostName_ARM, err := condition.HostName.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7517,7 +7517,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "HttpVersion":
 	if condition.HttpVersion != nil {
-		httpVersion_ARM, err := (*condition.HttpVersion).ConvertToARM(resolved)
+		httpVersion_ARM, err := condition.HttpVersion.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7527,7 +7527,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "IsDevice":
 	if condition.IsDevice != nil {
-		isDevice_ARM, err := (*condition.IsDevice).ConvertToARM(resolved)
+		isDevice_ARM, err := condition.IsDevice.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7537,7 +7537,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "PostArgs":
 	if condition.PostArgs != nil {
-		postArgs_ARM, err := (*condition.PostArgs).ConvertToARM(resolved)
+		postArgs_ARM, err := condition.PostArgs.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7547,7 +7547,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "QueryString":
 	if condition.QueryString != nil {
-		queryString_ARM, err := (*condition.QueryString).ConvertToARM(resolved)
+		queryString_ARM, err := condition.QueryString.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7557,7 +7557,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "RemoteAddress":
 	if condition.RemoteAddress != nil {
-		remoteAddress_ARM, err := (*condition.RemoteAddress).ConvertToARM(resolved)
+		remoteAddress_ARM, err := condition.RemoteAddress.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7567,7 +7567,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "RequestBody":
 	if condition.RequestBody != nil {
-		requestBody_ARM, err := (*condition.RequestBody).ConvertToARM(resolved)
+		requestBody_ARM, err := condition.RequestBody.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7577,7 +7577,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "RequestHeader":
 	if condition.RequestHeader != nil {
-		requestHeader_ARM, err := (*condition.RequestHeader).ConvertToARM(resolved)
+		requestHeader_ARM, err := condition.RequestHeader.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7587,7 +7587,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "RequestMethod":
 	if condition.RequestMethod != nil {
-		requestMethod_ARM, err := (*condition.RequestMethod).ConvertToARM(resolved)
+		requestMethod_ARM, err := condition.RequestMethod.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7597,7 +7597,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "RequestScheme":
 	if condition.RequestScheme != nil {
-		requestScheme_ARM, err := (*condition.RequestScheme).ConvertToARM(resolved)
+		requestScheme_ARM, err := condition.RequestScheme.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7607,7 +7607,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "RequestUri":
 	if condition.RequestUri != nil {
-		requestUri_ARM, err := (*condition.RequestUri).ConvertToARM(resolved)
+		requestUri_ARM, err := condition.RequestUri.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7617,7 +7617,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "ServerPort":
 	if condition.ServerPort != nil {
-		serverPort_ARM, err := (*condition.ServerPort).ConvertToARM(resolved)
+		serverPort_ARM, err := condition.ServerPort.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7627,7 +7627,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "SocketAddr":
 	if condition.SocketAddr != nil {
-		socketAddr_ARM, err := (*condition.SocketAddr).ConvertToARM(resolved)
+		socketAddr_ARM, err := condition.SocketAddr.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7637,7 +7637,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "SslProtocol":
 	if condition.SslProtocol != nil {
-		sslProtocol_ARM, err := (*condition.SslProtocol).ConvertToARM(resolved)
+		sslProtocol_ARM, err := condition.SslProtocol.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7647,7 +7647,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "UrlFileExtension":
 	if condition.UrlFileExtension != nil {
-		urlFileExtension_ARM, err := (*condition.UrlFileExtension).ConvertToARM(resolved)
+		urlFileExtension_ARM, err := condition.UrlFileExtension.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7657,7 +7657,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "UrlFileName":
 	if condition.UrlFileName != nil {
-		urlFileName_ARM, err := (*condition.UrlFileName).ConvertToARM(resolved)
+		urlFileName_ARM, err := condition.UrlFileName.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7667,7 +7667,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "UrlPath":
 	if condition.UrlPath != nil {
-		urlPath_ARM, err := (*condition.UrlPath).ConvertToARM(resolved)
+		urlPath_ARM, err := condition.UrlPath.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9710,7 +9710,7 @@ func (action *DeliveryRuleCacheExpirationAction) ConvertToARM(resolved genruntim
 
 	// Set property "Parameters":
 	if action.Parameters != nil {
-		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := action.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9983,7 +9983,7 @@ func (action *DeliveryRuleCacheKeyQueryStringAction) ConvertToARM(resolved genru
 
 	// Set property "Parameters":
 	if action.Parameters != nil {
-		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := action.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10256,7 +10256,7 @@ func (condition *DeliveryRuleClientPortCondition) ConvertToARM(resolved genrunti
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10529,7 +10529,7 @@ func (condition *DeliveryRuleCookiesCondition) ConvertToARM(resolved genruntime.
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10802,7 +10802,7 @@ func (condition *DeliveryRuleHostNameCondition) ConvertToARM(resolved genruntime
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11075,7 +11075,7 @@ func (condition *DeliveryRuleHttpVersionCondition) ConvertToARM(resolved genrunt
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11348,7 +11348,7 @@ func (condition *DeliveryRuleIsDeviceCondition) ConvertToARM(resolved genruntime
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11621,7 +11621,7 @@ func (condition *DeliveryRulePostArgsCondition) ConvertToARM(resolved genruntime
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11894,7 +11894,7 @@ func (condition *DeliveryRuleQueryStringCondition) ConvertToARM(resolved genrunt
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12167,7 +12167,7 @@ func (condition *DeliveryRuleRemoteAddressCondition) ConvertToARM(resolved genru
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12440,7 +12440,7 @@ func (condition *DeliveryRuleRequestBodyCondition) ConvertToARM(resolved genrunt
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12713,7 +12713,7 @@ func (action *DeliveryRuleRequestHeaderAction) ConvertToARM(resolved genruntime.
 
 	// Set property "Parameters":
 	if action.Parameters != nil {
-		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := action.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12986,7 +12986,7 @@ func (condition *DeliveryRuleRequestHeaderCondition) ConvertToARM(resolved genru
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -13259,7 +13259,7 @@ func (condition *DeliveryRuleRequestMethodCondition) ConvertToARM(resolved genru
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -13532,7 +13532,7 @@ func (condition *DeliveryRuleRequestSchemeCondition) ConvertToARM(resolved genru
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -13805,7 +13805,7 @@ func (condition *DeliveryRuleRequestUriCondition) ConvertToARM(resolved genrunti
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -14078,7 +14078,7 @@ func (action *DeliveryRuleResponseHeaderAction) ConvertToARM(resolved genruntime
 
 	// Set property "Parameters":
 	if action.Parameters != nil {
-		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := action.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -14351,7 +14351,7 @@ func (action *DeliveryRuleRouteConfigurationOverrideAction) ConvertToARM(resolve
 
 	// Set property "Parameters":
 	if action.Parameters != nil {
-		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := action.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -14624,7 +14624,7 @@ func (condition *DeliveryRuleServerPortCondition) ConvertToARM(resolved genrunti
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -14897,7 +14897,7 @@ func (condition *DeliveryRuleSocketAddrCondition) ConvertToARM(resolved genrunti
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15170,7 +15170,7 @@ func (condition *DeliveryRuleSslProtocolCondition) ConvertToARM(resolved genrunt
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15443,7 +15443,7 @@ func (condition *DeliveryRuleUrlFileExtensionCondition) ConvertToARM(resolved ge
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15716,7 +15716,7 @@ func (condition *DeliveryRuleUrlFileNameCondition) ConvertToARM(resolved genrunt
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15989,7 +15989,7 @@ func (condition *DeliveryRuleUrlPathCondition) ConvertToARM(resolved genruntime.
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -16262,7 +16262,7 @@ func (action *OriginGroupOverrideAction) ConvertToARM(resolved genruntime.Conver
 
 	// Set property "Parameters":
 	if action.Parameters != nil {
-		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := action.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -16535,7 +16535,7 @@ func (action *UrlRedirectAction) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Parameters":
 	if action.Parameters != nil {
-		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := action.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -16808,7 +16808,7 @@ func (action *UrlRewriteAction) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "Parameters":
 	if action.Parameters != nil {
-		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := action.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -17081,7 +17081,7 @@ func (action *UrlSigningAction) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "Parameters":
 	if action.Parameters != nil {
-		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := action.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -21087,7 +21087,7 @@ func (parameters *OriginGroupOverrideActionParameters) ConvertToARM(resolved gen
 
 	// Set property "OriginGroup":
 	if parameters.OriginGroup != nil {
-		originGroup_ARM, err := (*parameters.OriginGroup).ConvertToARM(resolved)
+		originGroup_ARM, err := parameters.OriginGroup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -25078,7 +25078,7 @@ func (parameters *RouteConfigurationOverrideActionParameters) ConvertToARM(resol
 
 	// Set property "CacheConfiguration":
 	if parameters.CacheConfiguration != nil {
-		cacheConfiguration_ARM, err := (*parameters.CacheConfiguration).ConvertToARM(resolved)
+		cacheConfiguration_ARM, err := parameters.CacheConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -25088,7 +25088,7 @@ func (parameters *RouteConfigurationOverrideActionParameters) ConvertToARM(resol
 
 	// Set property "OriginGroupOverride":
 	if parameters.OriginGroupOverride != nil {
-		originGroupOverride_ARM, err := (*parameters.OriginGroupOverride).ConvertToARM(resolved)
+		originGroupOverride_ARM, err := parameters.OriginGroupOverride.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -30299,7 +30299,7 @@ func (override *OriginGroupOverride) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "OriginGroup":
 	if override.OriginGroup != nil {
-		originGroup_ARM, err := (*override.OriginGroup).ConvertToARM(resolved)
+		originGroup_ARM, err := override.OriginGroup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/cdn/v1api20230501/afd_custom_domain_types_gen.go
+++ b/v2/api/cdn/v1api20230501/afd_custom_domain_types_gen.go
@@ -301,7 +301,7 @@ func (domain *AfdCustomDomain_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties = &arm.AFDDomainProperties{}
 	}
 	if domain.AzureDnsZone != nil {
-		azureDnsZone_ARM, err := (*domain.AzureDnsZone).ConvertToARM(resolved)
+		azureDnsZone_ARM, err := domain.AzureDnsZone.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -319,7 +319,7 @@ func (domain *AfdCustomDomain_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.HostName = &hostName
 	}
 	if domain.PreValidatedCustomDomainResourceId != nil {
-		preValidatedCustomDomainResourceId_ARM, err := (*domain.PreValidatedCustomDomainResourceId).ConvertToARM(resolved)
+		preValidatedCustomDomainResourceId_ARM, err := domain.PreValidatedCustomDomainResourceId.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -327,7 +327,7 @@ func (domain *AfdCustomDomain_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.PreValidatedCustomDomainResourceId = &preValidatedCustomDomainResourceId
 	}
 	if domain.TlsSettings != nil {
-		tlsSettings_ARM, err := (*domain.TlsSettings).ConvertToARM(resolved)
+		tlsSettings_ARM, err := domain.TlsSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1339,7 +1339,7 @@ func (parameters *AFDDomainHttpsParameters) ConvertToARM(resolved genruntime.Con
 
 	// Set property "Secret":
 	if parameters.Secret != nil {
-		secret_ARM, err := (*parameters.Secret).ConvertToARM(resolved)
+		secret_ARM, err := parameters.Secret.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/cdn/v1api20230501/afd_origin_group_types_gen.go
+++ b/v2/api/cdn/v1api20230501/afd_origin_group_types_gen.go
@@ -298,7 +298,7 @@ func (group *AfdOriginGroup_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Properties = &arm.AFDOriginGroupProperties{}
 	}
 	if group.HealthProbeSettings != nil {
-		healthProbeSettings_ARM, err := (*group.HealthProbeSettings).ConvertToARM(resolved)
+		healthProbeSettings_ARM, err := group.HealthProbeSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -306,7 +306,7 @@ func (group *AfdOriginGroup_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Properties.HealthProbeSettings = &healthProbeSettings
 	}
 	if group.LoadBalancingSettings != nil {
-		loadBalancingSettings_ARM, err := (*group.LoadBalancingSettings).ConvertToARM(resolved)
+		loadBalancingSettings_ARM, err := group.LoadBalancingSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/cdn/v1api20230501/afd_origin_types_gen.go
+++ b/v2/api/cdn/v1api20230501/afd_origin_types_gen.go
@@ -336,7 +336,7 @@ func (origin *AfdOrigin_Spec) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.Properties = &arm.AFDOriginProperties{}
 	}
 	if origin.AzureOrigin != nil {
-		azureOrigin_ARM, err := (*origin.AzureOrigin).ConvertToARM(resolved)
+		azureOrigin_ARM, err := origin.AzureOrigin.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -382,7 +382,7 @@ func (origin *AfdOrigin_Spec) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.Properties.Priority = &priority
 	}
 	if origin.SharedPrivateLinkResource != nil {
-		sharedPrivateLinkResource_ARM, err := (*origin.SharedPrivateLinkResource).ConvertToARM(resolved)
+		sharedPrivateLinkResource_ARM, err := origin.SharedPrivateLinkResource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1576,7 +1576,7 @@ func (properties *SharedPrivateLinkResourceProperties) ConvertToARM(resolved gen
 
 	// Set property "PrivateLink":
 	if properties.PrivateLink != nil {
-		privateLink_ARM, err := (*properties.PrivateLink).ConvertToARM(resolved)
+		privateLink_ARM, err := properties.PrivateLink.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/cdn/v1api20230501/profile_types_gen.go
+++ b/v2/api/cdn/v1api20230501/profile_types_gen.go
@@ -293,7 +293,7 @@ func (profile *Profile_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Identity":
 	if profile.Identity != nil {
-		identity_ARM, err := (*profile.Identity).ConvertToARM(resolved)
+		identity_ARM, err := profile.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -321,7 +321,7 @@ func (profile *Profile_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Sku":
 	if profile.Sku != nil {
-		sku_ARM, err := (*profile.Sku).ConvertToARM(resolved)
+		sku_ARM, err := profile.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/cdn/v1api20230501/route_types_gen.go
+++ b/v2/api/cdn/v1api20230501/route_types_gen.go
@@ -325,7 +325,7 @@ func (route *Route_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.Properties = &arm.RouteProperties{}
 	}
 	if route.CacheConfiguration != nil {
-		cacheConfiguration_ARM, err := (*route.CacheConfiguration).ConvertToARM(resolved)
+		cacheConfiguration_ARM, err := route.CacheConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -364,7 +364,7 @@ func (route *Route_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.Properties.LinkToDefaultDomain = &linkToDefaultDomain
 	}
 	if route.OriginGroup != nil {
-		originGroup_ARM, err := (*route.OriginGroup).ConvertToARM(resolved)
+		originGroup_ARM, err := route.OriginGroup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1899,7 +1899,7 @@ func (configuration *AfdRouteCacheConfiguration) ConvertToARM(resolved genruntim
 
 	// Set property "CompressionSettings":
 	if configuration.CompressionSettings != nil {
-		compressionSettings_ARM, err := (*configuration.CompressionSettings).ConvertToARM(resolved)
+		compressionSettings_ARM, err := configuration.CompressionSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/cdn/v1api20230501/rule_types_gen.go
+++ b/v2/api/cdn/v1api20230501/rule_types_gen.go
@@ -1137,7 +1137,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "CacheExpiration":
 	if action.CacheExpiration != nil {
-		cacheExpiration_ARM, err := (*action.CacheExpiration).ConvertToARM(resolved)
+		cacheExpiration_ARM, err := action.CacheExpiration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1147,7 +1147,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "CacheKeyQueryString":
 	if action.CacheKeyQueryString != nil {
-		cacheKeyQueryString_ARM, err := (*action.CacheKeyQueryString).ConvertToARM(resolved)
+		cacheKeyQueryString_ARM, err := action.CacheKeyQueryString.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1157,7 +1157,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "ModifyRequestHeader":
 	if action.ModifyRequestHeader != nil {
-		modifyRequestHeader_ARM, err := (*action.ModifyRequestHeader).ConvertToARM(resolved)
+		modifyRequestHeader_ARM, err := action.ModifyRequestHeader.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1167,7 +1167,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "ModifyResponseHeader":
 	if action.ModifyResponseHeader != nil {
-		modifyResponseHeader_ARM, err := (*action.ModifyResponseHeader).ConvertToARM(resolved)
+		modifyResponseHeader_ARM, err := action.ModifyResponseHeader.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1177,7 +1177,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "OriginGroupOverride":
 	if action.OriginGroupOverride != nil {
-		originGroupOverride_ARM, err := (*action.OriginGroupOverride).ConvertToARM(resolved)
+		originGroupOverride_ARM, err := action.OriginGroupOverride.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1187,7 +1187,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "RouteConfigurationOverride":
 	if action.RouteConfigurationOverride != nil {
-		routeConfigurationOverride_ARM, err := (*action.RouteConfigurationOverride).ConvertToARM(resolved)
+		routeConfigurationOverride_ARM, err := action.RouteConfigurationOverride.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1197,7 +1197,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "UrlRedirect":
 	if action.UrlRedirect != nil {
-		urlRedirect_ARM, err := (*action.UrlRedirect).ConvertToARM(resolved)
+		urlRedirect_ARM, err := action.UrlRedirect.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1207,7 +1207,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "UrlRewrite":
 	if action.UrlRewrite != nil {
-		urlRewrite_ARM, err := (*action.UrlRewrite).ConvertToARM(resolved)
+		urlRewrite_ARM, err := action.UrlRewrite.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1217,7 +1217,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "UrlSigning":
 	if action.UrlSigning != nil {
-		urlSigning_ARM, err := (*action.UrlSigning).ConvertToARM(resolved)
+		urlSigning_ARM, err := action.UrlSigning.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2153,7 +2153,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "ClientPort":
 	if condition.ClientPort != nil {
-		clientPort_ARM, err := (*condition.ClientPort).ConvertToARM(resolved)
+		clientPort_ARM, err := condition.ClientPort.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2163,7 +2163,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "Cookies":
 	if condition.Cookies != nil {
-		cookies_ARM, err := (*condition.Cookies).ConvertToARM(resolved)
+		cookies_ARM, err := condition.Cookies.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2173,7 +2173,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "HostName":
 	if condition.HostName != nil {
-		hostName_ARM, err := (*condition.HostName).ConvertToARM(resolved)
+		hostName_ARM, err := condition.HostName.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2183,7 +2183,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "HttpVersion":
 	if condition.HttpVersion != nil {
-		httpVersion_ARM, err := (*condition.HttpVersion).ConvertToARM(resolved)
+		httpVersion_ARM, err := condition.HttpVersion.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2193,7 +2193,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "IsDevice":
 	if condition.IsDevice != nil {
-		isDevice_ARM, err := (*condition.IsDevice).ConvertToARM(resolved)
+		isDevice_ARM, err := condition.IsDevice.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2203,7 +2203,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "PostArgs":
 	if condition.PostArgs != nil {
-		postArgs_ARM, err := (*condition.PostArgs).ConvertToARM(resolved)
+		postArgs_ARM, err := condition.PostArgs.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2213,7 +2213,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "QueryString":
 	if condition.QueryString != nil {
-		queryString_ARM, err := (*condition.QueryString).ConvertToARM(resolved)
+		queryString_ARM, err := condition.QueryString.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2223,7 +2223,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "RemoteAddress":
 	if condition.RemoteAddress != nil {
-		remoteAddress_ARM, err := (*condition.RemoteAddress).ConvertToARM(resolved)
+		remoteAddress_ARM, err := condition.RemoteAddress.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2233,7 +2233,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "RequestBody":
 	if condition.RequestBody != nil {
-		requestBody_ARM, err := (*condition.RequestBody).ConvertToARM(resolved)
+		requestBody_ARM, err := condition.RequestBody.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2243,7 +2243,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "RequestHeader":
 	if condition.RequestHeader != nil {
-		requestHeader_ARM, err := (*condition.RequestHeader).ConvertToARM(resolved)
+		requestHeader_ARM, err := condition.RequestHeader.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2253,7 +2253,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "RequestMethod":
 	if condition.RequestMethod != nil {
-		requestMethod_ARM, err := (*condition.RequestMethod).ConvertToARM(resolved)
+		requestMethod_ARM, err := condition.RequestMethod.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2263,7 +2263,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "RequestScheme":
 	if condition.RequestScheme != nil {
-		requestScheme_ARM, err := (*condition.RequestScheme).ConvertToARM(resolved)
+		requestScheme_ARM, err := condition.RequestScheme.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2273,7 +2273,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "RequestUri":
 	if condition.RequestUri != nil {
-		requestUri_ARM, err := (*condition.RequestUri).ConvertToARM(resolved)
+		requestUri_ARM, err := condition.RequestUri.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2283,7 +2283,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "ServerPort":
 	if condition.ServerPort != nil {
-		serverPort_ARM, err := (*condition.ServerPort).ConvertToARM(resolved)
+		serverPort_ARM, err := condition.ServerPort.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2293,7 +2293,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "SocketAddr":
 	if condition.SocketAddr != nil {
-		socketAddr_ARM, err := (*condition.SocketAddr).ConvertToARM(resolved)
+		socketAddr_ARM, err := condition.SocketAddr.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2303,7 +2303,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "SslProtocol":
 	if condition.SslProtocol != nil {
-		sslProtocol_ARM, err := (*condition.SslProtocol).ConvertToARM(resolved)
+		sslProtocol_ARM, err := condition.SslProtocol.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2313,7 +2313,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "UrlFileExtension":
 	if condition.UrlFileExtension != nil {
-		urlFileExtension_ARM, err := (*condition.UrlFileExtension).ConvertToARM(resolved)
+		urlFileExtension_ARM, err := condition.UrlFileExtension.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2323,7 +2323,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "UrlFileName":
 	if condition.UrlFileName != nil {
-		urlFileName_ARM, err := (*condition.UrlFileName).ConvertToARM(resolved)
+		urlFileName_ARM, err := condition.UrlFileName.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2333,7 +2333,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "UrlPath":
 	if condition.UrlPath != nil {
-		urlPath_ARM, err := (*condition.UrlPath).ConvertToARM(resolved)
+		urlPath_ARM, err := condition.UrlPath.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4245,7 +4245,7 @@ func (action *DeliveryRuleCacheExpirationAction) ConvertToARM(resolved genruntim
 
 	// Set property "Parameters":
 	if action.Parameters != nil {
-		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := action.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4518,7 +4518,7 @@ func (action *DeliveryRuleCacheKeyQueryStringAction) ConvertToARM(resolved genru
 
 	// Set property "Parameters":
 	if action.Parameters != nil {
-		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := action.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4791,7 +4791,7 @@ func (condition *DeliveryRuleClientPortCondition) ConvertToARM(resolved genrunti
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5064,7 +5064,7 @@ func (condition *DeliveryRuleCookiesCondition) ConvertToARM(resolved genruntime.
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5337,7 +5337,7 @@ func (condition *DeliveryRuleHostNameCondition) ConvertToARM(resolved genruntime
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5610,7 +5610,7 @@ func (condition *DeliveryRuleHttpVersionCondition) ConvertToARM(resolved genrunt
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5883,7 +5883,7 @@ func (condition *DeliveryRuleIsDeviceCondition) ConvertToARM(resolved genruntime
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6156,7 +6156,7 @@ func (condition *DeliveryRulePostArgsCondition) ConvertToARM(resolved genruntime
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6429,7 +6429,7 @@ func (condition *DeliveryRuleQueryStringCondition) ConvertToARM(resolved genrunt
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6702,7 +6702,7 @@ func (condition *DeliveryRuleRemoteAddressCondition) ConvertToARM(resolved genru
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6975,7 +6975,7 @@ func (condition *DeliveryRuleRequestBodyCondition) ConvertToARM(resolved genrunt
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7248,7 +7248,7 @@ func (action *DeliveryRuleRequestHeaderAction) ConvertToARM(resolved genruntime.
 
 	// Set property "Parameters":
 	if action.Parameters != nil {
-		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := action.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7521,7 +7521,7 @@ func (condition *DeliveryRuleRequestHeaderCondition) ConvertToARM(resolved genru
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7794,7 +7794,7 @@ func (condition *DeliveryRuleRequestMethodCondition) ConvertToARM(resolved genru
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8067,7 +8067,7 @@ func (condition *DeliveryRuleRequestSchemeCondition) ConvertToARM(resolved genru
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8340,7 +8340,7 @@ func (condition *DeliveryRuleRequestUriCondition) ConvertToARM(resolved genrunti
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8613,7 +8613,7 @@ func (action *DeliveryRuleResponseHeaderAction) ConvertToARM(resolved genruntime
 
 	// Set property "Parameters":
 	if action.Parameters != nil {
-		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := action.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8886,7 +8886,7 @@ func (action *DeliveryRuleRouteConfigurationOverrideAction) ConvertToARM(resolve
 
 	// Set property "Parameters":
 	if action.Parameters != nil {
-		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := action.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9159,7 +9159,7 @@ func (condition *DeliveryRuleServerPortCondition) ConvertToARM(resolved genrunti
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9432,7 +9432,7 @@ func (condition *DeliveryRuleSocketAddrCondition) ConvertToARM(resolved genrunti
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9705,7 +9705,7 @@ func (condition *DeliveryRuleSslProtocolCondition) ConvertToARM(resolved genrunt
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9978,7 +9978,7 @@ func (condition *DeliveryRuleUrlFileExtensionCondition) ConvertToARM(resolved ge
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10251,7 +10251,7 @@ func (condition *DeliveryRuleUrlFileNameCondition) ConvertToARM(resolved genrunt
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10524,7 +10524,7 @@ func (condition *DeliveryRuleUrlPathCondition) ConvertToARM(resolved genruntime.
 
 	// Set property "Parameters":
 	if condition.Parameters != nil {
-		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := condition.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10797,7 +10797,7 @@ func (action *OriginGroupOverrideAction) ConvertToARM(resolved genruntime.Conver
 
 	// Set property "Parameters":
 	if action.Parameters != nil {
-		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := action.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11070,7 +11070,7 @@ func (action *UrlRedirectAction) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Parameters":
 	if action.Parameters != nil {
-		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := action.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11343,7 +11343,7 @@ func (action *UrlRewriteAction) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "Parameters":
 	if action.Parameters != nil {
-		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := action.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11616,7 +11616,7 @@ func (action *UrlSigningAction) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "Parameters":
 	if action.Parameters != nil {
-		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := action.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15622,7 +15622,7 @@ func (parameters *OriginGroupOverrideActionParameters) ConvertToARM(resolved gen
 
 	// Set property "OriginGroup":
 	if parameters.OriginGroup != nil {
-		originGroup_ARM, err := (*parameters.OriginGroup).ConvertToARM(resolved)
+		originGroup_ARM, err := parameters.OriginGroup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -19613,7 +19613,7 @@ func (parameters *RouteConfigurationOverrideActionParameters) ConvertToARM(resol
 
 	// Set property "CacheConfiguration":
 	if parameters.CacheConfiguration != nil {
-		cacheConfiguration_ARM, err := (*parameters.CacheConfiguration).ConvertToARM(resolved)
+		cacheConfiguration_ARM, err := parameters.CacheConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -19623,7 +19623,7 @@ func (parameters *RouteConfigurationOverrideActionParameters) ConvertToARM(resol
 
 	// Set property "OriginGroupOverride":
 	if parameters.OriginGroupOverride != nil {
-		originGroupOverride_ARM, err := (*parameters.OriginGroupOverride).ConvertToARM(resolved)
+		originGroupOverride_ARM, err := parameters.OriginGroupOverride.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -24834,7 +24834,7 @@ func (override *OriginGroupOverride) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "OriginGroup":
 	if override.OriginGroup != nil {
-		originGroup_ARM, err := (*override.OriginGroup).ConvertToARM(resolved)
+		originGroup_ARM, err := override.OriginGroup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/cdn/v1api20230501/secret_types_gen.go
+++ b/v2/api/cdn/v1api20230501/secret_types_gen.go
@@ -282,7 +282,7 @@ func (secret *Secret_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.Properties = &arm.SecretProperties{}
 	}
 	if secret.Parameters != nil {
-		parameters_ARM, err := (*secret.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := secret.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -941,7 +941,7 @@ func (parameters *SecretParameters) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "AzureFirstPartyManagedCertificate":
 	if parameters.AzureFirstPartyManagedCertificate != nil {
-		azureFirstPartyManagedCertificate_ARM, err := (*parameters.AzureFirstPartyManagedCertificate).ConvertToARM(resolved)
+		azureFirstPartyManagedCertificate_ARM, err := parameters.AzureFirstPartyManagedCertificate.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -951,7 +951,7 @@ func (parameters *SecretParameters) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "CustomerCertificate":
 	if parameters.CustomerCertificate != nil {
-		customerCertificate_ARM, err := (*parameters.CustomerCertificate).ConvertToARM(resolved)
+		customerCertificate_ARM, err := parameters.CustomerCertificate.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -961,7 +961,7 @@ func (parameters *SecretParameters) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "ManagedCertificate":
 	if parameters.ManagedCertificate != nil {
-		managedCertificate_ARM, err := (*parameters.ManagedCertificate).ConvertToARM(resolved)
+		managedCertificate_ARM, err := parameters.ManagedCertificate.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -971,7 +971,7 @@ func (parameters *SecretParameters) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "UrlSigningKey":
 	if parameters.UrlSigningKey != nil {
-		urlSigningKey_ARM, err := (*parameters.UrlSigningKey).ConvertToARM(resolved)
+		urlSigningKey_ARM, err := parameters.UrlSigningKey.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1782,7 +1782,7 @@ func (parameters *CustomerCertificateParameters) ConvertToARM(resolved genruntim
 
 	// Set property "SecretSource":
 	if parameters.SecretSource != nil {
-		secretSource_ARM, err := (*parameters.SecretSource).ConvertToARM(resolved)
+		secretSource_ARM, err := parameters.SecretSource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2459,7 +2459,7 @@ func (parameters *UrlSigningKeyParameters) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "SecretSource":
 	if parameters.SecretSource != nil {
-		secretSource_ARM, err := (*parameters.SecretSource).ConvertToARM(resolved)
+		secretSource_ARM, err := parameters.SecretSource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/cdn/v1api20230501/security_policy_types_gen.go
+++ b/v2/api/cdn/v1api20230501/security_policy_types_gen.go
@@ -282,7 +282,7 @@ func (policy *SecurityPolicy_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties = &arm.SecurityPolicyProperties{}
 	}
 	if policy.Parameters != nil {
-		parameters_ARM, err := (*policy.Parameters).ConvertToARM(resolved)
+		parameters_ARM, err := policy.Parameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -968,7 +968,7 @@ func (parameters *SecurityPolicyPropertiesParameters) ConvertToARM(resolved genr
 
 	// Set property "WebApplicationFirewall":
 	if parameters.WebApplicationFirewall != nil {
-		webApplicationFirewall_ARM, err := (*parameters.WebApplicationFirewall).ConvertToARM(resolved)
+		webApplicationFirewall_ARM, err := parameters.WebApplicationFirewall.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1193,7 +1193,7 @@ func (parameters *SecurityPolicyWebApplicationFirewallParameters) ConvertToARM(r
 
 	// Set property "WafPolicy":
 	if parameters.WafPolicy != nil {
-		wafPolicy_ARM, err := (*parameters.WafPolicy).ConvertToARM(resolved)
+		wafPolicy_ARM, err := parameters.WafPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/cognitiveservices/v1api20250601/account_types_gen.go
+++ b/v2/api/cognitiveservices/v1api20250601/account_types_gen.go
@@ -295,7 +295,7 @@ func (account *Account_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Identity":
 	if account.Identity != nil {
-		identity_ARM, err := (*account.Identity).ConvertToARM(resolved)
+		identity_ARM, err := account.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -320,7 +320,7 @@ func (account *Account_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Properties":
 	if account.Properties != nil {
-		properties_ARM, err := (*account.Properties).ConvertToARM(resolved)
+		properties_ARM, err := account.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -330,7 +330,7 @@ func (account *Account_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Sku":
 	if account.Sku != nil {
-		sku_ARM, err := (*account.Sku).ConvertToARM(resolved)
+		sku_ARM, err := account.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1279,7 +1279,7 @@ func (properties *AccountProperties) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "AmlWorkspace":
 	if properties.AmlWorkspace != nil {
-		amlWorkspace_ARM, err := (*properties.AmlWorkspace).ConvertToARM(resolved)
+		amlWorkspace_ARM, err := properties.AmlWorkspace.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1289,7 +1289,7 @@ func (properties *AccountProperties) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "ApiProperties":
 	if properties.ApiProperties != nil {
-		apiProperties_ARM, err := (*properties.ApiProperties).ConvertToARM(resolved)
+		apiProperties_ARM, err := properties.ApiProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1328,7 +1328,7 @@ func (properties *AccountProperties) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "Encryption":
 	if properties.Encryption != nil {
-		encryption_ARM, err := (*properties.Encryption).ConvertToARM(resolved)
+		encryption_ARM, err := properties.Encryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1338,7 +1338,7 @@ func (properties *AccountProperties) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "Locations":
 	if properties.Locations != nil {
-		locations_ARM, err := (*properties.Locations).ConvertToARM(resolved)
+		locations_ARM, err := properties.Locations.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1358,7 +1358,7 @@ func (properties *AccountProperties) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "NetworkAcls":
 	if properties.NetworkAcls != nil {
-		networkAcls_ARM, err := (*properties.NetworkAcls).ConvertToARM(resolved)
+		networkAcls_ARM, err := properties.NetworkAcls.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1368,7 +1368,7 @@ func (properties *AccountProperties) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "NetworkInjections":
 	if properties.NetworkInjections != nil {
-		networkInjections_ARM, err := (*properties.NetworkInjections).ConvertToARM(resolved)
+		networkInjections_ARM, err := properties.NetworkInjections.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1386,7 +1386,7 @@ func (properties *AccountProperties) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "RaiMonitorConfig":
 	if properties.RaiMonitorConfig != nil {
-		raiMonitorConfig_ARM, err := (*properties.RaiMonitorConfig).ConvertToARM(resolved)
+		raiMonitorConfig_ARM, err := properties.RaiMonitorConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5179,7 +5179,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "KeyVaultProperties":
 	if encryption.KeyVaultProperties != nil {
-		keyVaultProperties_ARM, err := (*encryption.KeyVaultProperties).ConvertToARM(resolved)
+		keyVaultProperties_ARM, err := encryption.KeyVaultProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/cognitiveservices/v1api20250601/deployment_types_gen.go
+++ b/v2/api/cognitiveservices/v1api20250601/deployment_types_gen.go
@@ -285,7 +285,7 @@ func (deployment *Deployment_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Properties":
 	if deployment.Properties != nil {
-		properties_ARM, err := (*deployment.Properties).ConvertToARM(resolved)
+		properties_ARM, err := deployment.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -295,7 +295,7 @@ func (deployment *Deployment_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Sku":
 	if deployment.Sku != nil {
-		sku_ARM, err := (*deployment.Sku).ConvertToARM(resolved)
+		sku_ARM, err := deployment.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1025,7 +1025,7 @@ func (properties *DeploymentProperties) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "CapacitySettings":
 	if properties.CapacitySettings != nil {
-		capacitySettings_ARM, err := (*properties.CapacitySettings).ConvertToARM(resolved)
+		capacitySettings_ARM, err := properties.CapacitySettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1035,7 +1035,7 @@ func (properties *DeploymentProperties) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "Model":
 	if properties.Model != nil {
-		model_ARM, err := (*properties.Model).ConvertToARM(resolved)
+		model_ARM, err := properties.Model.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1057,7 +1057,7 @@ func (properties *DeploymentProperties) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "ScaleSettings":
 	if properties.ScaleSettings != nil {
-		scaleSettings_ARM, err := (*properties.ScaleSettings).ConvertToARM(resolved)
+		scaleSettings_ARM, err := properties.ScaleSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/compute/v1api20200930/disk_types_gen.go
+++ b/v2/api/compute/v1api20200930/disk_types_gen.go
@@ -357,7 +357,7 @@ func (disk *Disk_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 
 	// Set property "ExtendedLocation":
 	if disk.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*disk.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := disk.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -398,7 +398,7 @@ func (disk *Disk_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 		result.Properties.BurstingEnabled = &burstingEnabled
 	}
 	if disk.CreationData != nil {
-		creationData_ARM, err := (*disk.CreationData).ConvertToARM(resolved)
+		creationData_ARM, err := disk.CreationData.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -434,7 +434,7 @@ func (disk *Disk_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 		result.Properties.DiskSizeGB = &diskSizeGB
 	}
 	if disk.Encryption != nil {
-		encryption_ARM, err := (*disk.Encryption).ConvertToARM(resolved)
+		encryption_ARM, err := disk.Encryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -442,7 +442,7 @@ func (disk *Disk_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 		result.Properties.Encryption = &encryption
 	}
 	if disk.EncryptionSettingsCollection != nil {
-		encryptionSettingsCollection_ARM, err := (*disk.EncryptionSettingsCollection).ConvertToARM(resolved)
+		encryptionSettingsCollection_ARM, err := disk.EncryptionSettingsCollection.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -472,7 +472,7 @@ func (disk *Disk_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 		result.Properties.OsType = &osType
 	}
 	if disk.PurchasePlan != nil {
-		purchasePlan_ARM, err := (*disk.PurchasePlan).ConvertToARM(resolved)
+		purchasePlan_ARM, err := disk.PurchasePlan.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -486,7 +486,7 @@ func (disk *Disk_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 
 	// Set property "Sku":
 	if disk.Sku != nil {
-		sku_ARM, err := (*disk.Sku).ConvertToARM(resolved)
+		sku_ARM, err := disk.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2106,7 +2106,7 @@ func (data *CreationData) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "GalleryImageReference":
 	if data.GalleryImageReference != nil {
-		galleryImageReference_ARM, err := (*data.GalleryImageReference).ConvertToARM(resolved)
+		galleryImageReference_ARM, err := data.GalleryImageReference.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2116,7 +2116,7 @@ func (data *CreationData) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "ImageReference":
 	if data.ImageReference != nil {
-		imageReference_ARM, err := (*data.ImageReference).ConvertToARM(resolved)
+		imageReference_ARM, err := data.ImageReference.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4105,7 +4105,7 @@ func (element *EncryptionSettingsElement) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "DiskEncryptionKey":
 	if element.DiskEncryptionKey != nil {
-		diskEncryptionKey_ARM, err := (*element.DiskEncryptionKey).ConvertToARM(resolved)
+		diskEncryptionKey_ARM, err := element.DiskEncryptionKey.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4115,7 +4115,7 @@ func (element *EncryptionSettingsElement) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "KeyEncryptionKey":
 	if element.KeyEncryptionKey != nil {
-		keyEncryptionKey_ARM, err := (*element.KeyEncryptionKey).ConvertToARM(resolved)
+		keyEncryptionKey_ARM, err := element.KeyEncryptionKey.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4619,7 +4619,7 @@ func (reference *KeyVaultAndKeyReference) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "SourceVault":
 	if reference.SourceVault != nil {
-		sourceVault_ARM, err := (*reference.SourceVault).ConvertToARM(resolved)
+		sourceVault_ARM, err := reference.SourceVault.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4840,7 +4840,7 @@ func (reference *KeyVaultAndSecretReference) ConvertToARM(resolved genruntime.Co
 
 	// Set property "SourceVault":
 	if reference.SourceVault != nil {
-		sourceVault_ARM, err := (*reference.SourceVault).ConvertToARM(resolved)
+		sourceVault_ARM, err := reference.SourceVault.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/compute/v1api20200930/snapshot_types_gen.go
+++ b/v2/api/compute/v1api20200930/snapshot_types_gen.go
@@ -328,7 +328,7 @@ func (snapshot *Snapshot_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "ExtendedLocation":
 	if snapshot.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*snapshot.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := snapshot.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -360,7 +360,7 @@ func (snapshot *Snapshot_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties = &arm.SnapshotProperties{}
 	}
 	if snapshot.CreationData != nil {
-		creationData_ARM, err := (*snapshot.CreationData).ConvertToARM(resolved)
+		creationData_ARM, err := snapshot.CreationData.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -386,7 +386,7 @@ func (snapshot *Snapshot_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.DiskState = &diskState
 	}
 	if snapshot.Encryption != nil {
-		encryption_ARM, err := (*snapshot.Encryption).ConvertToARM(resolved)
+		encryption_ARM, err := snapshot.Encryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -394,7 +394,7 @@ func (snapshot *Snapshot_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.Encryption = &encryption
 	}
 	if snapshot.EncryptionSettingsCollection != nil {
-		encryptionSettingsCollection_ARM, err := (*snapshot.EncryptionSettingsCollection).ConvertToARM(resolved)
+		encryptionSettingsCollection_ARM, err := snapshot.EncryptionSettingsCollection.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -424,7 +424,7 @@ func (snapshot *Snapshot_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.OsType = &osType
 	}
 	if snapshot.PurchasePlan != nil {
-		purchasePlan_ARM, err := (*snapshot.PurchasePlan).ConvertToARM(resolved)
+		purchasePlan_ARM, err := snapshot.PurchasePlan.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -434,7 +434,7 @@ func (snapshot *Snapshot_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "Sku":
 	if snapshot.Sku != nil {
-		sku_ARM, err := (*snapshot.Sku).ConvertToARM(resolved)
+		sku_ARM, err := snapshot.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/compute/v1api20201201/virtual_machine_scale_set_types_gen.go
+++ b/v2/api/compute/v1api20201201/virtual_machine_scale_set_types_gen.go
@@ -351,7 +351,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 
 	// Set property "ExtendedLocation":
 	if scaleSet.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*scaleSet.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := scaleSet.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -361,7 +361,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Identity":
 	if scaleSet.Identity != nil {
-		identity_ARM, err := (*scaleSet.Identity).ConvertToARM(resolved)
+		identity_ARM, err := scaleSet.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -380,7 +380,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Plan":
 	if scaleSet.Plan != nil {
-		plan_ARM, err := (*scaleSet.Plan).ConvertToARM(resolved)
+		plan_ARM, err := scaleSet.Plan.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -405,7 +405,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties = &arm.VirtualMachineScaleSetProperties{}
 	}
 	if scaleSet.AdditionalCapabilities != nil {
-		additionalCapabilities_ARM, err := (*scaleSet.AdditionalCapabilities).ConvertToARM(resolved)
+		additionalCapabilities_ARM, err := scaleSet.AdditionalCapabilities.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -413,7 +413,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.AdditionalCapabilities = &additionalCapabilities
 	}
 	if scaleSet.AutomaticRepairsPolicy != nil {
-		automaticRepairsPolicy_ARM, err := (*scaleSet.AutomaticRepairsPolicy).ConvertToARM(resolved)
+		automaticRepairsPolicy_ARM, err := scaleSet.AutomaticRepairsPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -425,7 +425,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.DoNotRunExtensionsOnOverprovisionedVMs = &doNotRunExtensionsOnOverprovisionedVMs
 	}
 	if scaleSet.HostGroup != nil {
-		hostGroup_ARM, err := (*scaleSet.HostGroup).ConvertToARM(resolved)
+		hostGroup_ARM, err := scaleSet.HostGroup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -447,7 +447,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.PlatformFaultDomainCount = &platformFaultDomainCount
 	}
 	if scaleSet.ProximityPlacementGroup != nil {
-		proximityPlacementGroup_ARM, err := (*scaleSet.ProximityPlacementGroup).ConvertToARM(resolved)
+		proximityPlacementGroup_ARM, err := scaleSet.ProximityPlacementGroup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -455,7 +455,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.ProximityPlacementGroup = &proximityPlacementGroup
 	}
 	if scaleSet.ScaleInPolicy != nil {
-		scaleInPolicy_ARM, err := (*scaleSet.ScaleInPolicy).ConvertToARM(resolved)
+		scaleInPolicy_ARM, err := scaleSet.ScaleInPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -467,7 +467,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.SinglePlacementGroup = &singlePlacementGroup
 	}
 	if scaleSet.UpgradePolicy != nil {
-		upgradePolicy_ARM, err := (*scaleSet.UpgradePolicy).ConvertToARM(resolved)
+		upgradePolicy_ARM, err := scaleSet.UpgradePolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -475,7 +475,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.UpgradePolicy = &upgradePolicy
 	}
 	if scaleSet.VirtualMachineProfile != nil {
-		virtualMachineProfile_ARM, err := (*scaleSet.VirtualMachineProfile).ConvertToARM(resolved)
+		virtualMachineProfile_ARM, err := scaleSet.VirtualMachineProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -489,7 +489,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Sku":
 	if scaleSet.Sku != nil {
-		sku_ARM, err := (*scaleSet.Sku).ConvertToARM(resolved)
+		sku_ARM, err := scaleSet.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2764,7 +2764,7 @@ func (policy *UpgradePolicy) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "AutomaticOSUpgradePolicy":
 	if policy.AutomaticOSUpgradePolicy != nil {
-		automaticOSUpgradePolicy_ARM, err := (*policy.AutomaticOSUpgradePolicy).ConvertToARM(resolved)
+		automaticOSUpgradePolicy_ARM, err := policy.AutomaticOSUpgradePolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2782,7 +2782,7 @@ func (policy *UpgradePolicy) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "RollingUpgradePolicy":
 	if policy.RollingUpgradePolicy != nil {
-		rollingUpgradePolicy_ARM, err := (*policy.RollingUpgradePolicy).ConvertToARM(resolved)
+		rollingUpgradePolicy_ARM, err := policy.RollingUpgradePolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3551,7 +3551,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 
 	// Set property "BillingProfile":
 	if profile.BillingProfile != nil {
-		billingProfile_ARM, err := (*profile.BillingProfile).ConvertToARM(resolved)
+		billingProfile_ARM, err := profile.BillingProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3561,7 +3561,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 
 	// Set property "DiagnosticsProfile":
 	if profile.DiagnosticsProfile != nil {
-		diagnosticsProfile_ARM, err := (*profile.DiagnosticsProfile).ConvertToARM(resolved)
+		diagnosticsProfile_ARM, err := profile.DiagnosticsProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3579,7 +3579,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 
 	// Set property "ExtensionProfile":
 	if profile.ExtensionProfile != nil {
-		extensionProfile_ARM, err := (*profile.ExtensionProfile).ConvertToARM(resolved)
+		extensionProfile_ARM, err := profile.ExtensionProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3595,7 +3595,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 
 	// Set property "NetworkProfile":
 	if profile.NetworkProfile != nil {
-		networkProfile_ARM, err := (*profile.NetworkProfile).ConvertToARM(resolved)
+		networkProfile_ARM, err := profile.NetworkProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3605,7 +3605,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 
 	// Set property "OsProfile":
 	if profile.OsProfile != nil {
-		osProfile_ARM, err := (*profile.OsProfile).ConvertToARM(resolved)
+		osProfile_ARM, err := profile.OsProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3623,7 +3623,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 
 	// Set property "ScheduledEventsProfile":
 	if profile.ScheduledEventsProfile != nil {
-		scheduledEventsProfile_ARM, err := (*profile.ScheduledEventsProfile).ConvertToARM(resolved)
+		scheduledEventsProfile_ARM, err := profile.ScheduledEventsProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3633,7 +3633,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 
 	// Set property "SecurityProfile":
 	if profile.SecurityProfile != nil {
-		securityProfile_ARM, err := (*profile.SecurityProfile).ConvertToARM(resolved)
+		securityProfile_ARM, err := profile.SecurityProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3643,7 +3643,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 
 	// Set property "StorageProfile":
 	if profile.StorageProfile != nil {
-		storageProfile_ARM, err := (*profile.StorageProfile).ConvertToARM(resolved)
+		storageProfile_ARM, err := profile.StorageProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5111,7 +5111,7 @@ func (profile *ScheduledEventsProfile) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "TerminateNotificationProfile":
 	if profile.TerminateNotificationProfile != nil {
-		terminateNotificationProfile_ARM, err := (*profile.TerminateNotificationProfile).ConvertToARM(resolved)
+		terminateNotificationProfile_ARM, err := profile.TerminateNotificationProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5683,7 +5683,7 @@ func (profile *VirtualMachineScaleSetNetworkProfile) ConvertToARM(resolved genru
 
 	// Set property "HealthProbe":
 	if profile.HealthProbe != nil {
-		healthProbe_ARM, err := (*profile.HealthProbe).ConvertToARM(resolved)
+		healthProbe_ARM, err := profile.HealthProbe.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6053,7 +6053,7 @@ func (profile *VirtualMachineScaleSetOSProfile) ConvertToARM(resolved genruntime
 
 	// Set property "LinuxConfiguration":
 	if profile.LinuxConfiguration != nil {
-		linuxConfiguration_ARM, err := (*profile.LinuxConfiguration).ConvertToARM(resolved)
+		linuxConfiguration_ARM, err := profile.LinuxConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6072,7 +6072,7 @@ func (profile *VirtualMachineScaleSetOSProfile) ConvertToARM(resolved genruntime
 
 	// Set property "WindowsConfiguration":
 	if profile.WindowsConfiguration != nil {
-		windowsConfiguration_ARM, err := (*profile.WindowsConfiguration).ConvertToARM(resolved)
+		windowsConfiguration_ARM, err := profile.WindowsConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6563,7 +6563,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) ConvertToARM(resolved genru
 
 	// Set property "ImageReference":
 	if profile.ImageReference != nil {
-		imageReference_ARM, err := (*profile.ImageReference).ConvertToARM(resolved)
+		imageReference_ARM, err := profile.ImageReference.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6573,7 +6573,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) ConvertToARM(resolved genru
 
 	// Set property "OsDisk":
 	if profile.OsDisk != nil {
-		osDisk_ARM, err := (*profile.OsDisk).ConvertToARM(resolved)
+		osDisk_ARM, err := profile.OsDisk.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7340,7 +7340,7 @@ func (disk *VirtualMachineScaleSetDataDisk) ConvertToARM(resolved genruntime.Con
 
 	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
-		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
+		managedDisk_ARM, err := disk.ManagedDisk.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8520,7 +8520,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) ConvertToARM(re
 		result.Properties = &arm.VirtualMachineScaleSetNetworkConfigurationProperties{}
 	}
 	if configuration.DnsSettings != nil {
-		dnsSettings_ARM, err := (*configuration.DnsSettings).ConvertToARM(resolved)
+		dnsSettings_ARM, err := configuration.DnsSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8547,7 +8547,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) ConvertToARM(re
 		result.Properties.IpConfigurations = append(result.Properties.IpConfigurations, *item_ARM.(*arm.VirtualMachineScaleSetIPConfiguration))
 	}
 	if configuration.NetworkSecurityGroup != nil {
-		networkSecurityGroup_ARM, err := (*configuration.NetworkSecurityGroup).ConvertToARM(resolved)
+		networkSecurityGroup_ARM, err := configuration.NetworkSecurityGroup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9251,7 +9251,7 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "DiffDiskSettings":
 	if disk.DiffDiskSettings != nil {
-		diffDiskSettings_ARM, err := (*disk.DiffDiskSettings).ConvertToARM(resolved)
+		diffDiskSettings_ARM, err := disk.DiffDiskSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9267,7 +9267,7 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "Image":
 	if disk.Image != nil {
-		image_ARM, err := (*disk.Image).ConvertToARM(resolved)
+		image_ARM, err := disk.Image.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9277,7 +9277,7 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
-		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
+		managedDisk_ARM, err := disk.ManagedDisk.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10030,7 +10030,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) ConvertToARM(resolve
 		result.Properties.PrivateIPAddressVersion = &privateIPAddressVersion
 	}
 	if configuration.PublicIPAddressConfiguration != nil {
-		publicIPAddressConfiguration_ARM, err := (*configuration.PublicIPAddressConfiguration).ConvertToARM(resolved)
+		publicIPAddressConfiguration_ARM, err := configuration.PublicIPAddressConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10038,7 +10038,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) ConvertToARM(resolve
 		result.Properties.PublicIPAddressConfiguration = &publicIPAddressConfiguration
 	}
 	if configuration.Subnet != nil {
-		subnet_ARM, err := (*configuration.Subnet).ConvertToARM(resolved)
+		subnet_ARM, err := configuration.Subnet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10893,7 +10893,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters) ConvertToARM(reso
 
 	// Set property "DiskEncryptionSet":
 	if parameters.DiskEncryptionSet != nil {
-		diskEncryptionSet_ARM, err := (*parameters.DiskEncryptionSet).ConvertToARM(resolved)
+		diskEncryptionSet_ARM, err := parameters.DiskEncryptionSet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11352,7 +11352,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Convert
 		result.Properties = &arm.VirtualMachineScaleSetPublicIPAddressConfigurationProperties{}
 	}
 	if configuration.DnsSettings != nil {
-		dnsSettings_ARM, err := (*configuration.DnsSettings).ConvertToARM(resolved)
+		dnsSettings_ARM, err := configuration.DnsSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11377,7 +11377,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Convert
 		result.Properties.PublicIPAddressVersion = &publicIPAddressVersion
 	}
 	if configuration.PublicIPPrefix != nil {
-		publicIPPrefix_ARM, err := (*configuration.PublicIPPrefix).ConvertToARM(resolved)
+		publicIPPrefix_ARM, err := configuration.PublicIPPrefix.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/compute/v1api20201201/virtual_machine_types_gen.go
+++ b/v2/api/compute/v1api20201201/virtual_machine_types_gen.go
@@ -404,7 +404,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "ExtendedLocation":
 	if machine.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*machine.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := machine.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -414,7 +414,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Identity":
 	if machine.Identity != nil {
-		identity_ARM, err := (*machine.Identity).ConvertToARM(resolved)
+		identity_ARM, err := machine.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -433,7 +433,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Plan":
 	if machine.Plan != nil {
-		plan_ARM, err := (*machine.Plan).ConvertToARM(resolved)
+		plan_ARM, err := machine.Plan.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -463,7 +463,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties = &arm.VirtualMachineProperties{}
 	}
 	if machine.AdditionalCapabilities != nil {
-		additionalCapabilities_ARM, err := (*machine.AdditionalCapabilities).ConvertToARM(resolved)
+		additionalCapabilities_ARM, err := machine.AdditionalCapabilities.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -471,7 +471,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AdditionalCapabilities = &additionalCapabilities
 	}
 	if machine.AvailabilitySet != nil {
-		availabilitySet_ARM, err := (*machine.AvailabilitySet).ConvertToARM(resolved)
+		availabilitySet_ARM, err := machine.AvailabilitySet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -479,7 +479,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AvailabilitySet = &availabilitySet
 	}
 	if machine.BillingProfile != nil {
-		billingProfile_ARM, err := (*machine.BillingProfile).ConvertToARM(resolved)
+		billingProfile_ARM, err := machine.BillingProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -487,7 +487,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.BillingProfile = &billingProfile
 	}
 	if machine.DiagnosticsProfile != nil {
-		diagnosticsProfile_ARM, err := (*machine.DiagnosticsProfile).ConvertToARM(resolved)
+		diagnosticsProfile_ARM, err := machine.DiagnosticsProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -505,7 +505,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.ExtensionsTimeBudget = &extensionsTimeBudget
 	}
 	if machine.HardwareProfile != nil {
-		hardwareProfile_ARM, err := (*machine.HardwareProfile).ConvertToARM(resolved)
+		hardwareProfile_ARM, err := machine.HardwareProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -513,7 +513,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.HardwareProfile = &hardwareProfile
 	}
 	if machine.Host != nil {
-		host_ARM, err := (*machine.Host).ConvertToARM(resolved)
+		host_ARM, err := machine.Host.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -521,7 +521,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.Host = &host
 	}
 	if machine.HostGroup != nil {
-		hostGroup_ARM, err := (*machine.HostGroup).ConvertToARM(resolved)
+		hostGroup_ARM, err := machine.HostGroup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -533,7 +533,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.LicenseType = &licenseType
 	}
 	if machine.NetworkProfile != nil {
-		networkProfile_ARM, err := (*machine.NetworkProfile).ConvertToARM(resolved)
+		networkProfile_ARM, err := machine.NetworkProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -541,7 +541,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.NetworkProfile = &networkProfile
 	}
 	if machine.OsProfile != nil {
-		osProfile_ARM, err := (*machine.OsProfile).ConvertToARM(resolved)
+		osProfile_ARM, err := machine.OsProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -559,7 +559,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.Priority = &priority
 	}
 	if machine.ProximityPlacementGroup != nil {
-		proximityPlacementGroup_ARM, err := (*machine.ProximityPlacementGroup).ConvertToARM(resolved)
+		proximityPlacementGroup_ARM, err := machine.ProximityPlacementGroup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -567,7 +567,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.ProximityPlacementGroup = &proximityPlacementGroup
 	}
 	if machine.SecurityProfile != nil {
-		securityProfile_ARM, err := (*machine.SecurityProfile).ConvertToARM(resolved)
+		securityProfile_ARM, err := machine.SecurityProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -575,7 +575,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.SecurityProfile = &securityProfile
 	}
 	if machine.StorageProfile != nil {
-		storageProfile_ARM, err := (*machine.StorageProfile).ConvertToARM(resolved)
+		storageProfile_ARM, err := machine.StorageProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -583,7 +583,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.StorageProfile = &storageProfile
 	}
 	if machine.VirtualMachineScaleSet != nil {
-		virtualMachineScaleSet_ARM, err := (*machine.VirtualMachineScaleSet).ConvertToARM(resolved)
+		virtualMachineScaleSet_ARM, err := machine.VirtualMachineScaleSet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2990,7 +2990,7 @@ func (profile *DiagnosticsProfile) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "BootDiagnostics":
 	if profile.BootDiagnostics != nil {
-		bootDiagnostics_ARM, err := (*profile.BootDiagnostics).ConvertToARM(resolved)
+		bootDiagnostics_ARM, err := profile.BootDiagnostics.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3878,7 +3878,7 @@ func (profile *OSProfile) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "LinuxConfiguration":
 	if profile.LinuxConfiguration != nil {
-		linuxConfiguration_ARM, err := (*profile.LinuxConfiguration).ConvertToARM(resolved)
+		linuxConfiguration_ARM, err := profile.LinuxConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3903,7 +3903,7 @@ func (profile *OSProfile) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "WindowsConfiguration":
 	if profile.WindowsConfiguration != nil {
-		windowsConfiguration_ARM, err := (*profile.WindowsConfiguration).ConvertToARM(resolved)
+		windowsConfiguration_ARM, err := profile.WindowsConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4790,7 +4790,7 @@ func (profile *SecurityProfile) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "UefiSettings":
 	if profile.UefiSettings != nil {
-		uefiSettings_ARM, err := (*profile.UefiSettings).ConvertToARM(resolved)
+		uefiSettings_ARM, err := profile.UefiSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5099,7 +5099,7 @@ func (profile *StorageProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "ImageReference":
 	if profile.ImageReference != nil {
-		imageReference_ARM, err := (*profile.ImageReference).ConvertToARM(resolved)
+		imageReference_ARM, err := profile.ImageReference.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5109,7 +5109,7 @@ func (profile *StorageProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "OsDisk":
 	if profile.OsDisk != nil {
-		osDisk_ARM, err := (*profile.OsDisk).ConvertToARM(resolved)
+		osDisk_ARM, err := profile.OsDisk.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7281,7 +7281,7 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 
 	// Set property "Image":
 	if disk.Image != nil {
-		image_ARM, err := (*disk.Image).ConvertToARM(resolved)
+		image_ARM, err := disk.Image.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7297,7 +7297,7 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 
 	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
-		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
+		managedDisk_ARM, err := disk.ManagedDisk.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7319,7 +7319,7 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 
 	// Set property "Vhd":
 	if disk.Vhd != nil {
-		vhd_ARM, err := (*disk.Vhd).ConvertToARM(resolved)
+		vhd_ARM, err := disk.Vhd.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9031,7 +9031,7 @@ func (configuration *LinuxConfiguration) ConvertToARM(resolved genruntime.Conver
 
 	// Set property "PatchSettings":
 	if configuration.PatchSettings != nil {
-		patchSettings_ARM, err := (*configuration.PatchSettings).ConvertToARM(resolved)
+		patchSettings_ARM, err := configuration.PatchSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9047,7 +9047,7 @@ func (configuration *LinuxConfiguration) ConvertToARM(resolved genruntime.Conver
 
 	// Set property "Ssh":
 	if configuration.Ssh != nil {
-		ssh_ARM, err := (*configuration.Ssh).ConvertToARM(resolved)
+		ssh_ARM, err := configuration.Ssh.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9852,7 +9852,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 
 	// Set property "DiffDiskSettings":
 	if disk.DiffDiskSettings != nil {
-		diffDiskSettings_ARM, err := (*disk.DiffDiskSettings).ConvertToARM(resolved)
+		diffDiskSettings_ARM, err := disk.DiffDiskSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9868,7 +9868,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 
 	// Set property "EncryptionSettings":
 	if disk.EncryptionSettings != nil {
-		encryptionSettings_ARM, err := (*disk.EncryptionSettings).ConvertToARM(resolved)
+		encryptionSettings_ARM, err := disk.EncryptionSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9878,7 +9878,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 
 	// Set property "Image":
 	if disk.Image != nil {
-		image_ARM, err := (*disk.Image).ConvertToARM(resolved)
+		image_ARM, err := disk.Image.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9888,7 +9888,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 
 	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
-		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
+		managedDisk_ARM, err := disk.ManagedDisk.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9912,7 +9912,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 
 	// Set property "Vhd":
 	if disk.Vhd != nil {
-		vhd_ARM, err := (*disk.Vhd).ConvertToARM(resolved)
+		vhd_ARM, err := disk.Vhd.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10947,7 +10947,7 @@ func (group *VaultSecretGroup) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "SourceVault":
 	if group.SourceVault != nil {
-		sourceVault_ARM, err := (*group.SourceVault).ConvertToARM(resolved)
+		sourceVault_ARM, err := group.SourceVault.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11802,7 +11802,7 @@ func (configuration *WindowsConfiguration) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "PatchSettings":
 	if configuration.PatchSettings != nil {
-		patchSettings_ARM, err := (*configuration.PatchSettings).ConvertToARM(resolved)
+		patchSettings_ARM, err := configuration.PatchSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11824,7 +11824,7 @@ func (configuration *WindowsConfiguration) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "WinRM":
 	if configuration.WinRM != nil {
-		winRM_ARM, err := (*configuration.WinRM).ConvertToARM(resolved)
+		winRM_ARM, err := configuration.WinRM.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -13228,7 +13228,7 @@ func (settings *DiskEncryptionSettings) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "DiskEncryptionKey":
 	if settings.DiskEncryptionKey != nil {
-		diskEncryptionKey_ARM, err := (*settings.DiskEncryptionKey).ConvertToARM(resolved)
+		diskEncryptionKey_ARM, err := settings.DiskEncryptionKey.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -13244,7 +13244,7 @@ func (settings *DiskEncryptionSettings) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "KeyEncryptionKey":
 	if settings.KeyEncryptionKey != nil {
-		keyEncryptionKey_ARM, err := (*settings.KeyEncryptionKey).ConvertToARM(resolved)
+		keyEncryptionKey_ARM, err := settings.KeyEncryptionKey.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -14016,7 +14016,7 @@ func (parameters *ManagedDiskParameters) ConvertToARM(resolved genruntime.Conver
 
 	// Set property "DiskEncryptionSet":
 	if parameters.DiskEncryptionSet != nil {
-		diskEncryptionSet_ARM, err := (*parameters.DiskEncryptionSet).ConvertToARM(resolved)
+		diskEncryptionSet_ARM, err := parameters.DiskEncryptionSet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15742,7 +15742,7 @@ func (reference *KeyVaultKeyReference) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "SourceVault":
 	if reference.SourceVault != nil {
-		sourceVault_ARM, err := (*reference.SourceVault).ConvertToARM(resolved)
+		sourceVault_ARM, err := reference.SourceVault.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15963,7 +15963,7 @@ func (reference *KeyVaultSecretReference) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "SourceVault":
 	if reference.SourceVault != nil {
-		sourceVault_ARM, err := (*reference.SourceVault).ConvertToARM(resolved)
+		sourceVault_ARM, err := reference.SourceVault.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/compute/v1api20201201/virtual_machines_extension_types_gen.go
+++ b/v2/api/compute/v1api20201201/virtual_machines_extension_types_gen.go
@@ -347,7 +347,7 @@ func (extension *VirtualMachinesExtension_Spec) ConvertToARM(resolved genruntime
 		result.Properties.ForceUpdateTag = &forceUpdateTag
 	}
 	if extension.InstanceView != nil {
-		instanceView_ARM, err := (*extension.InstanceView).ConvertToARM(resolved)
+		instanceView_ARM, err := extension.InstanceView.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/compute/v1api20210701/image_types_gen.go
+++ b/v2/api/compute/v1api20210701/image_types_gen.go
@@ -303,7 +303,7 @@ func (image *Image_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 
 	// Set property "ExtendedLocation":
 	if image.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*image.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := image.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -333,7 +333,7 @@ func (image *Image_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.Properties.HyperVGeneration = &hyperVGeneration
 	}
 	if image.SourceVirtualMachine != nil {
-		sourceVirtualMachine_ARM, err := (*image.SourceVirtualMachine).ConvertToARM(resolved)
+		sourceVirtualMachine_ARM, err := image.SourceVirtualMachine.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -341,7 +341,7 @@ func (image *Image_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.Properties.SourceVirtualMachine = &sourceVirtualMachine
 	}
 	if image.StorageProfile != nil {
-		storageProfile_ARM, err := (*image.StorageProfile).ConvertToARM(resolved)
+		storageProfile_ARM, err := image.StorageProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1403,7 +1403,7 @@ func (profile *ImageStorageProfile) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "OsDisk":
 	if profile.OsDisk != nil {
-		osDisk_ARM, err := (*profile.OsDisk).ConvertToARM(resolved)
+		osDisk_ARM, err := profile.OsDisk.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1946,7 +1946,7 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 
 	// Set property "DiskEncryptionSet":
 	if disk.DiskEncryptionSet != nil {
-		diskEncryptionSet_ARM, err := (*disk.DiskEncryptionSet).ConvertToARM(resolved)
+		diskEncryptionSet_ARM, err := disk.DiskEncryptionSet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1968,7 +1968,7 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 
 	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
-		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
+		managedDisk_ARM, err := disk.ManagedDisk.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1978,7 +1978,7 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 
 	// Set property "Snapshot":
 	if disk.Snapshot != nil {
-		snapshot_ARM, err := (*disk.Snapshot).ConvertToARM(resolved)
+		snapshot_ARM, err := disk.Snapshot.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2563,7 +2563,7 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 
 	// Set property "DiskEncryptionSet":
 	if disk.DiskEncryptionSet != nil {
-		diskEncryptionSet_ARM, err := (*disk.DiskEncryptionSet).ConvertToARM(resolved)
+		diskEncryptionSet_ARM, err := disk.DiskEncryptionSet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2579,7 +2579,7 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 
 	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
-		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
+		managedDisk_ARM, err := disk.ManagedDisk.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2605,7 +2605,7 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 
 	// Set property "Snapshot":
 	if disk.Snapshot != nil {
-		snapshot_ARM, err := (*disk.Snapshot).ConvertToARM(resolved)
+		snapshot_ARM, err := disk.Snapshot.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/compute/v1api20220301/image_types_gen.go
+++ b/v2/api/compute/v1api20220301/image_types_gen.go
@@ -300,7 +300,7 @@ func (image *Image_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 
 	// Set property "ExtendedLocation":
 	if image.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*image.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := image.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -330,7 +330,7 @@ func (image *Image_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.Properties.HyperVGeneration = &hyperVGeneration
 	}
 	if image.SourceVirtualMachine != nil {
-		sourceVirtualMachine_ARM, err := (*image.SourceVirtualMachine).ConvertToARM(resolved)
+		sourceVirtualMachine_ARM, err := image.SourceVirtualMachine.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -338,7 +338,7 @@ func (image *Image_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.Properties.SourceVirtualMachine = &sourceVirtualMachine
 	}
 	if image.StorageProfile != nil {
-		storageProfile_ARM, err := (*image.StorageProfile).ConvertToARM(resolved)
+		storageProfile_ARM, err := image.StorageProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1475,7 +1475,7 @@ func (profile *ImageStorageProfile) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "OsDisk":
 	if profile.OsDisk != nil {
-		osDisk_ARM, err := (*profile.OsDisk).ConvertToARM(resolved)
+		osDisk_ARM, err := profile.OsDisk.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2078,7 +2078,7 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 
 	// Set property "DiskEncryptionSet":
 	if disk.DiskEncryptionSet != nil {
-		diskEncryptionSet_ARM, err := (*disk.DiskEncryptionSet).ConvertToARM(resolved)
+		diskEncryptionSet_ARM, err := disk.DiskEncryptionSet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2100,7 +2100,7 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 
 	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
-		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
+		managedDisk_ARM, err := disk.ManagedDisk.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2110,7 +2110,7 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 
 	// Set property "Snapshot":
 	if disk.Snapshot != nil {
-		snapshot_ARM, err := (*disk.Snapshot).ConvertToARM(resolved)
+		snapshot_ARM, err := disk.Snapshot.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2763,7 +2763,7 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 
 	// Set property "DiskEncryptionSet":
 	if disk.DiskEncryptionSet != nil {
-		diskEncryptionSet_ARM, err := (*disk.DiskEncryptionSet).ConvertToARM(resolved)
+		diskEncryptionSet_ARM, err := disk.DiskEncryptionSet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2779,7 +2779,7 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 
 	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
-		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
+		managedDisk_ARM, err := disk.ManagedDisk.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2805,7 +2805,7 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 
 	// Set property "Snapshot":
 	if disk.Snapshot != nil {
-		snapshot_ARM, err := (*disk.Snapshot).ConvertToARM(resolved)
+		snapshot_ARM, err := disk.Snapshot.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/compute/v1api20220301/virtual_machine_scale_set_types_gen.go
+++ b/v2/api/compute/v1api20220301/virtual_machine_scale_set_types_gen.go
@@ -352,7 +352,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 
 	// Set property "ExtendedLocation":
 	if scaleSet.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*scaleSet.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := scaleSet.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -362,7 +362,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Identity":
 	if scaleSet.Identity != nil {
-		identity_ARM, err := (*scaleSet.Identity).ConvertToARM(resolved)
+		identity_ARM, err := scaleSet.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -381,7 +381,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Plan":
 	if scaleSet.Plan != nil {
-		plan_ARM, err := (*scaleSet.Plan).ConvertToARM(resolved)
+		plan_ARM, err := scaleSet.Plan.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -407,7 +407,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties = &arm.VirtualMachineScaleSetProperties{}
 	}
 	if scaleSet.AdditionalCapabilities != nil {
-		additionalCapabilities_ARM, err := (*scaleSet.AdditionalCapabilities).ConvertToARM(resolved)
+		additionalCapabilities_ARM, err := scaleSet.AdditionalCapabilities.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -415,7 +415,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.AdditionalCapabilities = &additionalCapabilities
 	}
 	if scaleSet.AutomaticRepairsPolicy != nil {
-		automaticRepairsPolicy_ARM, err := (*scaleSet.AutomaticRepairsPolicy).ConvertToARM(resolved)
+		automaticRepairsPolicy_ARM, err := scaleSet.AutomaticRepairsPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -427,7 +427,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.DoNotRunExtensionsOnOverprovisionedVMs = &doNotRunExtensionsOnOverprovisionedVMs
 	}
 	if scaleSet.HostGroup != nil {
-		hostGroup_ARM, err := (*scaleSet.HostGroup).ConvertToARM(resolved)
+		hostGroup_ARM, err := scaleSet.HostGroup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -449,7 +449,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.PlatformFaultDomainCount = &platformFaultDomainCount
 	}
 	if scaleSet.ProximityPlacementGroup != nil {
-		proximityPlacementGroup_ARM, err := (*scaleSet.ProximityPlacementGroup).ConvertToARM(resolved)
+		proximityPlacementGroup_ARM, err := scaleSet.ProximityPlacementGroup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -457,7 +457,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.ProximityPlacementGroup = &proximityPlacementGroup
 	}
 	if scaleSet.ScaleInPolicy != nil {
-		scaleInPolicy_ARM, err := (*scaleSet.ScaleInPolicy).ConvertToARM(resolved)
+		scaleInPolicy_ARM, err := scaleSet.ScaleInPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -469,7 +469,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.SinglePlacementGroup = &singlePlacementGroup
 	}
 	if scaleSet.SpotRestorePolicy != nil {
-		spotRestorePolicy_ARM, err := (*scaleSet.SpotRestorePolicy).ConvertToARM(resolved)
+		spotRestorePolicy_ARM, err := scaleSet.SpotRestorePolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -477,7 +477,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.SpotRestorePolicy = &spotRestorePolicy
 	}
 	if scaleSet.UpgradePolicy != nil {
-		upgradePolicy_ARM, err := (*scaleSet.UpgradePolicy).ConvertToARM(resolved)
+		upgradePolicy_ARM, err := scaleSet.UpgradePolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -485,7 +485,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.UpgradePolicy = &upgradePolicy
 	}
 	if scaleSet.VirtualMachineProfile != nil {
-		virtualMachineProfile_ARM, err := (*scaleSet.VirtualMachineProfile).ConvertToARM(resolved)
+		virtualMachineProfile_ARM, err := scaleSet.VirtualMachineProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -499,7 +499,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Sku":
 	if scaleSet.Sku != nil {
-		sku_ARM, err := (*scaleSet.Sku).ConvertToARM(resolved)
+		sku_ARM, err := scaleSet.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3488,7 +3488,7 @@ func (policy *UpgradePolicy) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "AutomaticOSUpgradePolicy":
 	if policy.AutomaticOSUpgradePolicy != nil {
-		automaticOSUpgradePolicy_ARM, err := (*policy.AutomaticOSUpgradePolicy).ConvertToARM(resolved)
+		automaticOSUpgradePolicy_ARM, err := policy.AutomaticOSUpgradePolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3506,7 +3506,7 @@ func (policy *UpgradePolicy) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "RollingUpgradePolicy":
 	if policy.RollingUpgradePolicy != nil {
-		rollingUpgradePolicy_ARM, err := (*policy.RollingUpgradePolicy).ConvertToARM(resolved)
+		rollingUpgradePolicy_ARM, err := policy.RollingUpgradePolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4357,7 +4357,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 
 	// Set property "ApplicationProfile":
 	if profile.ApplicationProfile != nil {
-		applicationProfile_ARM, err := (*profile.ApplicationProfile).ConvertToARM(resolved)
+		applicationProfile_ARM, err := profile.ApplicationProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4367,7 +4367,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 
 	// Set property "BillingProfile":
 	if profile.BillingProfile != nil {
-		billingProfile_ARM, err := (*profile.BillingProfile).ConvertToARM(resolved)
+		billingProfile_ARM, err := profile.BillingProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4377,7 +4377,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 
 	// Set property "CapacityReservation":
 	if profile.CapacityReservation != nil {
-		capacityReservation_ARM, err := (*profile.CapacityReservation).ConvertToARM(resolved)
+		capacityReservation_ARM, err := profile.CapacityReservation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4387,7 +4387,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 
 	// Set property "DiagnosticsProfile":
 	if profile.DiagnosticsProfile != nil {
-		diagnosticsProfile_ARM, err := (*profile.DiagnosticsProfile).ConvertToARM(resolved)
+		diagnosticsProfile_ARM, err := profile.DiagnosticsProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4405,7 +4405,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 
 	// Set property "ExtensionProfile":
 	if profile.ExtensionProfile != nil {
-		extensionProfile_ARM, err := (*profile.ExtensionProfile).ConvertToARM(resolved)
+		extensionProfile_ARM, err := profile.ExtensionProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4415,7 +4415,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 
 	// Set property "HardwareProfile":
 	if profile.HardwareProfile != nil {
-		hardwareProfile_ARM, err := (*profile.HardwareProfile).ConvertToARM(resolved)
+		hardwareProfile_ARM, err := profile.HardwareProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4431,7 +4431,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 
 	// Set property "NetworkProfile":
 	if profile.NetworkProfile != nil {
-		networkProfile_ARM, err := (*profile.NetworkProfile).ConvertToARM(resolved)
+		networkProfile_ARM, err := profile.NetworkProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4441,7 +4441,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 
 	// Set property "OsProfile":
 	if profile.OsProfile != nil {
-		osProfile_ARM, err := (*profile.OsProfile).ConvertToARM(resolved)
+		osProfile_ARM, err := profile.OsProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4459,7 +4459,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 
 	// Set property "ScheduledEventsProfile":
 	if profile.ScheduledEventsProfile != nil {
-		scheduledEventsProfile_ARM, err := (*profile.ScheduledEventsProfile).ConvertToARM(resolved)
+		scheduledEventsProfile_ARM, err := profile.ScheduledEventsProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4469,7 +4469,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 
 	// Set property "SecurityProfile":
 	if profile.SecurityProfile != nil {
-		securityProfile_ARM, err := (*profile.SecurityProfile).ConvertToARM(resolved)
+		securityProfile_ARM, err := profile.SecurityProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4479,7 +4479,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 
 	// Set property "StorageProfile":
 	if profile.StorageProfile != nil {
-		storageProfile_ARM, err := (*profile.StorageProfile).ConvertToARM(resolved)
+		storageProfile_ARM, err := profile.StorageProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6827,7 +6827,7 @@ func (profile *VirtualMachineScaleSetHardwareProfile) ConvertToARM(resolved genr
 
 	// Set property "VmSizeProperties":
 	if profile.VmSizeProperties != nil {
-		vmSizeProperties_ARM, err := (*profile.VmSizeProperties).ConvertToARM(resolved)
+		vmSizeProperties_ARM, err := profile.VmSizeProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7148,7 +7148,7 @@ func (profile *VirtualMachineScaleSetNetworkProfile) ConvertToARM(resolved genru
 
 	// Set property "HealthProbe":
 	if profile.HealthProbe != nil {
-		healthProbe_ARM, err := (*profile.HealthProbe).ConvertToARM(resolved)
+		healthProbe_ARM, err := profile.HealthProbe.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7631,7 +7631,7 @@ func (profile *VirtualMachineScaleSetOSProfile) ConvertToARM(resolved genruntime
 
 	// Set property "LinuxConfiguration":
 	if profile.LinuxConfiguration != nil {
-		linuxConfiguration_ARM, err := (*profile.LinuxConfiguration).ConvertToARM(resolved)
+		linuxConfiguration_ARM, err := profile.LinuxConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7650,7 +7650,7 @@ func (profile *VirtualMachineScaleSetOSProfile) ConvertToARM(resolved genruntime
 
 	// Set property "WindowsConfiguration":
 	if profile.WindowsConfiguration != nil {
-		windowsConfiguration_ARM, err := (*profile.WindowsConfiguration).ConvertToARM(resolved)
+		windowsConfiguration_ARM, err := profile.WindowsConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8251,7 +8251,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) ConvertToARM(resolved genru
 
 	// Set property "ImageReference":
 	if profile.ImageReference != nil {
-		imageReference_ARM, err := (*profile.ImageReference).ConvertToARM(resolved)
+		imageReference_ARM, err := profile.ImageReference.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8261,7 +8261,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) ConvertToARM(resolved genru
 
 	// Set property "OsDisk":
 	if profile.OsDisk != nil {
-		osDisk_ARM, err := (*profile.OsDisk).ConvertToARM(resolved)
+		osDisk_ARM, err := profile.OsDisk.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8917,7 +8917,7 @@ func (disk *VirtualMachineScaleSetDataDisk) ConvertToARM(resolved genruntime.Con
 
 	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
-		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
+		managedDisk_ARM, err := disk.ManagedDisk.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9614,7 +9614,7 @@ func (extension *VirtualMachineScaleSetExtension) ConvertToARM(resolved genrunti
 		result.Properties.ProtectedSettings = temp
 	}
 	if extension.ProtectedSettingsFromKeyVault != nil {
-		protectedSettingsFromKeyVault_ARM, err := (*extension.ProtectedSettingsFromKeyVault).ConvertToARM(resolved)
+		protectedSettingsFromKeyVault_ARM, err := extension.ProtectedSettingsFromKeyVault.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10461,7 +10461,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) ConvertToARM(re
 		result.Properties.DeleteOption = &deleteOption
 	}
 	if configuration.DnsSettings != nil {
-		dnsSettings_ARM, err := (*configuration.DnsSettings).ConvertToARM(resolved)
+		dnsSettings_ARM, err := configuration.DnsSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10488,7 +10488,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) ConvertToARM(re
 		result.Properties.IpConfigurations = append(result.Properties.IpConfigurations, *item_ARM.(*arm.VirtualMachineScaleSetIPConfiguration))
 	}
 	if configuration.NetworkSecurityGroup != nil {
-		networkSecurityGroup_ARM, err := (*configuration.NetworkSecurityGroup).ConvertToARM(resolved)
+		networkSecurityGroup_ARM, err := configuration.NetworkSecurityGroup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11387,7 +11387,7 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "DiffDiskSettings":
 	if disk.DiffDiskSettings != nil {
-		diffDiskSettings_ARM, err := (*disk.DiffDiskSettings).ConvertToARM(resolved)
+		diffDiskSettings_ARM, err := disk.DiffDiskSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11403,7 +11403,7 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "Image":
 	if disk.Image != nil {
-		image_ARM, err := (*disk.Image).ConvertToARM(resolved)
+		image_ARM, err := disk.Image.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11413,7 +11413,7 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
-		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
+		managedDisk_ARM, err := disk.ManagedDisk.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12317,7 +12317,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) ConvertToARM(resolve
 		result.Properties.PrivateIPAddressVersion = &privateIPAddressVersion
 	}
 	if configuration.PublicIPAddressConfiguration != nil {
-		publicIPAddressConfiguration_ARM, err := (*configuration.PublicIPAddressConfiguration).ConvertToARM(resolved)
+		publicIPAddressConfiguration_ARM, err := configuration.PublicIPAddressConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12325,7 +12325,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) ConvertToARM(resolve
 		result.Properties.PublicIPAddressConfiguration = &publicIPAddressConfiguration
 	}
 	if configuration.Subnet != nil {
-		subnet_ARM, err := (*configuration.Subnet).ConvertToARM(resolved)
+		subnet_ARM, err := configuration.Subnet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -13313,7 +13313,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters) ConvertToARM(reso
 
 	// Set property "DiskEncryptionSet":
 	if parameters.DiskEncryptionSet != nil {
-		diskEncryptionSet_ARM, err := (*parameters.DiskEncryptionSet).ConvertToARM(resolved)
+		diskEncryptionSet_ARM, err := parameters.DiskEncryptionSet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -13323,7 +13323,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters) ConvertToARM(reso
 
 	// Set property "SecurityProfile":
 	if parameters.SecurityProfile != nil {
-		securityProfile_ARM, err := (*parameters.SecurityProfile).ConvertToARM(resolved)
+		securityProfile_ARM, err := parameters.SecurityProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -13944,7 +13944,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Convert
 		result.Properties.DeleteOption = &deleteOption
 	}
 	if configuration.DnsSettings != nil {
-		dnsSettings_ARM, err := (*configuration.DnsSettings).ConvertToARM(resolved)
+		dnsSettings_ARM, err := configuration.DnsSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -13969,7 +13969,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Convert
 		result.Properties.PublicIPAddressVersion = &publicIPAddressVersion
 	}
 	if configuration.PublicIPPrefix != nil {
-		publicIPPrefix_ARM, err := (*configuration.PublicIPPrefix).ConvertToARM(resolved)
+		publicIPPrefix_ARM, err := configuration.PublicIPPrefix.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -13979,7 +13979,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Convert
 
 	// Set property "Sku":
 	if configuration.Sku != nil {
-		sku_ARM, err := (*configuration.Sku).ConvertToARM(resolved)
+		sku_ARM, err := configuration.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/compute/v1api20220301/virtual_machine_scale_sets_extension_types_gen.go
+++ b/v2/api/compute/v1api20220301/virtual_machine_scale_sets_extension_types_gen.go
@@ -351,7 +351,7 @@ func (extension *VirtualMachineScaleSetsExtension_Spec) ConvertToARM(resolved ge
 		result.Properties.ProtectedSettings = temp
 	}
 	if extension.ProtectedSettingsFromKeyVault != nil {
-		protectedSettingsFromKeyVault_ARM, err := (*extension.ProtectedSettingsFromKeyVault).ConvertToARM(resolved)
+		protectedSettingsFromKeyVault_ARM, err := extension.ProtectedSettingsFromKeyVault.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1313,7 +1313,7 @@ func (reference *KeyVaultSecretReference) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "SourceVault":
 	if reference.SourceVault != nil {
-		sourceVault_ARM, err := (*reference.SourceVault).ConvertToARM(resolved)
+		sourceVault_ARM, err := reference.SourceVault.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/compute/v1api20220301/virtual_machine_types_gen.go
+++ b/v2/api/compute/v1api20220301/virtual_machine_types_gen.go
@@ -410,7 +410,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "ExtendedLocation":
 	if machine.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*machine.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := machine.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -420,7 +420,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Identity":
 	if machine.Identity != nil {
-		identity_ARM, err := (*machine.Identity).ConvertToARM(resolved)
+		identity_ARM, err := machine.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -439,7 +439,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Plan":
 	if machine.Plan != nil {
-		plan_ARM, err := (*machine.Plan).ConvertToARM(resolved)
+		plan_ARM, err := machine.Plan.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -473,7 +473,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties = &arm.VirtualMachineProperties{}
 	}
 	if machine.AdditionalCapabilities != nil {
-		additionalCapabilities_ARM, err := (*machine.AdditionalCapabilities).ConvertToARM(resolved)
+		additionalCapabilities_ARM, err := machine.AdditionalCapabilities.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -481,7 +481,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AdditionalCapabilities = &additionalCapabilities
 	}
 	if machine.ApplicationProfile != nil {
-		applicationProfile_ARM, err := (*machine.ApplicationProfile).ConvertToARM(resolved)
+		applicationProfile_ARM, err := machine.ApplicationProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -489,7 +489,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.ApplicationProfile = &applicationProfile
 	}
 	if machine.AvailabilitySet != nil {
-		availabilitySet_ARM, err := (*machine.AvailabilitySet).ConvertToARM(resolved)
+		availabilitySet_ARM, err := machine.AvailabilitySet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -497,7 +497,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AvailabilitySet = &availabilitySet
 	}
 	if machine.BillingProfile != nil {
-		billingProfile_ARM, err := (*machine.BillingProfile).ConvertToARM(resolved)
+		billingProfile_ARM, err := machine.BillingProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -505,7 +505,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.BillingProfile = &billingProfile
 	}
 	if machine.CapacityReservation != nil {
-		capacityReservation_ARM, err := (*machine.CapacityReservation).ConvertToARM(resolved)
+		capacityReservation_ARM, err := machine.CapacityReservation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -513,7 +513,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.CapacityReservation = &capacityReservation
 	}
 	if machine.DiagnosticsProfile != nil {
-		diagnosticsProfile_ARM, err := (*machine.DiagnosticsProfile).ConvertToARM(resolved)
+		diagnosticsProfile_ARM, err := machine.DiagnosticsProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -531,7 +531,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.ExtensionsTimeBudget = &extensionsTimeBudget
 	}
 	if machine.HardwareProfile != nil {
-		hardwareProfile_ARM, err := (*machine.HardwareProfile).ConvertToARM(resolved)
+		hardwareProfile_ARM, err := machine.HardwareProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -539,7 +539,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.HardwareProfile = &hardwareProfile
 	}
 	if machine.Host != nil {
-		host_ARM, err := (*machine.Host).ConvertToARM(resolved)
+		host_ARM, err := machine.Host.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -547,7 +547,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.Host = &host
 	}
 	if machine.HostGroup != nil {
-		hostGroup_ARM, err := (*machine.HostGroup).ConvertToARM(resolved)
+		hostGroup_ARM, err := machine.HostGroup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -559,7 +559,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.LicenseType = &licenseType
 	}
 	if machine.NetworkProfile != nil {
-		networkProfile_ARM, err := (*machine.NetworkProfile).ConvertToARM(resolved)
+		networkProfile_ARM, err := machine.NetworkProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -567,7 +567,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.NetworkProfile = &networkProfile
 	}
 	if machine.OsProfile != nil {
-		osProfile_ARM, err := (*machine.OsProfile).ConvertToARM(resolved)
+		osProfile_ARM, err := machine.OsProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -585,7 +585,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.Priority = &priority
 	}
 	if machine.ProximityPlacementGroup != nil {
-		proximityPlacementGroup_ARM, err := (*machine.ProximityPlacementGroup).ConvertToARM(resolved)
+		proximityPlacementGroup_ARM, err := machine.ProximityPlacementGroup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -593,7 +593,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.ProximityPlacementGroup = &proximityPlacementGroup
 	}
 	if machine.ScheduledEventsProfile != nil {
-		scheduledEventsProfile_ARM, err := (*machine.ScheduledEventsProfile).ConvertToARM(resolved)
+		scheduledEventsProfile_ARM, err := machine.ScheduledEventsProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -601,7 +601,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.ScheduledEventsProfile = &scheduledEventsProfile
 	}
 	if machine.SecurityProfile != nil {
-		securityProfile_ARM, err := (*machine.SecurityProfile).ConvertToARM(resolved)
+		securityProfile_ARM, err := machine.SecurityProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -609,7 +609,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.SecurityProfile = &securityProfile
 	}
 	if machine.StorageProfile != nil {
-		storageProfile_ARM, err := (*machine.StorageProfile).ConvertToARM(resolved)
+		storageProfile_ARM, err := machine.StorageProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -621,7 +621,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.UserData = &userData
 	}
 	if machine.VirtualMachineScaleSet != nil {
-		virtualMachineScaleSet_ARM, err := (*machine.VirtualMachineScaleSet).ConvertToARM(resolved)
+		virtualMachineScaleSet_ARM, err := machine.VirtualMachineScaleSet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3912,7 +3912,7 @@ func (profile *CapacityReservationProfile) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "CapacityReservationGroup":
 	if profile.CapacityReservationGroup != nil {
-		capacityReservationGroup_ARM, err := (*profile.CapacityReservationGroup).ConvertToARM(resolved)
+		capacityReservationGroup_ARM, err := profile.CapacityReservationGroup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4122,7 +4122,7 @@ func (profile *DiagnosticsProfile) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "BootDiagnostics":
 	if profile.BootDiagnostics != nil {
-		bootDiagnostics_ARM, err := (*profile.BootDiagnostics).ConvertToARM(resolved)
+		bootDiagnostics_ARM, err := profile.BootDiagnostics.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4380,7 +4380,7 @@ func (profile *HardwareProfile) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "VmSizeProperties":
 	if profile.VmSizeProperties != nil {
-		vmSizeProperties_ARM, err := (*profile.VmSizeProperties).ConvertToARM(resolved)
+		vmSizeProperties_ARM, err := profile.VmSizeProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5172,7 +5172,7 @@ func (profile *OSProfile) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "LinuxConfiguration":
 	if profile.LinuxConfiguration != nil {
-		linuxConfiguration_ARM, err := (*profile.LinuxConfiguration).ConvertToARM(resolved)
+		linuxConfiguration_ARM, err := profile.LinuxConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5197,7 +5197,7 @@ func (profile *OSProfile) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "WindowsConfiguration":
 	if profile.WindowsConfiguration != nil {
-		windowsConfiguration_ARM, err := (*profile.WindowsConfiguration).ConvertToARM(resolved)
+		windowsConfiguration_ARM, err := profile.WindowsConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6146,7 +6146,7 @@ func (profile *ScheduledEventsProfile) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "TerminateNotificationProfile":
 	if profile.TerminateNotificationProfile != nil {
-		terminateNotificationProfile_ARM, err := (*profile.TerminateNotificationProfile).ConvertToARM(resolved)
+		terminateNotificationProfile_ARM, err := profile.TerminateNotificationProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6373,7 +6373,7 @@ func (profile *SecurityProfile) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "UefiSettings":
 	if profile.UefiSettings != nil {
-		uefiSettings_ARM, err := (*profile.UefiSettings).ConvertToARM(resolved)
+		uefiSettings_ARM, err := profile.UefiSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6718,7 +6718,7 @@ func (profile *StorageProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "ImageReference":
 	if profile.ImageReference != nil {
-		imageReference_ARM, err := (*profile.ImageReference).ConvertToARM(resolved)
+		imageReference_ARM, err := profile.ImageReference.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6728,7 +6728,7 @@ func (profile *StorageProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "OsDisk":
 	if profile.OsDisk != nil {
-		osDisk_ARM, err := (*profile.OsDisk).ConvertToARM(resolved)
+		osDisk_ARM, err := profile.OsDisk.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8939,7 +8939,7 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 
 	// Set property "Image":
 	if disk.Image != nil {
-		image_ARM, err := (*disk.Image).ConvertToARM(resolved)
+		image_ARM, err := disk.Image.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8955,7 +8955,7 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 
 	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
-		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
+		managedDisk_ARM, err := disk.ManagedDisk.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8977,7 +8977,7 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 
 	// Set property "Vhd":
 	if disk.Vhd != nil {
-		vhd_ARM, err := (*disk.Vhd).ConvertToARM(resolved)
+		vhd_ARM, err := disk.Vhd.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10940,7 +10940,7 @@ func (configuration *LinuxConfiguration) ConvertToARM(resolved genruntime.Conver
 
 	// Set property "PatchSettings":
 	if configuration.PatchSettings != nil {
-		patchSettings_ARM, err := (*configuration.PatchSettings).ConvertToARM(resolved)
+		patchSettings_ARM, err := configuration.PatchSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10956,7 +10956,7 @@ func (configuration *LinuxConfiguration) ConvertToARM(resolved genruntime.Conver
 
 	// Set property "Ssh":
 	if configuration.Ssh != nil {
-		ssh_ARM, err := (*configuration.Ssh).ConvertToARM(resolved)
+		ssh_ARM, err := configuration.Ssh.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11940,7 +11940,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 
 	// Set property "DiffDiskSettings":
 	if disk.DiffDiskSettings != nil {
-		diffDiskSettings_ARM, err := (*disk.DiffDiskSettings).ConvertToARM(resolved)
+		diffDiskSettings_ARM, err := disk.DiffDiskSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11956,7 +11956,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 
 	// Set property "EncryptionSettings":
 	if disk.EncryptionSettings != nil {
-		encryptionSettings_ARM, err := (*disk.EncryptionSettings).ConvertToARM(resolved)
+		encryptionSettings_ARM, err := disk.EncryptionSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11966,7 +11966,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 
 	// Set property "Image":
 	if disk.Image != nil {
-		image_ARM, err := (*disk.Image).ConvertToARM(resolved)
+		image_ARM, err := disk.Image.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11976,7 +11976,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 
 	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
-		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
+		managedDisk_ARM, err := disk.ManagedDisk.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12000,7 +12000,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 
 	// Set property "Vhd":
 	if disk.Vhd != nil {
-		vhd_ARM, err := (*disk.Vhd).ConvertToARM(resolved)
+		vhd_ARM, err := disk.Vhd.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -13446,7 +13446,7 @@ func (group *VaultSecretGroup) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "SourceVault":
 	if group.SourceVault != nil {
-		sourceVault_ARM, err := (*group.SourceVault).ConvertToARM(resolved)
+		sourceVault_ARM, err := group.SourceVault.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -14180,7 +14180,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration) ConvertToARM(r
 		result.Properties.DeleteOption = &deleteOption
 	}
 	if configuration.DnsSettings != nil {
-		dnsSettings_ARM, err := (*configuration.DnsSettings).ConvertToARM(resolved)
+		dnsSettings_ARM, err := configuration.DnsSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -14188,7 +14188,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration) ConvertToARM(r
 		result.Properties.DnsSettings = &dnsSettings
 	}
 	if configuration.DscpConfiguration != nil {
-		dscpConfiguration_ARM, err := (*configuration.DscpConfiguration).ConvertToARM(resolved)
+		dscpConfiguration_ARM, err := configuration.DscpConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -14215,7 +14215,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration) ConvertToARM(r
 		result.Properties.IpConfigurations = append(result.Properties.IpConfigurations, *item_ARM.(*arm.VirtualMachineNetworkInterfaceIPConfiguration))
 	}
 	if configuration.NetworkSecurityGroup != nil {
-		networkSecurityGroup_ARM, err := (*configuration.NetworkSecurityGroup).ConvertToARM(resolved)
+		networkSecurityGroup_ARM, err := configuration.NetworkSecurityGroup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15883,7 +15883,7 @@ func (configuration *WindowsConfiguration) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "PatchSettings":
 	if configuration.PatchSettings != nil {
-		patchSettings_ARM, err := (*configuration.PatchSettings).ConvertToARM(resolved)
+		patchSettings_ARM, err := configuration.PatchSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15905,7 +15905,7 @@ func (configuration *WindowsConfiguration) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "WinRM":
 	if configuration.WinRM != nil {
-		winRM_ARM, err := (*configuration.WinRM).ConvertToARM(resolved)
+		winRM_ARM, err := configuration.WinRM.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -17471,7 +17471,7 @@ func (settings *DiskEncryptionSettings) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "DiskEncryptionKey":
 	if settings.DiskEncryptionKey != nil {
-		diskEncryptionKey_ARM, err := (*settings.DiskEncryptionKey).ConvertToARM(resolved)
+		diskEncryptionKey_ARM, err := settings.DiskEncryptionKey.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -17487,7 +17487,7 @@ func (settings *DiskEncryptionSettings) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "KeyEncryptionKey":
 	if settings.KeyEncryptionKey != nil {
-		keyEncryptionKey_ARM, err := (*settings.KeyEncryptionKey).ConvertToARM(resolved)
+		keyEncryptionKey_ARM, err := settings.KeyEncryptionKey.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -18127,7 +18127,7 @@ func (settings *LinuxPatchSettings) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "AutomaticByPlatformSettings":
 	if settings.AutomaticByPlatformSettings != nil {
-		automaticByPlatformSettings_ARM, err := (*settings.AutomaticByPlatformSettings).ConvertToARM(resolved)
+		automaticByPlatformSettings_ARM, err := settings.AutomaticByPlatformSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -18495,7 +18495,7 @@ func (parameters *ManagedDiskParameters) ConvertToARM(resolved genruntime.Conver
 
 	// Set property "DiskEncryptionSet":
 	if parameters.DiskEncryptionSet != nil {
-		diskEncryptionSet_ARM, err := (*parameters.DiskEncryptionSet).ConvertToARM(resolved)
+		diskEncryptionSet_ARM, err := parameters.DiskEncryptionSet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -18515,7 +18515,7 @@ func (parameters *ManagedDiskParameters) ConvertToARM(resolved genruntime.Conver
 
 	// Set property "SecurityProfile":
 	if parameters.SecurityProfile != nil {
-		securityProfile_ARM, err := (*parameters.SecurityProfile).ConvertToARM(resolved)
+		securityProfile_ARM, err := parameters.SecurityProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -18998,7 +18998,7 @@ func (settings *PatchSettings) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "AutomaticByPlatformSettings":
 	if settings.AutomaticByPlatformSettings != nil {
-		automaticByPlatformSettings_ARM, err := (*settings.AutomaticByPlatformSettings).ConvertToARM(resolved)
+		automaticByPlatformSettings_ARM, err := settings.AutomaticByPlatformSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -20341,7 +20341,7 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration) ConvertToARM
 		result.Properties.PrivateIPAddressVersion = &privateIPAddressVersion
 	}
 	if configuration.PublicIPAddressConfiguration != nil {
-		publicIPAddressConfiguration_ARM, err := (*configuration.PublicIPAddressConfiguration).ConvertToARM(resolved)
+		publicIPAddressConfiguration_ARM, err := configuration.PublicIPAddressConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -20349,7 +20349,7 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration) ConvertToARM
 		result.Properties.PublicIPAddressConfiguration = &publicIPAddressConfiguration
 	}
 	if configuration.Subnet != nil {
-		subnet_ARM, err := (*configuration.Subnet).ConvertToARM(resolved)
+		subnet_ARM, err := configuration.Subnet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -21726,7 +21726,7 @@ func (reference *KeyVaultKeyReference) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "SourceVault":
 	if reference.SourceVault != nil {
-		sourceVault_ARM, err := (*reference.SourceVault).ConvertToARM(resolved)
+		sourceVault_ARM, err := reference.SourceVault.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -22529,7 +22529,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration) ConvertToARM(re
 		result.Properties.DeleteOption = &deleteOption
 	}
 	if configuration.DnsSettings != nil {
-		dnsSettings_ARM, err := (*configuration.DnsSettings).ConvertToARM(resolved)
+		dnsSettings_ARM, err := configuration.DnsSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -22560,7 +22560,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration) ConvertToARM(re
 		result.Properties.PublicIPAllocationMethod = &publicIPAllocationMethod
 	}
 	if configuration.PublicIPPrefix != nil {
-		publicIPPrefix_ARM, err := (*configuration.PublicIPPrefix).ConvertToARM(resolved)
+		publicIPPrefix_ARM, err := configuration.PublicIPPrefix.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -22570,7 +22570,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration) ConvertToARM(re
 
 	// Set property "Sku":
 	if configuration.Sku != nil {
-		sku_ARM, err := (*configuration.Sku).ConvertToARM(resolved)
+		sku_ARM, err := configuration.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -23349,7 +23349,7 @@ func (profile *VMDiskSecurityProfile) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "DiskEncryptionSet":
 	if profile.DiskEncryptionSet != nil {
-		diskEncryptionSet_ARM, err := (*profile.DiskEncryptionSet).ConvertToARM(resolved)
+		diskEncryptionSet_ARM, err := profile.DiskEncryptionSet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/compute/v1api20220301/virtual_machines_extension_types_gen.go
+++ b/v2/api/compute/v1api20220301/virtual_machines_extension_types_gen.go
@@ -353,7 +353,7 @@ func (extension *VirtualMachinesExtension_Spec) ConvertToARM(resolved genruntime
 		result.Properties.ForceUpdateTag = &forceUpdateTag
 	}
 	if extension.InstanceView != nil {
-		instanceView_ARM, err := (*extension.InstanceView).ConvertToARM(resolved)
+		instanceView_ARM, err := extension.InstanceView.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -370,7 +370,7 @@ func (extension *VirtualMachinesExtension_Spec) ConvertToARM(resolved genruntime
 		result.Properties.ProtectedSettings = temp
 	}
 	if extension.ProtectedSettingsFromKeyVault != nil {
-		protectedSettingsFromKeyVault_ARM, err := (*extension.ProtectedSettingsFromKeyVault).ConvertToARM(resolved)
+		protectedSettingsFromKeyVault_ARM, err := extension.ProtectedSettingsFromKeyVault.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/compute/v1api20220702/disk_encryption_set_types_gen.go
+++ b/v2/api/compute/v1api20220702/disk_encryption_set_types_gen.go
@@ -310,7 +310,7 @@ func (encryptionSet *DiskEncryptionSet_Spec) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Identity":
 	if encryptionSet.Identity != nil {
-		identity_ARM, err := (*encryptionSet.Identity).ConvertToARM(resolved)
+		identity_ARM, err := encryptionSet.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -336,7 +336,7 @@ func (encryptionSet *DiskEncryptionSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties = &arm.EncryptionSetProperties{}
 	}
 	if encryptionSet.ActiveKey != nil {
-		activeKey_ARM, err := (*encryptionSet.ActiveKey).ConvertToARM(resolved)
+		activeKey_ARM, err := encryptionSet.ActiveKey.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1852,7 +1852,7 @@ func (encryptionSet *KeyForDiskEncryptionSet) ConvertToARM(resolved genruntime.C
 
 	// Set property "SourceVault":
 	if encryptionSet.SourceVault != nil {
-		sourceVault_ARM, err := (*encryptionSet.SourceVault).ConvertToARM(resolved)
+		sourceVault_ARM, err := encryptionSet.SourceVault.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/compute/v1api20240302/disk_access_types_gen.go
+++ b/v2/api/compute/v1api20240302/disk_access_types_gen.go
@@ -283,7 +283,7 @@ func (access *DiskAccess_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "ExtendedLocation":
 	if access.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*access.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := access.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/compute/v1api20240302/disk_encryption_set_types_gen.go
+++ b/v2/api/compute/v1api20240302/disk_encryption_set_types_gen.go
@@ -302,7 +302,7 @@ func (encryptionSet *DiskEncryptionSet_Spec) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Identity":
 	if encryptionSet.Identity != nil {
-		identity_ARM, err := (*encryptionSet.Identity).ConvertToARM(resolved)
+		identity_ARM, err := encryptionSet.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -328,7 +328,7 @@ func (encryptionSet *DiskEncryptionSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties = &arm.EncryptionSetProperties{}
 	}
 	if encryptionSet.ActiveKey != nil {
-		activeKey_ARM, err := (*encryptionSet.ActiveKey).ConvertToARM(resolved)
+		activeKey_ARM, err := encryptionSet.ActiveKey.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1927,7 +1927,7 @@ func (encryptionSet *KeyForDiskEncryptionSet) ConvertToARM(resolved genruntime.C
 
 	// Set property "SourceVault":
 	if encryptionSet.SourceVault != nil {
-		sourceVault_ARM, err := (*encryptionSet.SourceVault).ConvertToARM(resolved)
+		sourceVault_ARM, err := encryptionSet.SourceVault.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/compute/v1api20240302/disk_types_gen.go
+++ b/v2/api/compute/v1api20240302/disk_types_gen.go
@@ -379,7 +379,7 @@ func (disk *Disk_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 
 	// Set property "ExtendedLocation":
 	if disk.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*disk.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := disk.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -431,7 +431,7 @@ func (disk *Disk_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 		result.Properties.CompletionPercent = &completionPercent
 	}
 	if disk.CreationData != nil {
-		creationData_ARM, err := (*disk.CreationData).ConvertToARM(resolved)
+		creationData_ARM, err := disk.CreationData.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -473,7 +473,7 @@ func (disk *Disk_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 		result.Properties.DiskSizeGB = &diskSizeGB
 	}
 	if disk.Encryption != nil {
-		encryption_ARM, err := (*disk.Encryption).ConvertToARM(resolved)
+		encryption_ARM, err := disk.Encryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -481,7 +481,7 @@ func (disk *Disk_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 		result.Properties.Encryption = &encryption
 	}
 	if disk.EncryptionSettingsCollection != nil {
-		encryptionSettingsCollection_ARM, err := (*disk.EncryptionSettingsCollection).ConvertToARM(resolved)
+		encryptionSettingsCollection_ARM, err := disk.EncryptionSettingsCollection.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -521,7 +521,7 @@ func (disk *Disk_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 		result.Properties.PublicNetworkAccess = &publicNetworkAccess
 	}
 	if disk.PurchasePlan != nil {
-		purchasePlan_ARM, err := (*disk.PurchasePlan).ConvertToARM(resolved)
+		purchasePlan_ARM, err := disk.PurchasePlan.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -529,7 +529,7 @@ func (disk *Disk_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 		result.Properties.PurchasePlan = &purchasePlan
 	}
 	if disk.SecurityProfile != nil {
-		securityProfile_ARM, err := (*disk.SecurityProfile).ConvertToARM(resolved)
+		securityProfile_ARM, err := disk.SecurityProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -537,7 +537,7 @@ func (disk *Disk_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 		result.Properties.SecurityProfile = &securityProfile
 	}
 	if disk.SupportedCapabilities != nil {
-		supportedCapabilities_ARM, err := (*disk.SupportedCapabilities).ConvertToARM(resolved)
+		supportedCapabilities_ARM, err := disk.SupportedCapabilities.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -555,7 +555,7 @@ func (disk *Disk_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 
 	// Set property "Sku":
 	if disk.Sku != nil {
-		sku_ARM, err := (*disk.Sku).ConvertToARM(resolved)
+		sku_ARM, err := disk.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2930,7 +2930,7 @@ func (data *CreationData) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "GalleryImageReference":
 	if data.GalleryImageReference != nil {
-		galleryImageReference_ARM, err := (*data.GalleryImageReference).ConvertToARM(resolved)
+		galleryImageReference_ARM, err := data.GalleryImageReference.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2940,7 +2940,7 @@ func (data *CreationData) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "ImageReference":
 	if data.ImageReference != nil {
-		imageReference_ARM, err := (*data.ImageReference).ConvertToARM(resolved)
+		imageReference_ARM, err := data.ImageReference.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6039,7 +6039,7 @@ func (element *EncryptionSettingsElement) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "DiskEncryptionKey":
 	if element.DiskEncryptionKey != nil {
-		diskEncryptionKey_ARM, err := (*element.DiskEncryptionKey).ConvertToARM(resolved)
+		diskEncryptionKey_ARM, err := element.DiskEncryptionKey.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6049,7 +6049,7 @@ func (element *EncryptionSettingsElement) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "KeyEncryptionKey":
 	if element.KeyEncryptionKey != nil {
-		keyEncryptionKey_ARM, err := (*element.KeyEncryptionKey).ConvertToARM(resolved)
+		keyEncryptionKey_ARM, err := element.KeyEncryptionKey.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6707,7 +6707,7 @@ func (reference *KeyVaultAndKeyReference) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "SourceVault":
 	if reference.SourceVault != nil {
-		sourceVault_ARM, err := (*reference.SourceVault).ConvertToARM(resolved)
+		sourceVault_ARM, err := reference.SourceVault.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6950,7 +6950,7 @@ func (reference *KeyVaultAndSecretReference) ConvertToARM(resolved genruntime.Co
 
 	// Set property "SourceVault":
 	if reference.SourceVault != nil {
-		sourceVault_ARM, err := (*reference.SourceVault).ConvertToARM(resolved)
+		sourceVault_ARM, err := reference.SourceVault.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/compute/v1api20240302/snapshot_types_gen.go
+++ b/v2/api/compute/v1api20240302/snapshot_types_gen.go
@@ -348,7 +348,7 @@ func (snapshot *Snapshot_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "ExtendedLocation":
 	if snapshot.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*snapshot.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := snapshot.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -391,7 +391,7 @@ func (snapshot *Snapshot_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.CompletionPercent = &completionPercent
 	}
 	if snapshot.CopyCompletionError != nil {
-		copyCompletionError_ARM, err := (*snapshot.CopyCompletionError).ConvertToARM(resolved)
+		copyCompletionError_ARM, err := snapshot.CopyCompletionError.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -399,7 +399,7 @@ func (snapshot *Snapshot_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.CopyCompletionError = &copyCompletionError
 	}
 	if snapshot.CreationData != nil {
-		creationData_ARM, err := (*snapshot.CreationData).ConvertToARM(resolved)
+		creationData_ARM, err := snapshot.CreationData.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -431,7 +431,7 @@ func (snapshot *Snapshot_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.DiskState = &diskState
 	}
 	if snapshot.Encryption != nil {
-		encryption_ARM, err := (*snapshot.Encryption).ConvertToARM(resolved)
+		encryption_ARM, err := snapshot.Encryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -439,7 +439,7 @@ func (snapshot *Snapshot_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.Encryption = &encryption
 	}
 	if snapshot.EncryptionSettingsCollection != nil {
-		encryptionSettingsCollection_ARM, err := (*snapshot.EncryptionSettingsCollection).ConvertToARM(resolved)
+		encryptionSettingsCollection_ARM, err := snapshot.EncryptionSettingsCollection.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -475,7 +475,7 @@ func (snapshot *Snapshot_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.PublicNetworkAccess = &publicNetworkAccess
 	}
 	if snapshot.PurchasePlan != nil {
-		purchasePlan_ARM, err := (*snapshot.PurchasePlan).ConvertToARM(resolved)
+		purchasePlan_ARM, err := snapshot.PurchasePlan.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -483,7 +483,7 @@ func (snapshot *Snapshot_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.PurchasePlan = &purchasePlan
 	}
 	if snapshot.SecurityProfile != nil {
-		securityProfile_ARM, err := (*snapshot.SecurityProfile).ConvertToARM(resolved)
+		securityProfile_ARM, err := snapshot.SecurityProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -491,7 +491,7 @@ func (snapshot *Snapshot_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.SecurityProfile = &securityProfile
 	}
 	if snapshot.SupportedCapabilities != nil {
-		supportedCapabilities_ARM, err := (*snapshot.SupportedCapabilities).ConvertToARM(resolved)
+		supportedCapabilities_ARM, err := snapshot.SupportedCapabilities.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -505,7 +505,7 @@ func (snapshot *Snapshot_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "Sku":
 	if snapshot.Sku != nil {
-		sku_ARM, err := (*snapshot.Sku).ConvertToARM(resolved)
+		sku_ARM, err := snapshot.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/compute/v1api20241101/availability_set_types_gen.go
+++ b/v2/api/compute/v1api20241101/availability_set_types_gen.go
@@ -327,7 +327,7 @@ func (availabilitySet *AvailabilitySet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.PlatformUpdateDomainCount = &platformUpdateDomainCount
 	}
 	if availabilitySet.ProximityPlacementGroup != nil {
-		proximityPlacementGroup_ARM, err := (*availabilitySet.ProximityPlacementGroup).ConvertToARM(resolved)
+		proximityPlacementGroup_ARM, err := availabilitySet.ProximityPlacementGroup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -335,7 +335,7 @@ func (availabilitySet *AvailabilitySet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.ProximityPlacementGroup = &proximityPlacementGroup
 	}
 	if availabilitySet.ScheduledEventsPolicy != nil {
-		scheduledEventsPolicy_ARM, err := (*availabilitySet.ScheduledEventsPolicy).ConvertToARM(resolved)
+		scheduledEventsPolicy_ARM, err := availabilitySet.ScheduledEventsPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -345,7 +345,7 @@ func (availabilitySet *AvailabilitySet_Spec) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Sku":
 	if availabilitySet.Sku != nil {
-		sku_ARM, err := (*availabilitySet.Sku).ConvertToARM(resolved)
+		sku_ARM, err := availabilitySet.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1499,7 +1499,7 @@ func (policy *ScheduledEventsPolicy) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "ScheduledEventsAdditionalPublishingTargets":
 	if policy.ScheduledEventsAdditionalPublishingTargets != nil {
-		scheduledEventsAdditionalPublishingTargets_ARM, err := (*policy.ScheduledEventsAdditionalPublishingTargets).ConvertToARM(resolved)
+		scheduledEventsAdditionalPublishingTargets_ARM, err := policy.ScheduledEventsAdditionalPublishingTargets.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1509,7 +1509,7 @@ func (policy *ScheduledEventsPolicy) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "UserInitiatedReboot":
 	if policy.UserInitiatedReboot != nil {
-		userInitiatedReboot_ARM, err := (*policy.UserInitiatedReboot).ConvertToARM(resolved)
+		userInitiatedReboot_ARM, err := policy.UserInitiatedReboot.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1519,7 +1519,7 @@ func (policy *ScheduledEventsPolicy) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "UserInitiatedRedeploy":
 	if policy.UserInitiatedRedeploy != nil {
-		userInitiatedRedeploy_ARM, err := (*policy.UserInitiatedRedeploy).ConvertToARM(resolved)
+		userInitiatedRedeploy_ARM, err := policy.UserInitiatedRedeploy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2525,7 +2525,7 @@ func (targets *ScheduledEventsAdditionalPublishingTargets) ConvertToARM(resolved
 
 	// Set property "EventGridAndResourceGraph":
 	if targets.EventGridAndResourceGraph != nil {
-		eventGridAndResourceGraph_ARM, err := (*targets.EventGridAndResourceGraph).ConvertToARM(resolved)
+		eventGridAndResourceGraph_ARM, err := targets.EventGridAndResourceGraph.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/containerinstance/v1api20211001/container_group_types_gen.go
+++ b/v2/api/containerinstance/v1api20211001/container_group_types_gen.go
@@ -332,7 +332,7 @@ func (group *ContainerGroup_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "Identity":
 	if group.Identity != nil {
-		identity_ARM, err := (*group.Identity).ConvertToARM(resolved)
+		identity_ARM, err := group.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -372,7 +372,7 @@ func (group *ContainerGroup_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Properties.Containers = append(result.Properties.Containers, *item_ARM.(*arm.Container))
 	}
 	if group.Diagnostics != nil {
-		diagnostics_ARM, err := (*group.Diagnostics).ConvertToARM(resolved)
+		diagnostics_ARM, err := group.Diagnostics.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -380,7 +380,7 @@ func (group *ContainerGroup_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Properties.Diagnostics = &diagnostics
 	}
 	if group.DnsConfig != nil {
-		dnsConfig_ARM, err := (*group.DnsConfig).ConvertToARM(resolved)
+		dnsConfig_ARM, err := group.DnsConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -388,7 +388,7 @@ func (group *ContainerGroup_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Properties.DnsConfig = &dnsConfig
 	}
 	if group.EncryptionProperties != nil {
-		encryptionProperties_ARM, err := (*group.EncryptionProperties).ConvertToARM(resolved)
+		encryptionProperties_ARM, err := group.EncryptionProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -410,7 +410,7 @@ func (group *ContainerGroup_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Properties.InitContainers = append(result.Properties.InitContainers, *item_ARM.(*arm.InitContainerDefinition))
 	}
 	if group.IpAddress != nil {
-		ipAddress_ARM, err := (*group.IpAddress).ConvertToARM(resolved)
+		ipAddress_ARM, err := group.IpAddress.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2252,7 +2252,7 @@ func (container *Container) ConvertToARM(resolved genruntime.ConvertToARMResolve
 		result.Properties.Image = &image
 	}
 	if container.LivenessProbe != nil {
-		livenessProbe_ARM, err := (*container.LivenessProbe).ConvertToARM(resolved)
+		livenessProbe_ARM, err := container.LivenessProbe.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2267,7 +2267,7 @@ func (container *Container) ConvertToARM(resolved genruntime.ConvertToARMResolve
 		result.Properties.Ports = append(result.Properties.Ports, *item_ARM.(*arm.ContainerPort))
 	}
 	if container.ReadinessProbe != nil {
-		readinessProbe_ARM, err := (*container.ReadinessProbe).ConvertToARM(resolved)
+		readinessProbe_ARM, err := container.ReadinessProbe.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2275,7 +2275,7 @@ func (container *Container) ConvertToARM(resolved genruntime.ConvertToARMResolve
 		result.Properties.ReadinessProbe = &readinessProbe
 	}
 	if container.Resources != nil {
-		resources_ARM, err := (*container.Resources).ConvertToARM(resolved)
+		resources_ARM, err := container.Resources.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3335,7 +3335,7 @@ func (diagnostics *ContainerGroupDiagnostics) ConvertToARM(resolved genruntime.C
 
 	// Set property "LogAnalytics":
 	if diagnostics.LogAnalytics != nil {
-		logAnalytics_ARM, err := (*diagnostics.LogAnalytics).ConvertToARM(resolved)
+		logAnalytics_ARM, err := diagnostics.LogAnalytics.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5958,7 +5958,7 @@ func (volume *Volume) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 
 	// Set property "AzureFile":
 	if volume.AzureFile != nil {
-		azureFile_ARM, err := (*volume.AzureFile).ConvertToARM(resolved)
+		azureFile_ARM, err := volume.AzureFile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5976,7 +5976,7 @@ func (volume *Volume) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 
 	// Set property "GitRepo":
 	if volume.GitRepo != nil {
-		gitRepo_ARM, err := (*volume.GitRepo).ConvertToARM(resolved)
+		gitRepo_ARM, err := volume.GitRepo.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6981,7 +6981,7 @@ func (probe *ContainerProbe) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Exec":
 	if probe.Exec != nil {
-		exec_ARM, err := (*probe.Exec).ConvertToARM(resolved)
+		exec_ARM, err := probe.Exec.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6997,7 +6997,7 @@ func (probe *ContainerProbe) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "HttpGet":
 	if probe.HttpGet != nil {
-		httpGet_ARM, err := (*probe.HttpGet).ConvertToARM(resolved)
+		httpGet_ARM, err := probe.HttpGet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9008,7 +9008,7 @@ func (requirements *ResourceRequirements) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "Limits":
 	if requirements.Limits != nil {
-		limits_ARM, err := (*requirements.Limits).ConvertToARM(resolved)
+		limits_ARM, err := requirements.Limits.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9018,7 +9018,7 @@ func (requirements *ResourceRequirements) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "Requests":
 	if requirements.Requests != nil {
-		requests_ARM, err := (*requirements.Requests).ConvertToARM(resolved)
+		requests_ARM, err := requirements.Requests.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10395,7 +10395,7 @@ func (limits *ResourceLimits) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "Gpu":
 	if limits.Gpu != nil {
-		gpu_ARM, err := (*limits.Gpu).ConvertToARM(resolved)
+		gpu_ARM, err := limits.Gpu.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10727,7 +10727,7 @@ func (requests *ResourceRequests) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "Gpu":
 	if requests.Gpu != nil {
-		gpu_ARM, err := (*requests.Gpu).ConvertToARM(resolved)
+		gpu_ARM, err := requests.Gpu.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/containerregistry/v1api20210901/registry_types_gen.go
+++ b/v2/api/containerregistry/v1api20210901/registry_types_gen.go
@@ -322,7 +322,7 @@ func (registry *Registry_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "Identity":
 	if registry.Identity != nil {
-		identity_ARM, err := (*registry.Identity).ConvertToARM(resolved)
+		identity_ARM, err := registry.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -359,7 +359,7 @@ func (registry *Registry_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.DataEndpointEnabled = &dataEndpointEnabled
 	}
 	if registry.Encryption != nil {
-		encryption_ARM, err := (*registry.Encryption).ConvertToARM(resolved)
+		encryption_ARM, err := registry.Encryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -373,7 +373,7 @@ func (registry *Registry_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.NetworkRuleBypassOptions = &networkRuleBypassOptions
 	}
 	if registry.NetworkRuleSet != nil {
-		networkRuleSet_ARM, err := (*registry.NetworkRuleSet).ConvertToARM(resolved)
+		networkRuleSet_ARM, err := registry.NetworkRuleSet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -381,7 +381,7 @@ func (registry *Registry_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.NetworkRuleSet = &networkRuleSet
 	}
 	if registry.Policies != nil {
-		policies_ARM, err := (*registry.Policies).ConvertToARM(resolved)
+		policies_ARM, err := registry.Policies.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -403,7 +403,7 @@ func (registry *Registry_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "Sku":
 	if registry.Sku != nil {
-		sku_ARM, err := (*registry.Sku).ConvertToARM(resolved)
+		sku_ARM, err := registry.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1686,7 +1686,7 @@ func (property *EncryptionProperty) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "KeyVaultProperties":
 	if property.KeyVaultProperties != nil {
-		keyVaultProperties_ARM, err := (*property.KeyVaultProperties).ConvertToARM(resolved)
+		keyVaultProperties_ARM, err := property.KeyVaultProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2550,7 +2550,7 @@ func (policies *Policies) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "ExportPolicy":
 	if policies.ExportPolicy != nil {
-		exportPolicy_ARM, err := (*policies.ExportPolicy).ConvertToARM(resolved)
+		exportPolicy_ARM, err := policies.ExportPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2560,7 +2560,7 @@ func (policies *Policies) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "QuarantinePolicy":
 	if policies.QuarantinePolicy != nil {
-		quarantinePolicy_ARM, err := (*policies.QuarantinePolicy).ConvertToARM(resolved)
+		quarantinePolicy_ARM, err := policies.QuarantinePolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2570,7 +2570,7 @@ func (policies *Policies) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "RetentionPolicy":
 	if policies.RetentionPolicy != nil {
-		retentionPolicy_ARM, err := (*policies.RetentionPolicy).ConvertToARM(resolved)
+		retentionPolicy_ARM, err := policies.RetentionPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2580,7 +2580,7 @@ func (policies *Policies) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "TrustPolicy":
 	if policies.TrustPolicy != nil {
-		trustPolicy_ARM, err := (*policies.TrustPolicy).ConvertToARM(resolved)
+		trustPolicy_ARM, err := policies.TrustPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/containerregistry/v1api20230701/registry_types_gen.go
+++ b/v2/api/containerregistry/v1api20230701/registry_types_gen.go
@@ -319,7 +319,7 @@ func (registry *Registry_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "Identity":
 	if registry.Identity != nil {
-		identity_ARM, err := (*registry.Identity).ConvertToARM(resolved)
+		identity_ARM, err := registry.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -356,7 +356,7 @@ func (registry *Registry_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.DataEndpointEnabled = &dataEndpointEnabled
 	}
 	if registry.Encryption != nil {
-		encryption_ARM, err := (*registry.Encryption).ConvertToARM(resolved)
+		encryption_ARM, err := registry.Encryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -370,7 +370,7 @@ func (registry *Registry_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.NetworkRuleBypassOptions = &networkRuleBypassOptions
 	}
 	if registry.NetworkRuleSet != nil {
-		networkRuleSet_ARM, err := (*registry.NetworkRuleSet).ConvertToARM(resolved)
+		networkRuleSet_ARM, err := registry.NetworkRuleSet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -378,7 +378,7 @@ func (registry *Registry_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.NetworkRuleSet = &networkRuleSet
 	}
 	if registry.Policies != nil {
-		policies_ARM, err := (*registry.Policies).ConvertToARM(resolved)
+		policies_ARM, err := registry.Policies.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -400,7 +400,7 @@ func (registry *Registry_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "Sku":
 	if registry.Sku != nil {
-		sku_ARM, err := (*registry.Sku).ConvertToARM(resolved)
+		sku_ARM, err := registry.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1796,7 +1796,7 @@ func (property *EncryptionProperty) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "KeyVaultProperties":
 	if property.KeyVaultProperties != nil {
-		keyVaultProperties_ARM, err := (*property.KeyVaultProperties).ConvertToARM(resolved)
+		keyVaultProperties_ARM, err := property.KeyVaultProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2705,7 +2705,7 @@ func (policies *Policies) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "ExportPolicy":
 	if policies.ExportPolicy != nil {
-		exportPolicy_ARM, err := (*policies.ExportPolicy).ConvertToARM(resolved)
+		exportPolicy_ARM, err := policies.ExportPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2715,7 +2715,7 @@ func (policies *Policies) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "QuarantinePolicy":
 	if policies.QuarantinePolicy != nil {
-		quarantinePolicy_ARM, err := (*policies.QuarantinePolicy).ConvertToARM(resolved)
+		quarantinePolicy_ARM, err := policies.QuarantinePolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2725,7 +2725,7 @@ func (policies *Policies) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "RetentionPolicy":
 	if policies.RetentionPolicy != nil {
-		retentionPolicy_ARM, err := (*policies.RetentionPolicy).ConvertToARM(resolved)
+		retentionPolicy_ARM, err := policies.RetentionPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2735,7 +2735,7 @@ func (policies *Policies) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "TrustPolicy":
 	if policies.TrustPolicy != nil {
-		trustPolicy_ARM, err := (*policies.TrustPolicy).ConvertToARM(resolved)
+		trustPolicy_ARM, err := policies.TrustPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/containerservice/v1api20210501/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1api20210501/managed_cluster_types_gen.go
@@ -308,7 +308,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "ExtendedLocation":
 	if cluster.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*cluster.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := cluster.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -318,7 +318,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Identity":
 	if cluster.Identity != nil {
-		identity_ARM, err := (*cluster.Identity).ConvertToARM(resolved)
+		identity_ARM, err := cluster.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -361,7 +361,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties = &arm.ManagedClusterProperties{}
 	}
 	if cluster.AadProfile != nil {
-		aadProfile_ARM, err := (*cluster.AadProfile).ConvertToARM(resolved)
+		aadProfile_ARM, err := cluster.AadProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -386,7 +386,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AgentPoolProfiles = append(result.Properties.AgentPoolProfiles, *item_ARM.(*arm.ManagedClusterAgentPoolProfile))
 	}
 	if cluster.ApiServerAccessProfile != nil {
-		apiServerAccessProfile_ARM, err := (*cluster.ApiServerAccessProfile).ConvertToARM(resolved)
+		apiServerAccessProfile_ARM, err := cluster.ApiServerAccessProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -394,7 +394,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.ApiServerAccessProfile = &apiServerAccessProfile
 	}
 	if cluster.AutoScalerProfile != nil {
-		autoScalerProfile_ARM, err := (*cluster.AutoScalerProfile).ConvertToARM(resolved)
+		autoScalerProfile_ARM, err := cluster.AutoScalerProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -402,7 +402,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AutoScalerProfile = &autoScalerProfile
 	}
 	if cluster.AutoUpgradeProfile != nil {
-		autoUpgradeProfile_ARM, err := (*cluster.AutoUpgradeProfile).ConvertToARM(resolved)
+		autoUpgradeProfile_ARM, err := cluster.AutoUpgradeProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -438,7 +438,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.FqdnSubdomain = &fqdnSubdomain
 	}
 	if cluster.HttpProxyConfig != nil {
-		httpProxyConfig_ARM, err := (*cluster.HttpProxyConfig).ConvertToARM(resolved)
+		httpProxyConfig_ARM, err := cluster.HttpProxyConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -460,7 +460,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.KubernetesVersion = &kubernetesVersion
 	}
 	if cluster.LinuxProfile != nil {
-		linuxProfile_ARM, err := (*cluster.LinuxProfile).ConvertToARM(resolved)
+		linuxProfile_ARM, err := cluster.LinuxProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -468,7 +468,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.LinuxProfile = &linuxProfile
 	}
 	if cluster.NetworkProfile != nil {
-		networkProfile_ARM, err := (*cluster.NetworkProfile).ConvertToARM(resolved)
+		networkProfile_ARM, err := cluster.NetworkProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -480,7 +480,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.NodeResourceGroup = &nodeResourceGroup
 	}
 	if cluster.PodIdentityProfile != nil {
-		podIdentityProfile_ARM, err := (*cluster.PodIdentityProfile).ConvertToARM(resolved)
+		podIdentityProfile_ARM, err := cluster.PodIdentityProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -495,7 +495,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.PrivateLinkResources = append(result.Properties.PrivateLinkResources, *item_ARM.(*arm.PrivateLinkResource))
 	}
 	if cluster.ServicePrincipalProfile != nil {
-		servicePrincipalProfile_ARM, err := (*cluster.ServicePrincipalProfile).ConvertToARM(resolved)
+		servicePrincipalProfile_ARM, err := cluster.ServicePrincipalProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -503,7 +503,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.ServicePrincipalProfile = &servicePrincipalProfile
 	}
 	if cluster.WindowsProfile != nil {
-		windowsProfile_ARM, err := (*cluster.WindowsProfile).ConvertToARM(resolved)
+		windowsProfile_ARM, err := cluster.WindowsProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -513,7 +513,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Sku":
 	if cluster.Sku != nil {
-		sku_ARM, err := (*cluster.Sku).ConvertToARM(resolved)
+		sku_ARM, err := cluster.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2739,7 +2739,7 @@ func (profile *ContainerServiceLinuxProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Ssh":
 	if profile.Ssh != nil {
-		ssh_ARM, err := (*profile.Ssh).ConvertToARM(resolved)
+		ssh_ARM, err := profile.Ssh.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2971,7 +2971,7 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "LoadBalancerProfile":
 	if profile.LoadBalancerProfile != nil {
-		loadBalancerProfile_ARM, err := (*profile.LoadBalancerProfile).ConvertToARM(resolved)
+		loadBalancerProfile_ARM, err := profile.LoadBalancerProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4413,7 +4413,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "KubeletConfig":
 	if profile.KubeletConfig != nil {
-		kubeletConfig_ARM, err := (*profile.KubeletConfig).ConvertToARM(resolved)
+		kubeletConfig_ARM, err := profile.KubeletConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4431,7 +4431,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "LinuxOSConfig":
 	if profile.LinuxOSConfig != nil {
-		linuxOSConfig_ARM, err := (*profile.LinuxOSConfig).ConvertToARM(resolved)
+		linuxOSConfig_ARM, err := profile.LinuxOSConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4596,7 +4596,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "UpgradeSettings":
 	if profile.UpgradeSettings != nil {
-		upgradeSettings_ARM, err := (*profile.UpgradeSettings).ConvertToARM(resolved)
+		upgradeSettings_ARM, err := profile.UpgradeSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10021,7 +10021,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 
 	// Set property "ManagedOutboundIPs":
 	if profile.ManagedOutboundIPs != nil {
-		managedOutboundIPs_ARM, err := (*profile.ManagedOutboundIPs).ConvertToARM(resolved)
+		managedOutboundIPs_ARM, err := profile.ManagedOutboundIPs.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10031,7 +10031,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 
 	// Set property "OutboundIPPrefixes":
 	if profile.OutboundIPPrefixes != nil {
-		outboundIPPrefixes_ARM, err := (*profile.OutboundIPPrefixes).ConvertToARM(resolved)
+		outboundIPPrefixes_ARM, err := profile.OutboundIPPrefixes.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10041,7 +10041,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 
 	// Set property "OutboundIPs":
 	if profile.OutboundIPs != nil {
-		outboundIPs_ARM, err := (*profile.OutboundIPs).ConvertToARM(resolved)
+		outboundIPs_ARM, err := profile.OutboundIPs.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10585,7 +10585,7 @@ func (identity *ManagedClusterPodIdentity) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "Identity":
 	if identity.Identity != nil {
-		identity_ARM, err := (*identity.Identity).ConvertToARM(resolved)
+		identity_ARM, err := identity.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/containerservice/v1api20210501/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/containerservice/v1api20210501/managed_clusters_agent_pool_types_gen.go
@@ -471,7 +471,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.GpuInstanceProfile = &gpuInstanceProfile
 	}
 	if pool.KubeletConfig != nil {
-		kubeletConfig_ARM, err := (*pool.KubeletConfig).ConvertToARM(resolved)
+		kubeletConfig_ARM, err := pool.KubeletConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -485,7 +485,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.KubeletDiskType = &kubeletDiskType
 	}
 	if pool.LinuxOSConfig != nil {
-		linuxOSConfig_ARM, err := (*pool.LinuxOSConfig).ConvertToARM(resolved)
+		linuxOSConfig_ARM, err := pool.LinuxOSConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -604,7 +604,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.Type = &typeVar
 	}
 	if pool.UpgradeSettings != nil {
-		upgradeSettings_ARM, err := (*pool.UpgradeSettings).ConvertToARM(resolved)
+		upgradeSettings_ARM, err := pool.UpgradeSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3403,7 +3403,7 @@ func (config *LinuxOSConfig) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Sysctls":
 	if config.Sysctls != nil {
-		sysctls_ARM, err := (*config.Sysctls).ConvertToARM(resolved)
+		sysctls_ARM, err := config.Sysctls.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/containerservice/v1api20230201/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1api20230201/managed_cluster_types_gen.go
@@ -344,7 +344,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "ExtendedLocation":
 	if cluster.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*cluster.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := cluster.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -354,7 +354,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Identity":
 	if cluster.Identity != nil {
-		identity_ARM, err := (*cluster.Identity).ConvertToARM(resolved)
+		identity_ARM, err := cluster.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -403,7 +403,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties = &arm.ManagedClusterProperties{}
 	}
 	if cluster.AadProfile != nil {
-		aadProfile_ARM, err := (*cluster.AadProfile).ConvertToARM(resolved)
+		aadProfile_ARM, err := cluster.AadProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -428,7 +428,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AgentPoolProfiles = append(result.Properties.AgentPoolProfiles, *item_ARM.(*arm.ManagedClusterAgentPoolProfile))
 	}
 	if cluster.ApiServerAccessProfile != nil {
-		apiServerAccessProfile_ARM, err := (*cluster.ApiServerAccessProfile).ConvertToARM(resolved)
+		apiServerAccessProfile_ARM, err := cluster.ApiServerAccessProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -436,7 +436,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.ApiServerAccessProfile = &apiServerAccessProfile
 	}
 	if cluster.AutoScalerProfile != nil {
-		autoScalerProfile_ARM, err := (*cluster.AutoScalerProfile).ConvertToARM(resolved)
+		autoScalerProfile_ARM, err := cluster.AutoScalerProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -444,7 +444,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AutoScalerProfile = &autoScalerProfile
 	}
 	if cluster.AutoUpgradeProfile != nil {
-		autoUpgradeProfile_ARM, err := (*cluster.AutoUpgradeProfile).ConvertToARM(resolved)
+		autoUpgradeProfile_ARM, err := cluster.AutoUpgradeProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -452,7 +452,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AutoUpgradeProfile = &autoUpgradeProfile
 	}
 	if cluster.AzureMonitorProfile != nil {
-		azureMonitorProfile_ARM, err := (*cluster.AzureMonitorProfile).ConvertToARM(resolved)
+		azureMonitorProfile_ARM, err := cluster.AzureMonitorProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -488,7 +488,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.FqdnSubdomain = &fqdnSubdomain
 	}
 	if cluster.HttpProxyConfig != nil {
-		httpProxyConfig_ARM, err := (*cluster.HttpProxyConfig).ConvertToARM(resolved)
+		httpProxyConfig_ARM, err := cluster.HttpProxyConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -510,7 +510,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.KubernetesVersion = &kubernetesVersion
 	}
 	if cluster.LinuxProfile != nil {
-		linuxProfile_ARM, err := (*cluster.LinuxProfile).ConvertToARM(resolved)
+		linuxProfile_ARM, err := cluster.LinuxProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -518,7 +518,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.LinuxProfile = &linuxProfile
 	}
 	if cluster.NetworkProfile != nil {
-		networkProfile_ARM, err := (*cluster.NetworkProfile).ConvertToARM(resolved)
+		networkProfile_ARM, err := cluster.NetworkProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -530,7 +530,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.NodeResourceGroup = &nodeResourceGroup
 	}
 	if cluster.OidcIssuerProfile != nil {
-		oidcIssuerProfile_ARM, err := (*cluster.OidcIssuerProfile).ConvertToARM(resolved)
+		oidcIssuerProfile_ARM, err := cluster.OidcIssuerProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -538,7 +538,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.OidcIssuerProfile = &oidcIssuerProfile
 	}
 	if cluster.PodIdentityProfile != nil {
-		podIdentityProfile_ARM, err := (*cluster.PodIdentityProfile).ConvertToARM(resolved)
+		podIdentityProfile_ARM, err := cluster.PodIdentityProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -559,7 +559,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.PublicNetworkAccess = &publicNetworkAccess
 	}
 	if cluster.SecurityProfile != nil {
-		securityProfile_ARM, err := (*cluster.SecurityProfile).ConvertToARM(resolved)
+		securityProfile_ARM, err := cluster.SecurityProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -567,7 +567,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.SecurityProfile = &securityProfile
 	}
 	if cluster.ServicePrincipalProfile != nil {
-		servicePrincipalProfile_ARM, err := (*cluster.ServicePrincipalProfile).ConvertToARM(resolved)
+		servicePrincipalProfile_ARM, err := cluster.ServicePrincipalProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -575,7 +575,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.ServicePrincipalProfile = &servicePrincipalProfile
 	}
 	if cluster.StorageProfile != nil {
-		storageProfile_ARM, err := (*cluster.StorageProfile).ConvertToARM(resolved)
+		storageProfile_ARM, err := cluster.StorageProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -583,7 +583,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.StorageProfile = &storageProfile
 	}
 	if cluster.WindowsProfile != nil {
-		windowsProfile_ARM, err := (*cluster.WindowsProfile).ConvertToARM(resolved)
+		windowsProfile_ARM, err := cluster.WindowsProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -591,7 +591,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.WindowsProfile = &windowsProfile
 	}
 	if cluster.WorkloadAutoScalerProfile != nil {
-		workloadAutoScalerProfile_ARM, err := (*cluster.WorkloadAutoScalerProfile).ConvertToARM(resolved)
+		workloadAutoScalerProfile_ARM, err := cluster.WorkloadAutoScalerProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -601,7 +601,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Sku":
 	if cluster.Sku != nil {
-		sku_ARM, err := (*cluster.Sku).ConvertToARM(resolved)
+		sku_ARM, err := cluster.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3321,7 +3321,7 @@ func (profile *ContainerServiceLinuxProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Ssh":
 	if profile.Ssh != nil {
-		ssh_ARM, err := (*profile.Ssh).ConvertToARM(resolved)
+		ssh_ARM, err := profile.Ssh.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3566,7 +3566,7 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "LoadBalancerProfile":
 	if profile.LoadBalancerProfile != nil {
-		loadBalancerProfile_ARM, err := (*profile.LoadBalancerProfile).ConvertToARM(resolved)
+		loadBalancerProfile_ARM, err := profile.LoadBalancerProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3584,7 +3584,7 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "NatGatewayProfile":
 	if profile.NatGatewayProfile != nil {
-		natGatewayProfile_ARM, err := (*profile.NatGatewayProfile).ConvertToARM(resolved)
+		natGatewayProfile_ARM, err := profile.NatGatewayProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5298,7 +5298,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "CreationData":
 	if profile.CreationData != nil {
-		creationData_ARM, err := (*profile.CreationData).ConvertToARM(resolved)
+		creationData_ARM, err := profile.CreationData.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5356,7 +5356,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "KubeletConfig":
 	if profile.KubeletConfig != nil {
-		kubeletConfig_ARM, err := (*profile.KubeletConfig).ConvertToARM(resolved)
+		kubeletConfig_ARM, err := profile.KubeletConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5374,7 +5374,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "LinuxOSConfig":
 	if profile.LinuxOSConfig != nil {
-		linuxOSConfig_ARM, err := (*profile.LinuxOSConfig).ConvertToARM(resolved)
+		linuxOSConfig_ARM, err := profile.LinuxOSConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5492,7 +5492,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "PowerState":
 	if profile.PowerState != nil {
-		powerState_ARM, err := (*profile.PowerState).ConvertToARM(resolved)
+		powerState_ARM, err := profile.PowerState.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5561,7 +5561,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "UpgradeSettings":
 	if profile.UpgradeSettings != nil {
-		upgradeSettings_ARM, err := (*profile.UpgradeSettings).ConvertToARM(resolved)
+		upgradeSettings_ARM, err := profile.UpgradeSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7868,7 +7868,7 @@ func (profile *ManagedClusterAzureMonitorProfile) ConvertToARM(resolved genrunti
 
 	// Set property "Metrics":
 	if profile.Metrics != nil {
-		metrics_ARM, err := (*profile.Metrics).ConvertToARM(resolved)
+		metrics_ARM, err := profile.Metrics.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9978,7 +9978,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 
 	// Set property "AzureKeyVaultKms":
 	if profile.AzureKeyVaultKms != nil {
-		azureKeyVaultKms_ARM, err := (*profile.AzureKeyVaultKms).ConvertToARM(resolved)
+		azureKeyVaultKms_ARM, err := profile.AzureKeyVaultKms.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9988,7 +9988,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 
 	// Set property "Defender":
 	if profile.Defender != nil {
-		defender_ARM, err := (*profile.Defender).ConvertToARM(resolved)
+		defender_ARM, err := profile.Defender.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9998,7 +9998,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 
 	// Set property "ImageCleaner":
 	if profile.ImageCleaner != nil {
-		imageCleaner_ARM, err := (*profile.ImageCleaner).ConvertToARM(resolved)
+		imageCleaner_ARM, err := profile.ImageCleaner.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10008,7 +10008,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 
 	// Set property "WorkloadIdentity":
 	if profile.WorkloadIdentity != nil {
-		workloadIdentity_ARM, err := (*profile.WorkloadIdentity).ConvertToARM(resolved)
+		workloadIdentity_ARM, err := profile.WorkloadIdentity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10779,7 +10779,7 @@ func (profile *ManagedClusterStorageProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "BlobCSIDriver":
 	if profile.BlobCSIDriver != nil {
-		blobCSIDriver_ARM, err := (*profile.BlobCSIDriver).ConvertToARM(resolved)
+		blobCSIDriver_ARM, err := profile.BlobCSIDriver.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10789,7 +10789,7 @@ func (profile *ManagedClusterStorageProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "DiskCSIDriver":
 	if profile.DiskCSIDriver != nil {
-		diskCSIDriver_ARM, err := (*profile.DiskCSIDriver).ConvertToARM(resolved)
+		diskCSIDriver_ARM, err := profile.DiskCSIDriver.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10799,7 +10799,7 @@ func (profile *ManagedClusterStorageProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "FileCSIDriver":
 	if profile.FileCSIDriver != nil {
-		fileCSIDriver_ARM, err := (*profile.FileCSIDriver).ConvertToARM(resolved)
+		fileCSIDriver_ARM, err := profile.FileCSIDriver.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10809,7 +10809,7 @@ func (profile *ManagedClusterStorageProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "SnapshotController":
 	if profile.SnapshotController != nil {
-		snapshotController_ARM, err := (*profile.SnapshotController).ConvertToARM(resolved)
+		snapshotController_ARM, err := profile.SnapshotController.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11229,7 +11229,7 @@ func (profile *ManagedClusterWindowsProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "GmsaProfile":
 	if profile.GmsaProfile != nil {
-		gmsaProfile_ARM, err := (*profile.GmsaProfile).ConvertToARM(resolved)
+		gmsaProfile_ARM, err := profile.GmsaProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11555,7 +11555,7 @@ func (profile *ManagedClusterWorkloadAutoScalerProfile) ConvertToARM(resolved ge
 
 	// Set property "Keda":
 	if profile.Keda != nil {
-		keda_ARM, err := (*profile.Keda).ConvertToARM(resolved)
+		keda_ARM, err := profile.Keda.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -13206,7 +13206,7 @@ func (metrics *ManagedClusterAzureMonitorProfileMetrics) ConvertToARM(resolved g
 
 	// Set property "KubeStateMetrics":
 	if metrics.KubeStateMetrics != nil {
-		kubeStateMetrics_ARM, err := (*metrics.KubeStateMetrics).ConvertToARM(resolved)
+		kubeStateMetrics_ARM, err := metrics.KubeStateMetrics.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -13569,7 +13569,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 
 	// Set property "ManagedOutboundIPs":
 	if profile.ManagedOutboundIPs != nil {
-		managedOutboundIPs_ARM, err := (*profile.ManagedOutboundIPs).ConvertToARM(resolved)
+		managedOutboundIPs_ARM, err := profile.ManagedOutboundIPs.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -13579,7 +13579,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 
 	// Set property "OutboundIPPrefixes":
 	if profile.OutboundIPPrefixes != nil {
-		outboundIPPrefixes_ARM, err := (*profile.OutboundIPPrefixes).ConvertToARM(resolved)
+		outboundIPPrefixes_ARM, err := profile.OutboundIPPrefixes.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -13589,7 +13589,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 
 	// Set property "OutboundIPs":
 	if profile.OutboundIPs != nil {
-		outboundIPs_ARM, err := (*profile.OutboundIPs).ConvertToARM(resolved)
+		outboundIPs_ARM, err := profile.OutboundIPs.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -14118,7 +14118,7 @@ func (profile *ManagedClusterNATGatewayProfile) ConvertToARM(resolved genruntime
 
 	// Set property "ManagedOutboundIPProfile":
 	if profile.ManagedOutboundIPProfile != nil {
-		managedOutboundIPProfile_ARM, err := (*profile.ManagedOutboundIPProfile).ConvertToARM(resolved)
+		managedOutboundIPProfile_ARM, err := profile.ManagedOutboundIPProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -14559,7 +14559,7 @@ func (identity *ManagedClusterPodIdentity) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "Identity":
 	if identity.Identity != nil {
-		identity_ARM, err := (*identity.Identity).ConvertToARM(resolved)
+		identity_ARM, err := identity.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15137,7 +15137,7 @@ func (defender *ManagedClusterSecurityProfileDefender) ConvertToARM(resolved gen
 
 	// Set property "SecurityMonitoring":
 	if defender.SecurityMonitoring != nil {
-		securityMonitoring_ARM, err := (*defender.SecurityMonitoring).ConvertToARM(resolved)
+		securityMonitoring_ARM, err := defender.SecurityMonitoring.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/containerservice/v1api20230201/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/containerservice/v1api20230201/managed_clusters_agent_pool_types_gen.go
@@ -474,7 +474,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.Count = &count
 	}
 	if pool.CreationData != nil {
-		creationData_ARM, err := (*pool.CreationData).ConvertToARM(resolved)
+		creationData_ARM, err := pool.CreationData.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -516,7 +516,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.HostGroupID = &hostGroupID
 	}
 	if pool.KubeletConfig != nil {
-		kubeletConfig_ARM, err := (*pool.KubeletConfig).ConvertToARM(resolved)
+		kubeletConfig_ARM, err := pool.KubeletConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -530,7 +530,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.KubeletDiskType = &kubeletDiskType
 	}
 	if pool.LinuxOSConfig != nil {
-		linuxOSConfig_ARM, err := (*pool.LinuxOSConfig).ConvertToARM(resolved)
+		linuxOSConfig_ARM, err := pool.LinuxOSConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -614,7 +614,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.PodSubnetID = &podSubnetID
 	}
 	if pool.PowerState != nil {
-		powerState_ARM, err := (*pool.PowerState).ConvertToARM(resolved)
+		powerState_ARM, err := pool.PowerState.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -667,7 +667,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.Type = &typeVar
 	}
 	if pool.UpgradeSettings != nil {
-		upgradeSettings_ARM, err := (*pool.UpgradeSettings).ConvertToARM(resolved)
+		upgradeSettings_ARM, err := pool.UpgradeSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3914,7 +3914,7 @@ func (config *LinuxOSConfig) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Sysctls":
 	if config.Sysctls != nil {
-		sysctls_ARM, err := (*config.Sysctls).ConvertToARM(resolved)
+		sysctls_ARM, err := config.Sysctls.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/containerservice/v1api20230315preview/fleet_types_gen.go
+++ b/v2/api/containerservice/v1api20230315preview/fleet_types_gen.go
@@ -303,7 +303,7 @@ func (fleet *Fleet_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.Properties = &arm.FleetProperties{}
 	}
 	if fleet.HubProfile != nil {
-		hubProfile_ARM, err := (*fleet.HubProfile).ConvertToARM(resolved)
+		hubProfile_ARM, err := fleet.HubProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/containerservice/v1api20230315preview/fleets_update_run_types_gen.go
+++ b/v2/api/containerservice/v1api20230315preview/fleets_update_run_types_gen.go
@@ -294,7 +294,7 @@ func (updateRun *FleetsUpdateRun_Spec) ConvertToARM(resolved genruntime.ConvertT
 		result.Properties = &arm.UpdateRunProperties{}
 	}
 	if updateRun.ManagedClusterUpdate != nil {
-		managedClusterUpdate_ARM, err := (*updateRun.ManagedClusterUpdate).ConvertToARM(resolved)
+		managedClusterUpdate_ARM, err := updateRun.ManagedClusterUpdate.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -302,7 +302,7 @@ func (updateRun *FleetsUpdateRun_Spec) ConvertToARM(resolved genruntime.ConvertT
 		result.Properties.ManagedClusterUpdate = &managedClusterUpdate
 	}
 	if updateRun.Strategy != nil {
-		strategy_ARM, err := (*updateRun.Strategy).ConvertToARM(resolved)
+		strategy_ARM, err := updateRun.Strategy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1064,7 +1064,7 @@ func (update *ManagedClusterUpdate) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Upgrade":
 	if update.Upgrade != nil {
-		upgrade_ARM, err := (*update.Upgrade).ConvertToARM(resolved)
+		upgrade_ARM, err := update.Upgrade.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/containerservice/v1api20231001/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1api20231001/managed_cluster_types_gen.go
@@ -436,7 +436,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "ExtendedLocation":
 	if cluster.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*cluster.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := cluster.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -446,7 +446,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Identity":
 	if cluster.Identity != nil {
-		identity_ARM, err := (*cluster.Identity).ConvertToARM(resolved)
+		identity_ARM, err := cluster.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -498,7 +498,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties = &arm.ManagedClusterProperties{}
 	}
 	if cluster.AadProfile != nil {
-		aadProfile_ARM, err := (*cluster.AadProfile).ConvertToARM(resolved)
+		aadProfile_ARM, err := cluster.AadProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -523,7 +523,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AgentPoolProfiles = append(result.Properties.AgentPoolProfiles, *item_ARM.(*arm.ManagedClusterAgentPoolProfile))
 	}
 	if cluster.ApiServerAccessProfile != nil {
-		apiServerAccessProfile_ARM, err := (*cluster.ApiServerAccessProfile).ConvertToARM(resolved)
+		apiServerAccessProfile_ARM, err := cluster.ApiServerAccessProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -531,7 +531,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.ApiServerAccessProfile = &apiServerAccessProfile
 	}
 	if cluster.AutoScalerProfile != nil {
-		autoScalerProfile_ARM, err := (*cluster.AutoScalerProfile).ConvertToARM(resolved)
+		autoScalerProfile_ARM, err := cluster.AutoScalerProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -539,7 +539,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AutoScalerProfile = &autoScalerProfile
 	}
 	if cluster.AutoUpgradeProfile != nil {
-		autoUpgradeProfile_ARM, err := (*cluster.AutoUpgradeProfile).ConvertToARM(resolved)
+		autoUpgradeProfile_ARM, err := cluster.AutoUpgradeProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -547,7 +547,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AutoUpgradeProfile = &autoUpgradeProfile
 	}
 	if cluster.AzureMonitorProfile != nil {
-		azureMonitorProfile_ARM, err := (*cluster.AzureMonitorProfile).ConvertToARM(resolved)
+		azureMonitorProfile_ARM, err := cluster.AzureMonitorProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -583,7 +583,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.FqdnSubdomain = &fqdnSubdomain
 	}
 	if cluster.HttpProxyConfig != nil {
-		httpProxyConfig_ARM, err := (*cluster.HttpProxyConfig).ConvertToARM(resolved)
+		httpProxyConfig_ARM, err := cluster.HttpProxyConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -605,7 +605,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.KubernetesVersion = &kubernetesVersion
 	}
 	if cluster.LinuxProfile != nil {
-		linuxProfile_ARM, err := (*cluster.LinuxProfile).ConvertToARM(resolved)
+		linuxProfile_ARM, err := cluster.LinuxProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -613,7 +613,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.LinuxProfile = &linuxProfile
 	}
 	if cluster.NetworkProfile != nil {
-		networkProfile_ARM, err := (*cluster.NetworkProfile).ConvertToARM(resolved)
+		networkProfile_ARM, err := cluster.NetworkProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -625,7 +625,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.NodeResourceGroup = &nodeResourceGroup
 	}
 	if cluster.OidcIssuerProfile != nil {
-		oidcIssuerProfile_ARM, err := (*cluster.OidcIssuerProfile).ConvertToARM(resolved)
+		oidcIssuerProfile_ARM, err := cluster.OidcIssuerProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -633,7 +633,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.OidcIssuerProfile = &oidcIssuerProfile
 	}
 	if cluster.PodIdentityProfile != nil {
-		podIdentityProfile_ARM, err := (*cluster.PodIdentityProfile).ConvertToARM(resolved)
+		podIdentityProfile_ARM, err := cluster.PodIdentityProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -654,7 +654,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.PublicNetworkAccess = &publicNetworkAccess
 	}
 	if cluster.SecurityProfile != nil {
-		securityProfile_ARM, err := (*cluster.SecurityProfile).ConvertToARM(resolved)
+		securityProfile_ARM, err := cluster.SecurityProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -662,7 +662,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.SecurityProfile = &securityProfile
 	}
 	if cluster.ServiceMeshProfile != nil {
-		serviceMeshProfile_ARM, err := (*cluster.ServiceMeshProfile).ConvertToARM(resolved)
+		serviceMeshProfile_ARM, err := cluster.ServiceMeshProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -670,7 +670,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.ServiceMeshProfile = &serviceMeshProfile
 	}
 	if cluster.ServicePrincipalProfile != nil {
-		servicePrincipalProfile_ARM, err := (*cluster.ServicePrincipalProfile).ConvertToARM(resolved)
+		servicePrincipalProfile_ARM, err := cluster.ServicePrincipalProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -678,7 +678,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.ServicePrincipalProfile = &servicePrincipalProfile
 	}
 	if cluster.StorageProfile != nil {
-		storageProfile_ARM, err := (*cluster.StorageProfile).ConvertToARM(resolved)
+		storageProfile_ARM, err := cluster.StorageProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -692,7 +692,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.SupportPlan = &supportPlan
 	}
 	if cluster.UpgradeSettings != nil {
-		upgradeSettings_ARM, err := (*cluster.UpgradeSettings).ConvertToARM(resolved)
+		upgradeSettings_ARM, err := cluster.UpgradeSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -700,7 +700,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.UpgradeSettings = &upgradeSettings
 	}
 	if cluster.WindowsProfile != nil {
-		windowsProfile_ARM, err := (*cluster.WindowsProfile).ConvertToARM(resolved)
+		windowsProfile_ARM, err := cluster.WindowsProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -708,7 +708,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.WindowsProfile = &windowsProfile
 	}
 	if cluster.WorkloadAutoScalerProfile != nil {
-		workloadAutoScalerProfile_ARM, err := (*cluster.WorkloadAutoScalerProfile).ConvertToARM(resolved)
+		workloadAutoScalerProfile_ARM, err := cluster.WorkloadAutoScalerProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -718,7 +718,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Sku":
 	if cluster.Sku != nil {
-		sku_ARM, err := (*cluster.Sku).ConvertToARM(resolved)
+		sku_ARM, err := cluster.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3771,7 +3771,7 @@ func (settings *ClusterUpgradeSettings) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "OverrideSettings":
 	if settings.OverrideSettings != nil {
-		overrideSettings_ARM, err := (*settings.OverrideSettings).ConvertToARM(resolved)
+		overrideSettings_ARM, err := settings.OverrideSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3966,7 +3966,7 @@ func (profile *ContainerServiceLinuxProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Ssh":
 	if profile.Ssh != nil {
-		ssh_ARM, err := (*profile.Ssh).ConvertToARM(resolved)
+		ssh_ARM, err := profile.Ssh.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4242,7 +4242,7 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "LoadBalancerProfile":
 	if profile.LoadBalancerProfile != nil {
-		loadBalancerProfile_ARM, err := (*profile.LoadBalancerProfile).ConvertToARM(resolved)
+		loadBalancerProfile_ARM, err := profile.LoadBalancerProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4260,7 +4260,7 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "NatGatewayProfile":
 	if profile.NatGatewayProfile != nil {
-		natGatewayProfile_ARM, err := (*profile.NatGatewayProfile).ConvertToARM(resolved)
+		natGatewayProfile_ARM, err := profile.NatGatewayProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6190,7 +6190,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "CreationData":
 	if profile.CreationData != nil {
-		creationData_ARM, err := (*profile.CreationData).ConvertToARM(resolved)
+		creationData_ARM, err := profile.CreationData.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6248,7 +6248,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "KubeletConfig":
 	if profile.KubeletConfig != nil {
-		kubeletConfig_ARM, err := (*profile.KubeletConfig).ConvertToARM(resolved)
+		kubeletConfig_ARM, err := profile.KubeletConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6266,7 +6266,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "LinuxOSConfig":
 	if profile.LinuxOSConfig != nil {
-		linuxOSConfig_ARM, err := (*profile.LinuxOSConfig).ConvertToARM(resolved)
+		linuxOSConfig_ARM, err := profile.LinuxOSConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6308,7 +6308,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "NetworkProfile":
 	if profile.NetworkProfile != nil {
-		networkProfile_ARM, err := (*profile.NetworkProfile).ConvertToARM(resolved)
+		networkProfile_ARM, err := profile.NetworkProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6394,7 +6394,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "PowerState":
 	if profile.PowerState != nil {
-		powerState_ARM, err := (*profile.PowerState).ConvertToARM(resolved)
+		powerState_ARM, err := profile.PowerState.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6463,7 +6463,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "UpgradeSettings":
 	if profile.UpgradeSettings != nil {
-		upgradeSettings_ARM, err := (*profile.UpgradeSettings).ConvertToARM(resolved)
+		upgradeSettings_ARM, err := profile.UpgradeSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9100,7 +9100,7 @@ func (profile *ManagedClusterAzureMonitorProfile) ConvertToARM(resolved genrunti
 
 	// Set property "Metrics":
 	if profile.Metrics != nil {
-		metrics_ARM, err := (*profile.Metrics).ConvertToARM(resolved)
+		metrics_ARM, err := profile.Metrics.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11490,7 +11490,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 
 	// Set property "AzureKeyVaultKms":
 	if profile.AzureKeyVaultKms != nil {
-		azureKeyVaultKms_ARM, err := (*profile.AzureKeyVaultKms).ConvertToARM(resolved)
+		azureKeyVaultKms_ARM, err := profile.AzureKeyVaultKms.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11500,7 +11500,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 
 	// Set property "Defender":
 	if profile.Defender != nil {
-		defender_ARM, err := (*profile.Defender).ConvertToARM(resolved)
+		defender_ARM, err := profile.Defender.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11510,7 +11510,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 
 	// Set property "ImageCleaner":
 	if profile.ImageCleaner != nil {
-		imageCleaner_ARM, err := (*profile.ImageCleaner).ConvertToARM(resolved)
+		imageCleaner_ARM, err := profile.ImageCleaner.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11520,7 +11520,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 
 	// Set property "WorkloadIdentity":
 	if profile.WorkloadIdentity != nil {
-		workloadIdentity_ARM, err := (*profile.WorkloadIdentity).ConvertToARM(resolved)
+		workloadIdentity_ARM, err := profile.WorkloadIdentity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12325,7 +12325,7 @@ func (profile *ManagedClusterStorageProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "BlobCSIDriver":
 	if profile.BlobCSIDriver != nil {
-		blobCSIDriver_ARM, err := (*profile.BlobCSIDriver).ConvertToARM(resolved)
+		blobCSIDriver_ARM, err := profile.BlobCSIDriver.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12335,7 +12335,7 @@ func (profile *ManagedClusterStorageProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "DiskCSIDriver":
 	if profile.DiskCSIDriver != nil {
-		diskCSIDriver_ARM, err := (*profile.DiskCSIDriver).ConvertToARM(resolved)
+		diskCSIDriver_ARM, err := profile.DiskCSIDriver.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12345,7 +12345,7 @@ func (profile *ManagedClusterStorageProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "FileCSIDriver":
 	if profile.FileCSIDriver != nil {
-		fileCSIDriver_ARM, err := (*profile.FileCSIDriver).ConvertToARM(resolved)
+		fileCSIDriver_ARM, err := profile.FileCSIDriver.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12355,7 +12355,7 @@ func (profile *ManagedClusterStorageProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "SnapshotController":
 	if profile.SnapshotController != nil {
-		snapshotController_ARM, err := (*profile.SnapshotController).ConvertToARM(resolved)
+		snapshotController_ARM, err := profile.SnapshotController.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12809,7 +12809,7 @@ func (profile *ManagedClusterWindowsProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "GmsaProfile":
 	if profile.GmsaProfile != nil {
-		gmsaProfile_ARM, err := (*profile.GmsaProfile).ConvertToARM(resolved)
+		gmsaProfile_ARM, err := profile.GmsaProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -13156,7 +13156,7 @@ func (profile *ManagedClusterWorkloadAutoScalerProfile) ConvertToARM(resolved ge
 
 	// Set property "Keda":
 	if profile.Keda != nil {
-		keda_ARM, err := (*profile.Keda).ConvertToARM(resolved)
+		keda_ARM, err := profile.Keda.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -13166,7 +13166,7 @@ func (profile *ManagedClusterWorkloadAutoScalerProfile) ConvertToARM(resolved ge
 
 	// Set property "VerticalPodAutoscaler":
 	if profile.VerticalPodAutoscaler != nil {
-		verticalPodAutoscaler_ARM, err := (*profile.VerticalPodAutoscaler).ConvertToARM(resolved)
+		verticalPodAutoscaler_ARM, err := profile.VerticalPodAutoscaler.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -13797,7 +13797,7 @@ func (profile *ServiceMeshProfile) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Istio":
 	if profile.Istio != nil {
-		istio_ARM, err := (*profile.Istio).ConvertToARM(resolved)
+		istio_ARM, err := profile.Istio.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15423,7 +15423,7 @@ func (mesh *IstioServiceMesh) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "CertificateAuthority":
 	if mesh.CertificateAuthority != nil {
-		certificateAuthority_ARM, err := (*mesh.CertificateAuthority).ConvertToARM(resolved)
+		certificateAuthority_ARM, err := mesh.CertificateAuthority.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15433,7 +15433,7 @@ func (mesh *IstioServiceMesh) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "Components":
 	if mesh.Components != nil {
-		components_ARM, err := (*mesh.Components).ConvertToARM(resolved)
+		components_ARM, err := mesh.Components.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15807,7 +15807,7 @@ func (metrics *ManagedClusterAzureMonitorProfileMetrics) ConvertToARM(resolved g
 
 	// Set property "KubeStateMetrics":
 	if metrics.KubeStateMetrics != nil {
-		kubeStateMetrics_ARM, err := (*metrics.KubeStateMetrics).ConvertToARM(resolved)
+		kubeStateMetrics_ARM, err := metrics.KubeStateMetrics.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -16208,7 +16208,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 
 	// Set property "ManagedOutboundIPs":
 	if profile.ManagedOutboundIPs != nil {
-		managedOutboundIPs_ARM, err := (*profile.ManagedOutboundIPs).ConvertToARM(resolved)
+		managedOutboundIPs_ARM, err := profile.ManagedOutboundIPs.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -16218,7 +16218,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 
 	// Set property "OutboundIPPrefixes":
 	if profile.OutboundIPPrefixes != nil {
-		outboundIPPrefixes_ARM, err := (*profile.OutboundIPPrefixes).ConvertToARM(resolved)
+		outboundIPPrefixes_ARM, err := profile.OutboundIPPrefixes.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -16228,7 +16228,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 
 	// Set property "OutboundIPs":
 	if profile.OutboundIPs != nil {
-		outboundIPs_ARM, err := (*profile.OutboundIPs).ConvertToARM(resolved)
+		outboundIPs_ARM, err := profile.OutboundIPs.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -16832,7 +16832,7 @@ func (profile *ManagedClusterNATGatewayProfile) ConvertToARM(resolved genruntime
 
 	// Set property "ManagedOutboundIPProfile":
 	if profile.ManagedOutboundIPProfile != nil {
-		managedOutboundIPProfile_ARM, err := (*profile.ManagedOutboundIPProfile).ConvertToARM(resolved)
+		managedOutboundIPProfile_ARM, err := profile.ManagedOutboundIPProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -17285,7 +17285,7 @@ func (identity *ManagedClusterPodIdentity) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "Identity":
 	if identity.Identity != nil {
-		identity_ARM, err := (*identity.Identity).ConvertToARM(resolved)
+		identity_ARM, err := identity.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -17891,7 +17891,7 @@ func (defender *ManagedClusterSecurityProfileDefender) ConvertToARM(resolved gen
 
 	// Set property "SecurityMonitoring":
 	if defender.SecurityMonitoring != nil {
-		securityMonitoring_ARM, err := (*defender.SecurityMonitoring).ConvertToARM(resolved)
+		securityMonitoring_ARM, err := defender.SecurityMonitoring.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -20162,7 +20162,7 @@ func (authority *IstioCertificateAuthority) ConvertToARM(resolved genruntime.Con
 
 	// Set property "Plugin":
 	if authority.Plugin != nil {
-		plugin_ARM, err := (*authority.Plugin).ConvertToARM(resolved)
+		plugin_ARM, err := authority.Plugin.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/containerservice/v1api20231001/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/containerservice/v1api20231001/managed_clusters_agent_pool_types_gen.go
@@ -493,7 +493,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.Count = &count
 	}
 	if pool.CreationData != nil {
-		creationData_ARM, err := (*pool.CreationData).ConvertToARM(resolved)
+		creationData_ARM, err := pool.CreationData.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -535,7 +535,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.HostGroupID = &hostGroupID
 	}
 	if pool.KubeletConfig != nil {
-		kubeletConfig_ARM, err := (*pool.KubeletConfig).ConvertToARM(resolved)
+		kubeletConfig_ARM, err := pool.KubeletConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -549,7 +549,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.KubeletDiskType = &kubeletDiskType
 	}
 	if pool.LinuxOSConfig != nil {
-		linuxOSConfig_ARM, err := (*pool.LinuxOSConfig).ConvertToARM(resolved)
+		linuxOSConfig_ARM, err := pool.LinuxOSConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -575,7 +575,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.Mode = &mode
 	}
 	if pool.NetworkProfile != nil {
-		networkProfile_ARM, err := (*pool.NetworkProfile).ConvertToARM(resolved)
+		networkProfile_ARM, err := pool.NetworkProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -641,7 +641,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.PodSubnetID = &podSubnetID
 	}
 	if pool.PowerState != nil {
-		powerState_ARM, err := (*pool.PowerState).ConvertToARM(resolved)
+		powerState_ARM, err := pool.PowerState.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -694,7 +694,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.Type = &typeVar
 	}
 	if pool.UpgradeSettings != nil {
-		upgradeSettings_ARM, err := (*pool.UpgradeSettings).ConvertToARM(resolved)
+		upgradeSettings_ARM, err := pool.UpgradeSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4555,7 +4555,7 @@ func (config *LinuxOSConfig) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Sysctls":
 	if config.Sysctls != nil {
-		sysctls_ARM, err := (*config.Sysctls).ConvertToARM(resolved)
+		sysctls_ARM, err := config.Sysctls.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/containerservice/v1api20231102preview/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1api20231102preview/managed_cluster_types_gen.go
@@ -348,7 +348,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "ExtendedLocation":
 	if cluster.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*cluster.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := cluster.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -358,7 +358,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Identity":
 	if cluster.Identity != nil {
-		identity_ARM, err := (*cluster.Identity).ConvertToARM(resolved)
+		identity_ARM, err := cluster.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -418,7 +418,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties = &arm.ManagedClusterProperties{}
 	}
 	if cluster.AadProfile != nil {
-		aadProfile_ARM, err := (*cluster.AadProfile).ConvertToARM(resolved)
+		aadProfile_ARM, err := cluster.AadProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -443,7 +443,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AgentPoolProfiles = append(result.Properties.AgentPoolProfiles, *item_ARM.(*arm.ManagedClusterAgentPoolProfile))
 	}
 	if cluster.AiToolchainOperatorProfile != nil {
-		aiToolchainOperatorProfile_ARM, err := (*cluster.AiToolchainOperatorProfile).ConvertToARM(resolved)
+		aiToolchainOperatorProfile_ARM, err := cluster.AiToolchainOperatorProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -451,7 +451,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AiToolchainOperatorProfile = &aiToolchainOperatorProfile
 	}
 	if cluster.ApiServerAccessProfile != nil {
-		apiServerAccessProfile_ARM, err := (*cluster.ApiServerAccessProfile).ConvertToARM(resolved)
+		apiServerAccessProfile_ARM, err := cluster.ApiServerAccessProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -459,7 +459,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.ApiServerAccessProfile = &apiServerAccessProfile
 	}
 	if cluster.AutoScalerProfile != nil {
-		autoScalerProfile_ARM, err := (*cluster.AutoScalerProfile).ConvertToARM(resolved)
+		autoScalerProfile_ARM, err := cluster.AutoScalerProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -467,7 +467,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AutoScalerProfile = &autoScalerProfile
 	}
 	if cluster.AutoUpgradeProfile != nil {
-		autoUpgradeProfile_ARM, err := (*cluster.AutoUpgradeProfile).ConvertToARM(resolved)
+		autoUpgradeProfile_ARM, err := cluster.AutoUpgradeProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -475,7 +475,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AutoUpgradeProfile = &autoUpgradeProfile
 	}
 	if cluster.AzureMonitorProfile != nil {
-		azureMonitorProfile_ARM, err := (*cluster.AzureMonitorProfile).ConvertToARM(resolved)
+		azureMonitorProfile_ARM, err := cluster.AzureMonitorProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -483,7 +483,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AzureMonitorProfile = &azureMonitorProfile
 	}
 	if cluster.CreationData != nil {
-		creationData_ARM, err := (*cluster.CreationData).ConvertToARM(resolved)
+		creationData_ARM, err := cluster.CreationData.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -523,7 +523,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.FqdnSubdomain = &fqdnSubdomain
 	}
 	if cluster.HttpProxyConfig != nil {
-		httpProxyConfig_ARM, err := (*cluster.HttpProxyConfig).ConvertToARM(resolved)
+		httpProxyConfig_ARM, err := cluster.HttpProxyConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -541,7 +541,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		}
 	}
 	if cluster.IngressProfile != nil {
-		ingressProfile_ARM, err := (*cluster.IngressProfile).ConvertToARM(resolved)
+		ingressProfile_ARM, err := cluster.IngressProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -553,7 +553,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.KubernetesVersion = &kubernetesVersion
 	}
 	if cluster.LinuxProfile != nil {
-		linuxProfile_ARM, err := (*cluster.LinuxProfile).ConvertToARM(resolved)
+		linuxProfile_ARM, err := cluster.LinuxProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -561,7 +561,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.LinuxProfile = &linuxProfile
 	}
 	if cluster.MetricsProfile != nil {
-		metricsProfile_ARM, err := (*cluster.MetricsProfile).ConvertToARM(resolved)
+		metricsProfile_ARM, err := cluster.MetricsProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -569,7 +569,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.MetricsProfile = &metricsProfile
 	}
 	if cluster.NetworkProfile != nil {
-		networkProfile_ARM, err := (*cluster.NetworkProfile).ConvertToARM(resolved)
+		networkProfile_ARM, err := cluster.NetworkProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -577,7 +577,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.NetworkProfile = &networkProfile
 	}
 	if cluster.NodeProvisioningProfile != nil {
-		nodeProvisioningProfile_ARM, err := (*cluster.NodeProvisioningProfile).ConvertToARM(resolved)
+		nodeProvisioningProfile_ARM, err := cluster.NodeProvisioningProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -589,7 +589,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.NodeResourceGroup = &nodeResourceGroup
 	}
 	if cluster.NodeResourceGroupProfile != nil {
-		nodeResourceGroupProfile_ARM, err := (*cluster.NodeResourceGroupProfile).ConvertToARM(resolved)
+		nodeResourceGroupProfile_ARM, err := cluster.NodeResourceGroupProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -597,7 +597,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.NodeResourceGroupProfile = &nodeResourceGroupProfile
 	}
 	if cluster.OidcIssuerProfile != nil {
-		oidcIssuerProfile_ARM, err := (*cluster.OidcIssuerProfile).ConvertToARM(resolved)
+		oidcIssuerProfile_ARM, err := cluster.OidcIssuerProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -605,7 +605,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.OidcIssuerProfile = &oidcIssuerProfile
 	}
 	if cluster.PodIdentityProfile != nil {
-		podIdentityProfile_ARM, err := (*cluster.PodIdentityProfile).ConvertToARM(resolved)
+		podIdentityProfile_ARM, err := cluster.PodIdentityProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -626,7 +626,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.PublicNetworkAccess = &publicNetworkAccess
 	}
 	if cluster.SafeguardsProfile != nil {
-		safeguardsProfile_ARM, err := (*cluster.SafeguardsProfile).ConvertToARM(resolved)
+		safeguardsProfile_ARM, err := cluster.SafeguardsProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -634,7 +634,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.SafeguardsProfile = &safeguardsProfile
 	}
 	if cluster.SecurityProfile != nil {
-		securityProfile_ARM, err := (*cluster.SecurityProfile).ConvertToARM(resolved)
+		securityProfile_ARM, err := cluster.SecurityProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -642,7 +642,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.SecurityProfile = &securityProfile
 	}
 	if cluster.ServiceMeshProfile != nil {
-		serviceMeshProfile_ARM, err := (*cluster.ServiceMeshProfile).ConvertToARM(resolved)
+		serviceMeshProfile_ARM, err := cluster.ServiceMeshProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -650,7 +650,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.ServiceMeshProfile = &serviceMeshProfile
 	}
 	if cluster.ServicePrincipalProfile != nil {
-		servicePrincipalProfile_ARM, err := (*cluster.ServicePrincipalProfile).ConvertToARM(resolved)
+		servicePrincipalProfile_ARM, err := cluster.ServicePrincipalProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -658,7 +658,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.ServicePrincipalProfile = &servicePrincipalProfile
 	}
 	if cluster.StorageProfile != nil {
-		storageProfile_ARM, err := (*cluster.StorageProfile).ConvertToARM(resolved)
+		storageProfile_ARM, err := cluster.StorageProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -672,7 +672,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.SupportPlan = &supportPlan
 	}
 	if cluster.UpgradeSettings != nil {
-		upgradeSettings_ARM, err := (*cluster.UpgradeSettings).ConvertToARM(resolved)
+		upgradeSettings_ARM, err := cluster.UpgradeSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -680,7 +680,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.UpgradeSettings = &upgradeSettings
 	}
 	if cluster.WindowsProfile != nil {
-		windowsProfile_ARM, err := (*cluster.WindowsProfile).ConvertToARM(resolved)
+		windowsProfile_ARM, err := cluster.WindowsProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -688,7 +688,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.WindowsProfile = &windowsProfile
 	}
 	if cluster.WorkloadAutoScalerProfile != nil {
-		workloadAutoScalerProfile_ARM, err := (*cluster.WorkloadAutoScalerProfile).ConvertToARM(resolved)
+		workloadAutoScalerProfile_ARM, err := cluster.WorkloadAutoScalerProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -698,7 +698,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Sku":
 	if cluster.Sku != nil {
-		sku_ARM, err := (*cluster.Sku).ConvertToARM(resolved)
+		sku_ARM, err := cluster.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4224,7 +4224,7 @@ func (settings *ClusterUpgradeSettings) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "OverrideSettings":
 	if settings.OverrideSettings != nil {
-		overrideSettings_ARM, err := (*settings.OverrideSettings).ConvertToARM(resolved)
+		overrideSettings_ARM, err := settings.OverrideSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4414,7 +4414,7 @@ func (profile *ContainerServiceLinuxProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Ssh":
 	if profile.Ssh != nil {
-		ssh_ARM, err := (*profile.Ssh).ConvertToARM(resolved)
+		ssh_ARM, err := profile.Ssh.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4652,7 +4652,7 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "KubeProxyConfig":
 	if profile.KubeProxyConfig != nil {
-		kubeProxyConfig_ARM, err := (*profile.KubeProxyConfig).ConvertToARM(resolved)
+		kubeProxyConfig_ARM, err := profile.KubeProxyConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4662,7 +4662,7 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "LoadBalancerProfile":
 	if profile.LoadBalancerProfile != nil {
-		loadBalancerProfile_ARM, err := (*profile.LoadBalancerProfile).ConvertToARM(resolved)
+		loadBalancerProfile_ARM, err := profile.LoadBalancerProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4680,7 +4680,7 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "Monitoring":
 	if profile.Monitoring != nil {
-		monitoring_ARM, err := (*profile.Monitoring).ConvertToARM(resolved)
+		monitoring_ARM, err := profile.Monitoring.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4690,7 +4690,7 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "NatGatewayProfile":
 	if profile.NatGatewayProfile != nil {
-		natGatewayProfile_ARM, err := (*profile.NatGatewayProfile).ConvertToARM(resolved)
+		natGatewayProfile_ARM, err := profile.NatGatewayProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6687,7 +6687,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "ArtifactStreamingProfile":
 	if profile.ArtifactStreamingProfile != nil {
-		artifactStreamingProfile_ARM, err := (*profile.ArtifactStreamingProfile).ConvertToARM(resolved)
+		artifactStreamingProfile_ARM, err := profile.ArtifactStreamingProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6718,7 +6718,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "CreationData":
 	if profile.CreationData != nil {
-		creationData_ARM, err := (*profile.CreationData).ConvertToARM(resolved)
+		creationData_ARM, err := profile.CreationData.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6772,7 +6772,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "GpuProfile":
 	if profile.GpuProfile != nil {
-		gpuProfile_ARM, err := (*profile.GpuProfile).ConvertToARM(resolved)
+		gpuProfile_ARM, err := profile.GpuProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6792,7 +6792,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "KubeletConfig":
 	if profile.KubeletConfig != nil {
-		kubeletConfig_ARM, err := (*profile.KubeletConfig).ConvertToARM(resolved)
+		kubeletConfig_ARM, err := profile.KubeletConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6810,7 +6810,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "LinuxOSConfig":
 	if profile.LinuxOSConfig != nil {
-		linuxOSConfig_ARM, err := (*profile.LinuxOSConfig).ConvertToARM(resolved)
+		linuxOSConfig_ARM, err := profile.LinuxOSConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6858,7 +6858,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "NetworkProfile":
 	if profile.NetworkProfile != nil {
-		networkProfile_ARM, err := (*profile.NetworkProfile).ConvertToARM(resolved)
+		networkProfile_ARM, err := profile.NetworkProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6949,7 +6949,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "PowerState":
 	if profile.PowerState != nil {
-		powerState_ARM, err := (*profile.PowerState).ConvertToARM(resolved)
+		powerState_ARM, err := profile.PowerState.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6993,7 +6993,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "SecurityProfile":
 	if profile.SecurityProfile != nil {
-		securityProfile_ARM, err := (*profile.SecurityProfile).ConvertToARM(resolved)
+		securityProfile_ARM, err := profile.SecurityProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7028,7 +7028,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "UpgradeSettings":
 	if profile.UpgradeSettings != nil {
-		upgradeSettings_ARM, err := (*profile.UpgradeSettings).ConvertToARM(resolved)
+		upgradeSettings_ARM, err := profile.UpgradeSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7047,7 +7047,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "VirtualMachinesProfile":
 	if profile.VirtualMachinesProfile != nil {
-		virtualMachinesProfile_ARM, err := (*profile.VirtualMachinesProfile).ConvertToARM(resolved)
+		virtualMachinesProfile_ARM, err := profile.VirtualMachinesProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7073,7 +7073,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "WindowsProfile":
 	if profile.WindowsProfile != nil {
-		windowsProfile_ARM, err := (*profile.WindowsProfile).ConvertToARM(resolved)
+		windowsProfile_ARM, err := profile.WindowsProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10301,7 +10301,7 @@ func (profile *ManagedClusterAzureMonitorProfile) ConvertToARM(resolved genrunti
 
 	// Set property "Logs":
 	if profile.Logs != nil {
-		logs_ARM, err := (*profile.Logs).ConvertToARM(resolved)
+		logs_ARM, err := profile.Logs.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10311,7 +10311,7 @@ func (profile *ManagedClusterAzureMonitorProfile) ConvertToARM(resolved genrunti
 
 	// Set property "Metrics":
 	if profile.Metrics != nil {
-		metrics_ARM, err := (*profile.Metrics).ConvertToARM(resolved)
+		metrics_ARM, err := profile.Metrics.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11190,7 +11190,7 @@ func (profile *ManagedClusterIngressProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "WebAppRouting":
 	if profile.WebAppRouting != nil {
-		webAppRouting_ARM, err := (*profile.WebAppRouting).ConvertToARM(resolved)
+		webAppRouting_ARM, err := profile.WebAppRouting.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11369,7 +11369,7 @@ func (profile *ManagedClusterMetricsProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "CostAnalysis":
 	if profile.CostAnalysis != nil {
-		costAnalysis_ARM, err := (*profile.CostAnalysis).ConvertToARM(resolved)
+		costAnalysis_ARM, err := profile.CostAnalysis.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -13451,7 +13451,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 
 	// Set property "AzureKeyVaultKms":
 	if profile.AzureKeyVaultKms != nil {
-		azureKeyVaultKms_ARM, err := (*profile.AzureKeyVaultKms).ConvertToARM(resolved)
+		azureKeyVaultKms_ARM, err := profile.AzureKeyVaultKms.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -13468,7 +13468,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 
 	// Set property "Defender":
 	if profile.Defender != nil {
-		defender_ARM, err := (*profile.Defender).ConvertToARM(resolved)
+		defender_ARM, err := profile.Defender.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -13478,7 +13478,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 
 	// Set property "ImageCleaner":
 	if profile.ImageCleaner != nil {
-		imageCleaner_ARM, err := (*profile.ImageCleaner).ConvertToARM(resolved)
+		imageCleaner_ARM, err := profile.ImageCleaner.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -13488,7 +13488,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 
 	// Set property "ImageIntegrity":
 	if profile.ImageIntegrity != nil {
-		imageIntegrity_ARM, err := (*profile.ImageIntegrity).ConvertToARM(resolved)
+		imageIntegrity_ARM, err := profile.ImageIntegrity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -13498,7 +13498,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 
 	// Set property "NodeRestriction":
 	if profile.NodeRestriction != nil {
-		nodeRestriction_ARM, err := (*profile.NodeRestriction).ConvertToARM(resolved)
+		nodeRestriction_ARM, err := profile.NodeRestriction.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -13508,7 +13508,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 
 	// Set property "WorkloadIdentity":
 	if profile.WorkloadIdentity != nil {
-		workloadIdentity_ARM, err := (*profile.WorkloadIdentity).ConvertToARM(resolved)
+		workloadIdentity_ARM, err := profile.WorkloadIdentity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -14446,7 +14446,7 @@ func (profile *ManagedClusterStorageProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "BlobCSIDriver":
 	if profile.BlobCSIDriver != nil {
-		blobCSIDriver_ARM, err := (*profile.BlobCSIDriver).ConvertToARM(resolved)
+		blobCSIDriver_ARM, err := profile.BlobCSIDriver.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -14456,7 +14456,7 @@ func (profile *ManagedClusterStorageProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "DiskCSIDriver":
 	if profile.DiskCSIDriver != nil {
-		diskCSIDriver_ARM, err := (*profile.DiskCSIDriver).ConvertToARM(resolved)
+		diskCSIDriver_ARM, err := profile.DiskCSIDriver.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -14466,7 +14466,7 @@ func (profile *ManagedClusterStorageProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "FileCSIDriver":
 	if profile.FileCSIDriver != nil {
-		fileCSIDriver_ARM, err := (*profile.FileCSIDriver).ConvertToARM(resolved)
+		fileCSIDriver_ARM, err := profile.FileCSIDriver.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -14476,7 +14476,7 @@ func (profile *ManagedClusterStorageProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "SnapshotController":
 	if profile.SnapshotController != nil {
-		snapshotController_ARM, err := (*profile.SnapshotController).ConvertToARM(resolved)
+		snapshotController_ARM, err := profile.SnapshotController.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -14896,7 +14896,7 @@ func (profile *ManagedClusterWindowsProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "GmsaProfile":
 	if profile.GmsaProfile != nil {
-		gmsaProfile_ARM, err := (*profile.GmsaProfile).ConvertToARM(resolved)
+		gmsaProfile_ARM, err := profile.GmsaProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15223,7 +15223,7 @@ func (profile *ManagedClusterWorkloadAutoScalerProfile) ConvertToARM(resolved ge
 
 	// Set property "Keda":
 	if profile.Keda != nil {
-		keda_ARM, err := (*profile.Keda).ConvertToARM(resolved)
+		keda_ARM, err := profile.Keda.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15233,7 +15233,7 @@ func (profile *ManagedClusterWorkloadAutoScalerProfile) ConvertToARM(resolved ge
 
 	// Set property "VerticalPodAutoscaler":
 	if profile.VerticalPodAutoscaler != nil {
-		verticalPodAutoscaler_ARM, err := (*profile.VerticalPodAutoscaler).ConvertToARM(resolved)
+		verticalPodAutoscaler_ARM, err := profile.VerticalPodAutoscaler.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -16065,7 +16065,7 @@ func (profile *ServiceMeshProfile) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Istio":
 	if profile.Istio != nil {
-		istio_ARM, err := (*profile.Istio).ConvertToARM(resolved)
+		istio_ARM, err := profile.Istio.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -16945,7 +16945,7 @@ func (config *ContainerServiceNetworkProfile_KubeProxyConfig) ConvertToARM(resol
 
 	// Set property "IpvsConfig":
 	if config.IpvsConfig != nil {
-		ipvsConfig_ARM, err := (*config.IpvsConfig).ConvertToARM(resolved)
+		ipvsConfig_ARM, err := config.IpvsConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -17786,7 +17786,7 @@ func (mesh *IstioServiceMesh) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "CertificateAuthority":
 	if mesh.CertificateAuthority != nil {
-		certificateAuthority_ARM, err := (*mesh.CertificateAuthority).ConvertToARM(resolved)
+		certificateAuthority_ARM, err := mesh.CertificateAuthority.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -17796,7 +17796,7 @@ func (mesh *IstioServiceMesh) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "Components":
 	if mesh.Components != nil {
-		components_ARM, err := (*mesh.Components).ConvertToARM(resolved)
+		components_ARM, err := mesh.Components.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -18176,7 +18176,7 @@ func (logs *ManagedClusterAzureMonitorProfileLogs) ConvertToARM(resolved genrunt
 
 	// Set property "AppMonitoring":
 	if logs.AppMonitoring != nil {
-		appMonitoring_ARM, err := (*logs.AppMonitoring).ConvertToARM(resolved)
+		appMonitoring_ARM, err := logs.AppMonitoring.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -18186,7 +18186,7 @@ func (logs *ManagedClusterAzureMonitorProfileLogs) ConvertToARM(resolved genrunt
 
 	// Set property "ContainerInsights":
 	if logs.ContainerInsights != nil {
-		containerInsights_ARM, err := (*logs.ContainerInsights).ConvertToARM(resolved)
+		containerInsights_ARM, err := logs.ContainerInsights.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -18440,7 +18440,7 @@ func (metrics *ManagedClusterAzureMonitorProfileMetrics) ConvertToARM(resolved g
 
 	// Set property "AppMonitoringOpenTelemetryMetrics":
 	if metrics.AppMonitoringOpenTelemetryMetrics != nil {
-		appMonitoringOpenTelemetryMetrics_ARM, err := (*metrics.AppMonitoringOpenTelemetryMetrics).ConvertToARM(resolved)
+		appMonitoringOpenTelemetryMetrics_ARM, err := metrics.AppMonitoringOpenTelemetryMetrics.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -18456,7 +18456,7 @@ func (metrics *ManagedClusterAzureMonitorProfileMetrics) ConvertToARM(resolved g
 
 	// Set property "KubeStateMetrics":
 	if metrics.KubeStateMetrics != nil {
-		kubeStateMetrics_ARM, err := (*metrics.KubeStateMetrics).ConvertToARM(resolved)
+		kubeStateMetrics_ARM, err := metrics.KubeStateMetrics.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -19283,7 +19283,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 
 	// Set property "ManagedOutboundIPs":
 	if profile.ManagedOutboundIPs != nil {
-		managedOutboundIPs_ARM, err := (*profile.ManagedOutboundIPs).ConvertToARM(resolved)
+		managedOutboundIPs_ARM, err := profile.ManagedOutboundIPs.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -19293,7 +19293,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 
 	// Set property "OutboundIPPrefixes":
 	if profile.OutboundIPPrefixes != nil {
-		outboundIPPrefixes_ARM, err := (*profile.OutboundIPPrefixes).ConvertToARM(resolved)
+		outboundIPPrefixes_ARM, err := profile.OutboundIPPrefixes.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -19303,7 +19303,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 
 	// Set property "OutboundIPs":
 	if profile.OutboundIPs != nil {
-		outboundIPs_ARM, err := (*profile.OutboundIPs).ConvertToARM(resolved)
+		outboundIPs_ARM, err := profile.OutboundIPs.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -19883,7 +19883,7 @@ func (profile *ManagedClusterNATGatewayProfile) ConvertToARM(resolved genruntime
 
 	// Set property "ManagedOutboundIPProfile":
 	if profile.ManagedOutboundIPProfile != nil {
-		managedOutboundIPProfile_ARM, err := (*profile.ManagedOutboundIPProfile).ConvertToARM(resolved)
+		managedOutboundIPProfile_ARM, err := profile.ManagedOutboundIPProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -20359,7 +20359,7 @@ func (identity *ManagedClusterPodIdentity) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "Identity":
 	if identity.Identity != nil {
-		identity_ARM, err := (*identity.Identity).ConvertToARM(resolved)
+		identity_ARM, err := identity.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -20906,7 +20906,7 @@ func (defender *ManagedClusterSecurityProfileDefender) ConvertToARM(resolved gen
 
 	// Set property "SecurityMonitoring":
 	if defender.SecurityMonitoring != nil {
-		securityMonitoring_ARM, err := (*defender.SecurityMonitoring).ConvertToARM(resolved)
+		securityMonitoring_ARM, err := defender.SecurityMonitoring.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -24067,7 +24067,7 @@ func (authority *IstioCertificateAuthority) ConvertToARM(resolved genruntime.Con
 
 	// Set property "Plugin":
 	if authority.Plugin != nil {
-		plugin_ARM, err := (*authority.Plugin).ConvertToARM(resolved)
+		plugin_ARM, err := authority.Plugin.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -24865,7 +24865,7 @@ func (insights *ManagedClusterAzureMonitorProfileContainerInsights) ConvertToARM
 
 	// Set property "WindowsHostLogs":
 	if insights.WindowsHostLogs != nil {
-		windowsHostLogs_ARM, err := (*insights.WindowsHostLogs).ConvertToARM(resolved)
+		windowsHostLogs_ARM, err := insights.WindowsHostLogs.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/containerservice/v1api20231102preview/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/containerservice/v1api20231102preview/managed_clusters_agent_pool_types_gen.go
@@ -520,7 +520,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties = &arm.ManagedClusterAgentPoolProfileProperties{}
 	}
 	if pool.ArtifactStreamingProfile != nil {
-		artifactStreamingProfile_ARM, err := (*pool.ArtifactStreamingProfile).ConvertToARM(resolved)
+		artifactStreamingProfile_ARM, err := pool.ArtifactStreamingProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -543,7 +543,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.Count = &count
 	}
 	if pool.CreationData != nil {
-		creationData_ARM, err := (*pool.CreationData).ConvertToARM(resolved)
+		creationData_ARM, err := pool.CreationData.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -581,7 +581,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.GpuInstanceProfile = &gpuInstanceProfile
 	}
 	if pool.GpuProfile != nil {
-		gpuProfile_ARM, err := (*pool.GpuProfile).ConvertToARM(resolved)
+		gpuProfile_ARM, err := pool.GpuProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -597,7 +597,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.HostGroupID = &hostGroupID
 	}
 	if pool.KubeletConfig != nil {
-		kubeletConfig_ARM, err := (*pool.KubeletConfig).ConvertToARM(resolved)
+		kubeletConfig_ARM, err := pool.KubeletConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -611,7 +611,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.KubeletDiskType = &kubeletDiskType
 	}
 	if pool.LinuxOSConfig != nil {
-		linuxOSConfig_ARM, err := (*pool.LinuxOSConfig).ConvertToARM(resolved)
+		linuxOSConfig_ARM, err := pool.LinuxOSConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -641,7 +641,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.Mode = &mode
 	}
 	if pool.NetworkProfile != nil {
-		networkProfile_ARM, err := (*pool.NetworkProfile).ConvertToARM(resolved)
+		networkProfile_ARM, err := pool.NetworkProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -710,7 +710,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.PodSubnetID = &podSubnetID
 	}
 	if pool.PowerState != nil {
-		powerState_ARM, err := (*pool.PowerState).ConvertToARM(resolved)
+		powerState_ARM, err := pool.PowerState.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -744,7 +744,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.ScaleSetPriority = &scaleSetPriority
 	}
 	if pool.SecurityProfile != nil {
-		securityProfile_ARM, err := (*pool.SecurityProfile).ConvertToARM(resolved)
+		securityProfile_ARM, err := pool.SecurityProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -771,7 +771,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.Type = &typeVar
 	}
 	if pool.UpgradeSettings != nil {
-		upgradeSettings_ARM, err := (*pool.UpgradeSettings).ConvertToARM(resolved)
+		upgradeSettings_ARM, err := pool.UpgradeSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -786,7 +786,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.VirtualMachineNodesStatus = append(result.Properties.VirtualMachineNodesStatus, *item_ARM.(*arm.VirtualMachineNodes))
 	}
 	if pool.VirtualMachinesProfile != nil {
-		virtualMachinesProfile_ARM, err := (*pool.VirtualMachinesProfile).ConvertToARM(resolved)
+		virtualMachinesProfile_ARM, err := pool.VirtualMachinesProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -806,7 +806,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.VnetSubnetID = &vnetSubnetID
 	}
 	if pool.WindowsProfile != nil {
-		windowsProfile_ARM, err := (*pool.WindowsProfile).ConvertToARM(resolved)
+		windowsProfile_ARM, err := pool.WindowsProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5770,7 +5770,7 @@ func (config *LinuxOSConfig) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Sysctls":
 	if config.Sysctls != nil {
-		sysctls_ARM, err := (*config.Sysctls).ConvertToARM(resolved)
+		sysctls_ARM, err := config.Sysctls.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6570,7 +6570,7 @@ func (profile *VirtualMachinesProfile) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "Scale":
 	if profile.Scale != nil {
-		scale_ARM, err := (*profile.Scale).ConvertToARM(resolved)
+		scale_ARM, err := profile.Scale.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/containerservice/v1api20240402preview/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1api20240402preview/managed_cluster_types_gen.go
@@ -459,7 +459,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "ExtendedLocation":
 	if cluster.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*cluster.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := cluster.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -469,7 +469,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Identity":
 	if cluster.Identity != nil {
-		identity_ARM, err := (*cluster.Identity).ConvertToARM(resolved)
+		identity_ARM, err := cluster.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -536,7 +536,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties = &arm.ManagedClusterProperties{}
 	}
 	if cluster.AadProfile != nil {
-		aadProfile_ARM, err := (*cluster.AadProfile).ConvertToARM(resolved)
+		aadProfile_ARM, err := cluster.AadProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -561,7 +561,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AgentPoolProfiles = append(result.Properties.AgentPoolProfiles, *item_ARM.(*arm.ManagedClusterAgentPoolProfile))
 	}
 	if cluster.AiToolchainOperatorProfile != nil {
-		aiToolchainOperatorProfile_ARM, err := (*cluster.AiToolchainOperatorProfile).ConvertToARM(resolved)
+		aiToolchainOperatorProfile_ARM, err := cluster.AiToolchainOperatorProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -569,7 +569,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AiToolchainOperatorProfile = &aiToolchainOperatorProfile
 	}
 	if cluster.ApiServerAccessProfile != nil {
-		apiServerAccessProfile_ARM, err := (*cluster.ApiServerAccessProfile).ConvertToARM(resolved)
+		apiServerAccessProfile_ARM, err := cluster.ApiServerAccessProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -577,7 +577,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.ApiServerAccessProfile = &apiServerAccessProfile
 	}
 	if cluster.AutoScalerProfile != nil {
-		autoScalerProfile_ARM, err := (*cluster.AutoScalerProfile).ConvertToARM(resolved)
+		autoScalerProfile_ARM, err := cluster.AutoScalerProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -585,7 +585,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AutoScalerProfile = &autoScalerProfile
 	}
 	if cluster.AutoUpgradeProfile != nil {
-		autoUpgradeProfile_ARM, err := (*cluster.AutoUpgradeProfile).ConvertToARM(resolved)
+		autoUpgradeProfile_ARM, err := cluster.AutoUpgradeProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -593,7 +593,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AutoUpgradeProfile = &autoUpgradeProfile
 	}
 	if cluster.AzureMonitorProfile != nil {
-		azureMonitorProfile_ARM, err := (*cluster.AzureMonitorProfile).ConvertToARM(resolved)
+		azureMonitorProfile_ARM, err := cluster.AzureMonitorProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -601,7 +601,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AzureMonitorProfile = &azureMonitorProfile
 	}
 	if cluster.BootstrapProfile != nil {
-		bootstrapProfile_ARM, err := (*cluster.BootstrapProfile).ConvertToARM(resolved)
+		bootstrapProfile_ARM, err := cluster.BootstrapProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -609,7 +609,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.BootstrapProfile = &bootstrapProfile
 	}
 	if cluster.CreationData != nil {
-		creationData_ARM, err := (*cluster.CreationData).ConvertToARM(resolved)
+		creationData_ARM, err := cluster.CreationData.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -649,7 +649,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.FqdnSubdomain = &fqdnSubdomain
 	}
 	if cluster.HttpProxyConfig != nil {
-		httpProxyConfig_ARM, err := (*cluster.HttpProxyConfig).ConvertToARM(resolved)
+		httpProxyConfig_ARM, err := cluster.HttpProxyConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -667,7 +667,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		}
 	}
 	if cluster.IngressProfile != nil {
-		ingressProfile_ARM, err := (*cluster.IngressProfile).ConvertToARM(resolved)
+		ingressProfile_ARM, err := cluster.IngressProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -679,7 +679,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.KubernetesVersion = &kubernetesVersion
 	}
 	if cluster.LinuxProfile != nil {
-		linuxProfile_ARM, err := (*cluster.LinuxProfile).ConvertToARM(resolved)
+		linuxProfile_ARM, err := cluster.LinuxProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -687,7 +687,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.LinuxProfile = &linuxProfile
 	}
 	if cluster.MetricsProfile != nil {
-		metricsProfile_ARM, err := (*cluster.MetricsProfile).ConvertToARM(resolved)
+		metricsProfile_ARM, err := cluster.MetricsProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -695,7 +695,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.MetricsProfile = &metricsProfile
 	}
 	if cluster.NetworkProfile != nil {
-		networkProfile_ARM, err := (*cluster.NetworkProfile).ConvertToARM(resolved)
+		networkProfile_ARM, err := cluster.NetworkProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -703,7 +703,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.NetworkProfile = &networkProfile
 	}
 	if cluster.NodeProvisioningProfile != nil {
-		nodeProvisioningProfile_ARM, err := (*cluster.NodeProvisioningProfile).ConvertToARM(resolved)
+		nodeProvisioningProfile_ARM, err := cluster.NodeProvisioningProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -715,7 +715,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.NodeResourceGroup = &nodeResourceGroup
 	}
 	if cluster.NodeResourceGroupProfile != nil {
-		nodeResourceGroupProfile_ARM, err := (*cluster.NodeResourceGroupProfile).ConvertToARM(resolved)
+		nodeResourceGroupProfile_ARM, err := cluster.NodeResourceGroupProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -723,7 +723,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.NodeResourceGroupProfile = &nodeResourceGroupProfile
 	}
 	if cluster.OidcIssuerProfile != nil {
-		oidcIssuerProfile_ARM, err := (*cluster.OidcIssuerProfile).ConvertToARM(resolved)
+		oidcIssuerProfile_ARM, err := cluster.OidcIssuerProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -731,7 +731,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.OidcIssuerProfile = &oidcIssuerProfile
 	}
 	if cluster.PodIdentityProfile != nil {
-		podIdentityProfile_ARM, err := (*cluster.PodIdentityProfile).ConvertToARM(resolved)
+		podIdentityProfile_ARM, err := cluster.PodIdentityProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -752,7 +752,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.PublicNetworkAccess = &publicNetworkAccess
 	}
 	if cluster.SafeguardsProfile != nil {
-		safeguardsProfile_ARM, err := (*cluster.SafeguardsProfile).ConvertToARM(resolved)
+		safeguardsProfile_ARM, err := cluster.SafeguardsProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -760,7 +760,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.SafeguardsProfile = &safeguardsProfile
 	}
 	if cluster.SecurityProfile != nil {
-		securityProfile_ARM, err := (*cluster.SecurityProfile).ConvertToARM(resolved)
+		securityProfile_ARM, err := cluster.SecurityProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -768,7 +768,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.SecurityProfile = &securityProfile
 	}
 	if cluster.ServiceMeshProfile != nil {
-		serviceMeshProfile_ARM, err := (*cluster.ServiceMeshProfile).ConvertToARM(resolved)
+		serviceMeshProfile_ARM, err := cluster.ServiceMeshProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -776,7 +776,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.ServiceMeshProfile = &serviceMeshProfile
 	}
 	if cluster.ServicePrincipalProfile != nil {
-		servicePrincipalProfile_ARM, err := (*cluster.ServicePrincipalProfile).ConvertToARM(resolved)
+		servicePrincipalProfile_ARM, err := cluster.ServicePrincipalProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -784,7 +784,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.ServicePrincipalProfile = &servicePrincipalProfile
 	}
 	if cluster.StorageProfile != nil {
-		storageProfile_ARM, err := (*cluster.StorageProfile).ConvertToARM(resolved)
+		storageProfile_ARM, err := cluster.StorageProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -798,7 +798,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.SupportPlan = &supportPlan
 	}
 	if cluster.UpgradeSettings != nil {
-		upgradeSettings_ARM, err := (*cluster.UpgradeSettings).ConvertToARM(resolved)
+		upgradeSettings_ARM, err := cluster.UpgradeSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -806,7 +806,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.UpgradeSettings = &upgradeSettings
 	}
 	if cluster.WindowsProfile != nil {
-		windowsProfile_ARM, err := (*cluster.WindowsProfile).ConvertToARM(resolved)
+		windowsProfile_ARM, err := cluster.WindowsProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -814,7 +814,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.WindowsProfile = &windowsProfile
 	}
 	if cluster.WorkloadAutoScalerProfile != nil {
-		workloadAutoScalerProfile_ARM, err := (*cluster.WorkloadAutoScalerProfile).ConvertToARM(resolved)
+		workloadAutoScalerProfile_ARM, err := cluster.WorkloadAutoScalerProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -824,7 +824,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Sku":
 	if cluster.Sku != nil {
-		sku_ARM, err := (*cluster.Sku).ConvertToARM(resolved)
+		sku_ARM, err := cluster.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4604,7 +4604,7 @@ func (settings *ClusterUpgradeSettings) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "OverrideSettings":
 	if settings.OverrideSettings != nil {
-		overrideSettings_ARM, err := (*settings.OverrideSettings).ConvertToARM(resolved)
+		overrideSettings_ARM, err := settings.OverrideSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4799,7 +4799,7 @@ func (profile *ContainerServiceLinuxProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Ssh":
 	if profile.Ssh != nil {
-		ssh_ARM, err := (*profile.Ssh).ConvertToARM(resolved)
+		ssh_ARM, err := profile.Ssh.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5079,7 +5079,7 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "AdvancedNetworking":
 	if profile.AdvancedNetworking != nil {
-		advancedNetworking_ARM, err := (*profile.AdvancedNetworking).ConvertToARM(resolved)
+		advancedNetworking_ARM, err := profile.AdvancedNetworking.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5102,7 +5102,7 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "KubeProxyConfig":
 	if profile.KubeProxyConfig != nil {
-		kubeProxyConfig_ARM, err := (*profile.KubeProxyConfig).ConvertToARM(resolved)
+		kubeProxyConfig_ARM, err := profile.KubeProxyConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5112,7 +5112,7 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "LoadBalancerProfile":
 	if profile.LoadBalancerProfile != nil {
-		loadBalancerProfile_ARM, err := (*profile.LoadBalancerProfile).ConvertToARM(resolved)
+		loadBalancerProfile_ARM, err := profile.LoadBalancerProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5130,7 +5130,7 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "NatGatewayProfile":
 	if profile.NatGatewayProfile != nil {
-		natGatewayProfile_ARM, err := (*profile.NatGatewayProfile).ConvertToARM(resolved)
+		natGatewayProfile_ARM, err := profile.NatGatewayProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5218,7 +5218,7 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "StaticEgressGatewayProfile":
 	if profile.StaticEgressGatewayProfile != nil {
-		staticEgressGatewayProfile_ARM, err := (*profile.StaticEgressGatewayProfile).ConvertToARM(resolved)
+		staticEgressGatewayProfile_ARM, err := profile.StaticEgressGatewayProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7518,7 +7518,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "ArtifactStreamingProfile":
 	if profile.ArtifactStreamingProfile != nil {
-		artifactStreamingProfile_ARM, err := (*profile.ArtifactStreamingProfile).ConvertToARM(resolved)
+		artifactStreamingProfile_ARM, err := profile.ArtifactStreamingProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7549,7 +7549,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "CreationData":
 	if profile.CreationData != nil {
-		creationData_ARM, err := (*profile.CreationData).ConvertToARM(resolved)
+		creationData_ARM, err := profile.CreationData.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7595,7 +7595,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "GatewayProfile":
 	if profile.GatewayProfile != nil {
-		gatewayProfile_ARM, err := (*profile.GatewayProfile).ConvertToARM(resolved)
+		gatewayProfile_ARM, err := profile.GatewayProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7613,7 +7613,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "GpuProfile":
 	if profile.GpuProfile != nil {
-		gpuProfile_ARM, err := (*profile.GpuProfile).ConvertToARM(resolved)
+		gpuProfile_ARM, err := profile.GpuProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7633,7 +7633,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "KubeletConfig":
 	if profile.KubeletConfig != nil {
-		kubeletConfig_ARM, err := (*profile.KubeletConfig).ConvertToARM(resolved)
+		kubeletConfig_ARM, err := profile.KubeletConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7651,7 +7651,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "LinuxOSConfig":
 	if profile.LinuxOSConfig != nil {
-		linuxOSConfig_ARM, err := (*profile.LinuxOSConfig).ConvertToARM(resolved)
+		linuxOSConfig_ARM, err := profile.LinuxOSConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7699,7 +7699,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "NetworkProfile":
 	if profile.NetworkProfile != nil {
-		networkProfile_ARM, err := (*profile.NetworkProfile).ConvertToARM(resolved)
+		networkProfile_ARM, err := profile.NetworkProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7798,7 +7798,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "PowerState":
 	if profile.PowerState != nil {
-		powerState_ARM, err := (*profile.PowerState).ConvertToARM(resolved)
+		powerState_ARM, err := profile.PowerState.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7842,7 +7842,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "SecurityProfile":
 	if profile.SecurityProfile != nil {
-		securityProfile_ARM, err := (*profile.SecurityProfile).ConvertToARM(resolved)
+		securityProfile_ARM, err := profile.SecurityProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7877,7 +7877,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "UpgradeSettings":
 	if profile.UpgradeSettings != nil {
-		upgradeSettings_ARM, err := (*profile.UpgradeSettings).ConvertToARM(resolved)
+		upgradeSettings_ARM, err := profile.UpgradeSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7896,7 +7896,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "VirtualMachinesProfile":
 	if profile.VirtualMachinesProfile != nil {
-		virtualMachinesProfile_ARM, err := (*profile.VirtualMachinesProfile).ConvertToARM(resolved)
+		virtualMachinesProfile_ARM, err := profile.VirtualMachinesProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7922,7 +7922,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "WindowsProfile":
 	if profile.WindowsProfile != nil {
-		windowsProfile_ARM, err := (*profile.WindowsProfile).ConvertToARM(resolved)
+		windowsProfile_ARM, err := profile.WindowsProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11511,7 +11511,7 @@ func (profile *ManagedClusterAzureMonitorProfile) ConvertToARM(resolved genrunti
 
 	// Set property "AppMonitoring":
 	if profile.AppMonitoring != nil {
-		appMonitoring_ARM, err := (*profile.AppMonitoring).ConvertToARM(resolved)
+		appMonitoring_ARM, err := profile.AppMonitoring.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11521,7 +11521,7 @@ func (profile *ManagedClusterAzureMonitorProfile) ConvertToARM(resolved genrunti
 
 	// Set property "ContainerInsights":
 	if profile.ContainerInsights != nil {
-		containerInsights_ARM, err := (*profile.ContainerInsights).ConvertToARM(resolved)
+		containerInsights_ARM, err := profile.ContainerInsights.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11531,7 +11531,7 @@ func (profile *ManagedClusterAzureMonitorProfile) ConvertToARM(resolved genrunti
 
 	// Set property "Metrics":
 	if profile.Metrics != nil {
-		metrics_ARM, err := (*profile.Metrics).ConvertToARM(resolved)
+		metrics_ARM, err := profile.Metrics.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12742,7 +12742,7 @@ func (profile *ManagedClusterIngressProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "WebAppRouting":
 	if profile.WebAppRouting != nil {
-		webAppRouting_ARM, err := (*profile.WebAppRouting).ConvertToARM(resolved)
+		webAppRouting_ARM, err := profile.WebAppRouting.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12925,7 +12925,7 @@ func (profile *ManagedClusterMetricsProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "CostAnalysis":
 	if profile.CostAnalysis != nil {
-		costAnalysis_ARM, err := (*profile.CostAnalysis).ConvertToARM(resolved)
+		costAnalysis_ARM, err := profile.CostAnalysis.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15171,7 +15171,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 
 	// Set property "AzureKeyVaultKms":
 	if profile.AzureKeyVaultKms != nil {
-		azureKeyVaultKms_ARM, err := (*profile.AzureKeyVaultKms).ConvertToARM(resolved)
+		azureKeyVaultKms_ARM, err := profile.AzureKeyVaultKms.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15188,7 +15188,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 
 	// Set property "Defender":
 	if profile.Defender != nil {
-		defender_ARM, err := (*profile.Defender).ConvertToARM(resolved)
+		defender_ARM, err := profile.Defender.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15198,7 +15198,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 
 	// Set property "ImageCleaner":
 	if profile.ImageCleaner != nil {
-		imageCleaner_ARM, err := (*profile.ImageCleaner).ConvertToARM(resolved)
+		imageCleaner_ARM, err := profile.ImageCleaner.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15208,7 +15208,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 
 	// Set property "ImageIntegrity":
 	if profile.ImageIntegrity != nil {
-		imageIntegrity_ARM, err := (*profile.ImageIntegrity).ConvertToARM(resolved)
+		imageIntegrity_ARM, err := profile.ImageIntegrity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15218,7 +15218,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 
 	// Set property "NodeRestriction":
 	if profile.NodeRestriction != nil {
-		nodeRestriction_ARM, err := (*profile.NodeRestriction).ConvertToARM(resolved)
+		nodeRestriction_ARM, err := profile.NodeRestriction.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15228,7 +15228,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 
 	// Set property "WorkloadIdentity":
 	if profile.WorkloadIdentity != nil {
-		workloadIdentity_ARM, err := (*profile.WorkloadIdentity).ConvertToARM(resolved)
+		workloadIdentity_ARM, err := profile.WorkloadIdentity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -16212,7 +16212,7 @@ func (profile *ManagedClusterStorageProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "BlobCSIDriver":
 	if profile.BlobCSIDriver != nil {
-		blobCSIDriver_ARM, err := (*profile.BlobCSIDriver).ConvertToARM(resolved)
+		blobCSIDriver_ARM, err := profile.BlobCSIDriver.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -16222,7 +16222,7 @@ func (profile *ManagedClusterStorageProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "DiskCSIDriver":
 	if profile.DiskCSIDriver != nil {
-		diskCSIDriver_ARM, err := (*profile.DiskCSIDriver).ConvertToARM(resolved)
+		diskCSIDriver_ARM, err := profile.DiskCSIDriver.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -16232,7 +16232,7 @@ func (profile *ManagedClusterStorageProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "FileCSIDriver":
 	if profile.FileCSIDriver != nil {
-		fileCSIDriver_ARM, err := (*profile.FileCSIDriver).ConvertToARM(resolved)
+		fileCSIDriver_ARM, err := profile.FileCSIDriver.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -16242,7 +16242,7 @@ func (profile *ManagedClusterStorageProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "SnapshotController":
 	if profile.SnapshotController != nil {
-		snapshotController_ARM, err := (*profile.SnapshotController).ConvertToARM(resolved)
+		snapshotController_ARM, err := profile.SnapshotController.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -16696,7 +16696,7 @@ func (profile *ManagedClusterWindowsProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "GmsaProfile":
 	if profile.GmsaProfile != nil {
-		gmsaProfile_ARM, err := (*profile.GmsaProfile).ConvertToARM(resolved)
+		gmsaProfile_ARM, err := profile.GmsaProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -17041,7 +17041,7 @@ func (profile *ManagedClusterWorkloadAutoScalerProfile) ConvertToARM(resolved ge
 
 	// Set property "Keda":
 	if profile.Keda != nil {
-		keda_ARM, err := (*profile.Keda).ConvertToARM(resolved)
+		keda_ARM, err := profile.Keda.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -17051,7 +17051,7 @@ func (profile *ManagedClusterWorkloadAutoScalerProfile) ConvertToARM(resolved ge
 
 	// Set property "VerticalPodAutoscaler":
 	if profile.VerticalPodAutoscaler != nil {
-		verticalPodAutoscaler_ARM, err := (*profile.VerticalPodAutoscaler).ConvertToARM(resolved)
+		verticalPodAutoscaler_ARM, err := profile.VerticalPodAutoscaler.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -17927,7 +17927,7 @@ func (profile *ServiceMeshProfile) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Istio":
 	if profile.Istio != nil {
-		istio_ARM, err := (*profile.Istio).ConvertToARM(resolved)
+		istio_ARM, err := profile.Istio.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -18547,7 +18547,7 @@ func (networking *AdvancedNetworking) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "Observability":
 	if networking.Observability != nil {
-		observability_ARM, err := (*networking.Observability).ConvertToARM(resolved)
+		observability_ARM, err := networking.Observability.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -19054,7 +19054,7 @@ func (config *ContainerServiceNetworkProfile_KubeProxyConfig) ConvertToARM(resol
 
 	// Set property "IpvsConfig":
 	if config.IpvsConfig != nil {
-		ipvsConfig_ARM, err := (*config.IpvsConfig).ConvertToARM(resolved)
+		ipvsConfig_ARM, err := config.IpvsConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -19942,7 +19942,7 @@ func (mesh *IstioServiceMesh) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "CertificateAuthority":
 	if mesh.CertificateAuthority != nil {
-		certificateAuthority_ARM, err := (*mesh.CertificateAuthority).ConvertToARM(resolved)
+		certificateAuthority_ARM, err := mesh.CertificateAuthority.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -19952,7 +19952,7 @@ func (mesh *IstioServiceMesh) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "Components":
 	if mesh.Components != nil {
-		components_ARM, err := (*mesh.Components).ConvertToARM(resolved)
+		components_ARM, err := mesh.Components.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -20360,7 +20360,7 @@ func (monitoring *ManagedClusterAzureMonitorProfileAppMonitoring) ConvertToARM(r
 
 	// Set property "AutoInstrumentation":
 	if monitoring.AutoInstrumentation != nil {
-		autoInstrumentation_ARM, err := (*monitoring.AutoInstrumentation).ConvertToARM(resolved)
+		autoInstrumentation_ARM, err := monitoring.AutoInstrumentation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -20370,7 +20370,7 @@ func (monitoring *ManagedClusterAzureMonitorProfileAppMonitoring) ConvertToARM(r
 
 	// Set property "OpenTelemetryLogs":
 	if monitoring.OpenTelemetryLogs != nil {
-		openTelemetryLogs_ARM, err := (*monitoring.OpenTelemetryLogs).ConvertToARM(resolved)
+		openTelemetryLogs_ARM, err := monitoring.OpenTelemetryLogs.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -20380,7 +20380,7 @@ func (monitoring *ManagedClusterAzureMonitorProfileAppMonitoring) ConvertToARM(r
 
 	// Set property "OpenTelemetryMetrics":
 	if monitoring.OpenTelemetryMetrics != nil {
-		openTelemetryMetrics_ARM, err := (*monitoring.OpenTelemetryMetrics).ConvertToARM(resolved)
+		openTelemetryMetrics_ARM, err := monitoring.OpenTelemetryMetrics.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -21086,7 +21086,7 @@ func (metrics *ManagedClusterAzureMonitorProfileMetrics) ConvertToARM(resolved g
 
 	// Set property "KubeStateMetrics":
 	if metrics.KubeStateMetrics != nil {
-		kubeStateMetrics_ARM, err := (*metrics.KubeStateMetrics).ConvertToARM(resolved)
+		kubeStateMetrics_ARM, err := metrics.KubeStateMetrics.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -21929,7 +21929,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 
 	// Set property "ManagedOutboundIPs":
 	if profile.ManagedOutboundIPs != nil {
-		managedOutboundIPs_ARM, err := (*profile.ManagedOutboundIPs).ConvertToARM(resolved)
+		managedOutboundIPs_ARM, err := profile.ManagedOutboundIPs.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -21939,7 +21939,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 
 	// Set property "OutboundIPPrefixes":
 	if profile.OutboundIPPrefixes != nil {
-		outboundIPPrefixes_ARM, err := (*profile.OutboundIPPrefixes).ConvertToARM(resolved)
+		outboundIPPrefixes_ARM, err := profile.OutboundIPPrefixes.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -21949,7 +21949,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 
 	// Set property "OutboundIPs":
 	if profile.OutboundIPs != nil {
-		outboundIPs_ARM, err := (*profile.OutboundIPs).ConvertToARM(resolved)
+		outboundIPs_ARM, err := profile.OutboundIPs.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -22606,7 +22606,7 @@ func (profile *ManagedClusterNATGatewayProfile) ConvertToARM(resolved genruntime
 
 	// Set property "ManagedOutboundIPProfile":
 	if profile.ManagedOutboundIPProfile != nil {
-		managedOutboundIPProfile_ARM, err := (*profile.ManagedOutboundIPProfile).ConvertToARM(resolved)
+		managedOutboundIPProfile_ARM, err := profile.ManagedOutboundIPProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -23094,7 +23094,7 @@ func (identity *ManagedClusterPodIdentity) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "Identity":
 	if identity.Identity != nil {
-		identity_ARM, err := (*identity.Identity).ConvertToARM(resolved)
+		identity_ARM, err := identity.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -23669,7 +23669,7 @@ func (defender *ManagedClusterSecurityProfileDefender) ConvertToARM(resolved gen
 
 	// Set property "SecurityMonitoring":
 	if defender.SecurityMonitoring != nil {
-		securityMonitoring_ARM, err := (*defender.SecurityMonitoring).ConvertToARM(resolved)
+		securityMonitoring_ARM, err := defender.SecurityMonitoring.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -27149,7 +27149,7 @@ func (authority *IstioCertificateAuthority) ConvertToARM(resolved genruntime.Con
 
 	// Set property "Plugin":
 	if authority.Plugin != nil {
-		plugin_ARM, err := (*authority.Plugin).ConvertToARM(resolved)
+		plugin_ARM, err := authority.Plugin.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/containerservice/v1api20240402preview/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/containerservice/v1api20240402preview/managed_clusters_agent_pool_types_gen.go
@@ -530,7 +530,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties = &arm.ManagedClusterAgentPoolProfileProperties{}
 	}
 	if pool.ArtifactStreamingProfile != nil {
-		artifactStreamingProfile_ARM, err := (*pool.ArtifactStreamingProfile).ConvertToARM(resolved)
+		artifactStreamingProfile_ARM, err := pool.ArtifactStreamingProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -553,7 +553,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.Count = &count
 	}
 	if pool.CreationData != nil {
-		creationData_ARM, err := (*pool.CreationData).ConvertToARM(resolved)
+		creationData_ARM, err := pool.CreationData.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -585,7 +585,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.EnableUltraSSD = &enableUltraSSD
 	}
 	if pool.GatewayProfile != nil {
-		gatewayProfile_ARM, err := (*pool.GatewayProfile).ConvertToARM(resolved)
+		gatewayProfile_ARM, err := pool.GatewayProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -599,7 +599,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.GpuInstanceProfile = &gpuInstanceProfile
 	}
 	if pool.GpuProfile != nil {
-		gpuProfile_ARM, err := (*pool.GpuProfile).ConvertToARM(resolved)
+		gpuProfile_ARM, err := pool.GpuProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -615,7 +615,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.HostGroupID = &hostGroupID
 	}
 	if pool.KubeletConfig != nil {
-		kubeletConfig_ARM, err := (*pool.KubeletConfig).ConvertToARM(resolved)
+		kubeletConfig_ARM, err := pool.KubeletConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -629,7 +629,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.KubeletDiskType = &kubeletDiskType
 	}
 	if pool.LinuxOSConfig != nil {
-		linuxOSConfig_ARM, err := (*pool.LinuxOSConfig).ConvertToARM(resolved)
+		linuxOSConfig_ARM, err := pool.LinuxOSConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -659,7 +659,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.Mode = &mode
 	}
 	if pool.NetworkProfile != nil {
-		networkProfile_ARM, err := (*pool.NetworkProfile).ConvertToARM(resolved)
+		networkProfile_ARM, err := pool.NetworkProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -734,7 +734,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.PodSubnetID = &podSubnetID
 	}
 	if pool.PowerState != nil {
-		powerState_ARM, err := (*pool.PowerState).ConvertToARM(resolved)
+		powerState_ARM, err := pool.PowerState.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -768,7 +768,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.ScaleSetPriority = &scaleSetPriority
 	}
 	if pool.SecurityProfile != nil {
-		securityProfile_ARM, err := (*pool.SecurityProfile).ConvertToARM(resolved)
+		securityProfile_ARM, err := pool.SecurityProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -795,7 +795,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.Type = &typeVar
 	}
 	if pool.UpgradeSettings != nil {
-		upgradeSettings_ARM, err := (*pool.UpgradeSettings).ConvertToARM(resolved)
+		upgradeSettings_ARM, err := pool.UpgradeSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -810,7 +810,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.VirtualMachineNodesStatus = append(result.Properties.VirtualMachineNodesStatus, *item_ARM.(*arm.VirtualMachineNodes))
 	}
 	if pool.VirtualMachinesProfile != nil {
-		virtualMachinesProfile_ARM, err := (*pool.VirtualMachinesProfile).ConvertToARM(resolved)
+		virtualMachinesProfile_ARM, err := pool.VirtualMachinesProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -830,7 +830,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.VnetSubnetID = &vnetSubnetID
 	}
 	if pool.WindowsProfile != nil {
-		windowsProfile_ARM, err := (*pool.WindowsProfile).ConvertToARM(resolved)
+		windowsProfile_ARM, err := pool.WindowsProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6316,7 +6316,7 @@ func (config *LinuxOSConfig) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Sysctls":
 	if config.Sysctls != nil {
-		sysctls_ARM, err := (*config.Sysctls).ConvertToARM(resolved)
+		sysctls_ARM, err := config.Sysctls.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7191,7 +7191,7 @@ func (profile *VirtualMachinesProfile) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "Scale":
 	if profile.Scale != nil {
-		scale_ARM, err := (*profile.Scale).ConvertToARM(resolved)
+		scale_ARM, err := profile.Scale.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/containerservice/v1api20240901/maintenance_configuration_types_gen.go
+++ b/v2/api/containerservice/v1api20240901/maintenance_configuration_types_gen.go
@@ -296,7 +296,7 @@ func (configuration *MaintenanceConfiguration_Spec) ConvertToARM(resolved genrun
 		result.Properties = &arm.MaintenanceConfigurationProperties{}
 	}
 	if configuration.MaintenanceWindow != nil {
-		maintenanceWindow_ARM, err := (*configuration.MaintenanceWindow).ConvertToARM(resolved)
+		maintenanceWindow_ARM, err := configuration.MaintenanceWindow.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1166,7 +1166,7 @@ func (window *MaintenanceWindow) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Schedule":
 	if window.Schedule != nil {
-		schedule_ARM, err := (*window.Schedule).ConvertToARM(resolved)
+		schedule_ARM, err := window.Schedule.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2430,7 +2430,7 @@ func (schedule *Schedule) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "AbsoluteMonthly":
 	if schedule.AbsoluteMonthly != nil {
-		absoluteMonthly_ARM, err := (*schedule.AbsoluteMonthly).ConvertToARM(resolved)
+		absoluteMonthly_ARM, err := schedule.AbsoluteMonthly.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2440,7 +2440,7 @@ func (schedule *Schedule) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "Daily":
 	if schedule.Daily != nil {
-		daily_ARM, err := (*schedule.Daily).ConvertToARM(resolved)
+		daily_ARM, err := schedule.Daily.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2450,7 +2450,7 @@ func (schedule *Schedule) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "RelativeMonthly":
 	if schedule.RelativeMonthly != nil {
-		relativeMonthly_ARM, err := (*schedule.RelativeMonthly).ConvertToARM(resolved)
+		relativeMonthly_ARM, err := schedule.RelativeMonthly.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2460,7 +2460,7 @@ func (schedule *Schedule) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "Weekly":
 	if schedule.Weekly != nil {
-		weekly_ARM, err := (*schedule.Weekly).ConvertToARM(resolved)
+		weekly_ARM, err := schedule.Weekly.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/containerservice/v1api20240901/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1api20240901/managed_cluster_types_gen.go
@@ -432,7 +432,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "ExtendedLocation":
 	if cluster.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*cluster.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := cluster.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -442,7 +442,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Identity":
 	if cluster.Identity != nil {
-		identity_ARM, err := (*cluster.Identity).ConvertToARM(resolved)
+		identity_ARM, err := cluster.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -497,7 +497,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties = &arm.ManagedClusterProperties{}
 	}
 	if cluster.AadProfile != nil {
-		aadProfile_ARM, err := (*cluster.AadProfile).ConvertToARM(resolved)
+		aadProfile_ARM, err := cluster.AadProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -522,7 +522,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AgentPoolProfiles = append(result.Properties.AgentPoolProfiles, *item_ARM.(*arm.ManagedClusterAgentPoolProfile))
 	}
 	if cluster.ApiServerAccessProfile != nil {
-		apiServerAccessProfile_ARM, err := (*cluster.ApiServerAccessProfile).ConvertToARM(resolved)
+		apiServerAccessProfile_ARM, err := cluster.ApiServerAccessProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -530,7 +530,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.ApiServerAccessProfile = &apiServerAccessProfile
 	}
 	if cluster.AutoScalerProfile != nil {
-		autoScalerProfile_ARM, err := (*cluster.AutoScalerProfile).ConvertToARM(resolved)
+		autoScalerProfile_ARM, err := cluster.AutoScalerProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -538,7 +538,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AutoScalerProfile = &autoScalerProfile
 	}
 	if cluster.AutoUpgradeProfile != nil {
-		autoUpgradeProfile_ARM, err := (*cluster.AutoUpgradeProfile).ConvertToARM(resolved)
+		autoUpgradeProfile_ARM, err := cluster.AutoUpgradeProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -546,7 +546,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AutoUpgradeProfile = &autoUpgradeProfile
 	}
 	if cluster.AzureMonitorProfile != nil {
-		azureMonitorProfile_ARM, err := (*cluster.AzureMonitorProfile).ConvertToARM(resolved)
+		azureMonitorProfile_ARM, err := cluster.AzureMonitorProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -582,7 +582,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.FqdnSubdomain = &fqdnSubdomain
 	}
 	if cluster.HttpProxyConfig != nil {
-		httpProxyConfig_ARM, err := (*cluster.HttpProxyConfig).ConvertToARM(resolved)
+		httpProxyConfig_ARM, err := cluster.HttpProxyConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -600,7 +600,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		}
 	}
 	if cluster.IngressProfile != nil {
-		ingressProfile_ARM, err := (*cluster.IngressProfile).ConvertToARM(resolved)
+		ingressProfile_ARM, err := cluster.IngressProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -612,7 +612,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.KubernetesVersion = &kubernetesVersion
 	}
 	if cluster.LinuxProfile != nil {
-		linuxProfile_ARM, err := (*cluster.LinuxProfile).ConvertToARM(resolved)
+		linuxProfile_ARM, err := cluster.LinuxProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -620,7 +620,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.LinuxProfile = &linuxProfile
 	}
 	if cluster.MetricsProfile != nil {
-		metricsProfile_ARM, err := (*cluster.MetricsProfile).ConvertToARM(resolved)
+		metricsProfile_ARM, err := cluster.MetricsProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -628,7 +628,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.MetricsProfile = &metricsProfile
 	}
 	if cluster.NetworkProfile != nil {
-		networkProfile_ARM, err := (*cluster.NetworkProfile).ConvertToARM(resolved)
+		networkProfile_ARM, err := cluster.NetworkProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -640,7 +640,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.NodeResourceGroup = &nodeResourceGroup
 	}
 	if cluster.NodeResourceGroupProfile != nil {
-		nodeResourceGroupProfile_ARM, err := (*cluster.NodeResourceGroupProfile).ConvertToARM(resolved)
+		nodeResourceGroupProfile_ARM, err := cluster.NodeResourceGroupProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -648,7 +648,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.NodeResourceGroupProfile = &nodeResourceGroupProfile
 	}
 	if cluster.OidcIssuerProfile != nil {
-		oidcIssuerProfile_ARM, err := (*cluster.OidcIssuerProfile).ConvertToARM(resolved)
+		oidcIssuerProfile_ARM, err := cluster.OidcIssuerProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -656,7 +656,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.OidcIssuerProfile = &oidcIssuerProfile
 	}
 	if cluster.PodIdentityProfile != nil {
-		podIdentityProfile_ARM, err := (*cluster.PodIdentityProfile).ConvertToARM(resolved)
+		podIdentityProfile_ARM, err := cluster.PodIdentityProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -677,7 +677,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.PublicNetworkAccess = &publicNetworkAccess
 	}
 	if cluster.SecurityProfile != nil {
-		securityProfile_ARM, err := (*cluster.SecurityProfile).ConvertToARM(resolved)
+		securityProfile_ARM, err := cluster.SecurityProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -685,7 +685,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.SecurityProfile = &securityProfile
 	}
 	if cluster.ServiceMeshProfile != nil {
-		serviceMeshProfile_ARM, err := (*cluster.ServiceMeshProfile).ConvertToARM(resolved)
+		serviceMeshProfile_ARM, err := cluster.ServiceMeshProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -693,7 +693,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.ServiceMeshProfile = &serviceMeshProfile
 	}
 	if cluster.ServicePrincipalProfile != nil {
-		servicePrincipalProfile_ARM, err := (*cluster.ServicePrincipalProfile).ConvertToARM(resolved)
+		servicePrincipalProfile_ARM, err := cluster.ServicePrincipalProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -701,7 +701,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.ServicePrincipalProfile = &servicePrincipalProfile
 	}
 	if cluster.StorageProfile != nil {
-		storageProfile_ARM, err := (*cluster.StorageProfile).ConvertToARM(resolved)
+		storageProfile_ARM, err := cluster.StorageProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -715,7 +715,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.SupportPlan = &supportPlan
 	}
 	if cluster.UpgradeSettings != nil {
-		upgradeSettings_ARM, err := (*cluster.UpgradeSettings).ConvertToARM(resolved)
+		upgradeSettings_ARM, err := cluster.UpgradeSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -723,7 +723,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.UpgradeSettings = &upgradeSettings
 	}
 	if cluster.WindowsProfile != nil {
-		windowsProfile_ARM, err := (*cluster.WindowsProfile).ConvertToARM(resolved)
+		windowsProfile_ARM, err := cluster.WindowsProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -731,7 +731,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.WindowsProfile = &windowsProfile
 	}
 	if cluster.WorkloadAutoScalerProfile != nil {
-		workloadAutoScalerProfile_ARM, err := (*cluster.WorkloadAutoScalerProfile).ConvertToARM(resolved)
+		workloadAutoScalerProfile_ARM, err := cluster.WorkloadAutoScalerProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -741,7 +741,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Sku":
 	if cluster.Sku != nil {
-		sku_ARM, err := (*cluster.Sku).ConvertToARM(resolved)
+		sku_ARM, err := cluster.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4463,7 +4463,7 @@ func (settings *ClusterUpgradeSettings) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "OverrideSettings":
 	if settings.OverrideSettings != nil {
-		overrideSettings_ARM, err := (*settings.OverrideSettings).ConvertToARM(resolved)
+		overrideSettings_ARM, err := settings.OverrideSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4677,7 +4677,7 @@ func (profile *ContainerServiceLinuxProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Ssh":
 	if profile.Ssh != nil {
-		ssh_ARM, err := (*profile.Ssh).ConvertToARM(resolved)
+		ssh_ARM, err := profile.Ssh.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4966,7 +4966,7 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "AdvancedNetworking":
 	if profile.AdvancedNetworking != nil {
-		advancedNetworking_ARM, err := (*profile.AdvancedNetworking).ConvertToARM(resolved)
+		advancedNetworking_ARM, err := profile.AdvancedNetworking.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4989,7 +4989,7 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "LoadBalancerProfile":
 	if profile.LoadBalancerProfile != nil {
-		loadBalancerProfile_ARM, err := (*profile.LoadBalancerProfile).ConvertToARM(resolved)
+		loadBalancerProfile_ARM, err := profile.LoadBalancerProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5007,7 +5007,7 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "NatGatewayProfile":
 	if profile.NatGatewayProfile != nil {
-		natGatewayProfile_ARM, err := (*profile.NatGatewayProfile).ConvertToARM(resolved)
+		natGatewayProfile_ARM, err := profile.NatGatewayProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7219,7 +7219,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "CreationData":
 	if profile.CreationData != nil {
-		creationData_ARM, err := (*profile.CreationData).ConvertToARM(resolved)
+		creationData_ARM, err := profile.CreationData.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7277,7 +7277,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "KubeletConfig":
 	if profile.KubeletConfig != nil {
-		kubeletConfig_ARM, err := (*profile.KubeletConfig).ConvertToARM(resolved)
+		kubeletConfig_ARM, err := profile.KubeletConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7295,7 +7295,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "LinuxOSConfig":
 	if profile.LinuxOSConfig != nil {
-		linuxOSConfig_ARM, err := (*profile.LinuxOSConfig).ConvertToARM(resolved)
+		linuxOSConfig_ARM, err := profile.LinuxOSConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7337,7 +7337,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "NetworkProfile":
 	if profile.NetworkProfile != nil {
-		networkProfile_ARM, err := (*profile.NetworkProfile).ConvertToARM(resolved)
+		networkProfile_ARM, err := profile.NetworkProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7423,7 +7423,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "PowerState":
 	if profile.PowerState != nil {
-		powerState_ARM, err := (*profile.PowerState).ConvertToARM(resolved)
+		powerState_ARM, err := profile.PowerState.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7467,7 +7467,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "SecurityProfile":
 	if profile.SecurityProfile != nil {
-		securityProfile_ARM, err := (*profile.SecurityProfile).ConvertToARM(resolved)
+		securityProfile_ARM, err := profile.SecurityProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7502,7 +7502,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "UpgradeSettings":
 	if profile.UpgradeSettings != nil {
-		upgradeSettings_ARM, err := (*profile.UpgradeSettings).ConvertToARM(resolved)
+		upgradeSettings_ARM, err := profile.UpgradeSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7528,7 +7528,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "WindowsProfile":
 	if profile.WindowsProfile != nil {
-		windowsProfile_ARM, err := (*profile.WindowsProfile).ConvertToARM(resolved)
+		windowsProfile_ARM, err := profile.WindowsProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10652,7 +10652,7 @@ func (profile *ManagedClusterAzureMonitorProfile) ConvertToARM(resolved genrunti
 
 	// Set property "Metrics":
 	if profile.Metrics != nil {
-		metrics_ARM, err := (*profile.Metrics).ConvertToARM(resolved)
+		metrics_ARM, err := profile.Metrics.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11576,7 +11576,7 @@ func (profile *ManagedClusterIngressProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "WebAppRouting":
 	if profile.WebAppRouting != nil {
-		webAppRouting_ARM, err := (*profile.WebAppRouting).ConvertToARM(resolved)
+		webAppRouting_ARM, err := profile.WebAppRouting.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11779,7 +11779,7 @@ func (profile *ManagedClusterMetricsProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "CostAnalysis":
 	if profile.CostAnalysis != nil {
-		costAnalysis_ARM, err := (*profile.CostAnalysis).ConvertToARM(resolved)
+		costAnalysis_ARM, err := profile.CostAnalysis.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -14048,7 +14048,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 
 	// Set property "AzureKeyVaultKms":
 	if profile.AzureKeyVaultKms != nil {
-		azureKeyVaultKms_ARM, err := (*profile.AzureKeyVaultKms).ConvertToARM(resolved)
+		azureKeyVaultKms_ARM, err := profile.AzureKeyVaultKms.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -14058,7 +14058,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 
 	// Set property "Defender":
 	if profile.Defender != nil {
-		defender_ARM, err := (*profile.Defender).ConvertToARM(resolved)
+		defender_ARM, err := profile.Defender.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -14068,7 +14068,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 
 	// Set property "ImageCleaner":
 	if profile.ImageCleaner != nil {
-		imageCleaner_ARM, err := (*profile.ImageCleaner).ConvertToARM(resolved)
+		imageCleaner_ARM, err := profile.ImageCleaner.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -14078,7 +14078,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 
 	// Set property "WorkloadIdentity":
 	if profile.WorkloadIdentity != nil {
-		workloadIdentity_ARM, err := (*profile.WorkloadIdentity).ConvertToARM(resolved)
+		workloadIdentity_ARM, err := profile.WorkloadIdentity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -14971,7 +14971,7 @@ func (profile *ManagedClusterStorageProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "BlobCSIDriver":
 	if profile.BlobCSIDriver != nil {
-		blobCSIDriver_ARM, err := (*profile.BlobCSIDriver).ConvertToARM(resolved)
+		blobCSIDriver_ARM, err := profile.BlobCSIDriver.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -14981,7 +14981,7 @@ func (profile *ManagedClusterStorageProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "DiskCSIDriver":
 	if profile.DiskCSIDriver != nil {
-		diskCSIDriver_ARM, err := (*profile.DiskCSIDriver).ConvertToARM(resolved)
+		diskCSIDriver_ARM, err := profile.DiskCSIDriver.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -14991,7 +14991,7 @@ func (profile *ManagedClusterStorageProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "FileCSIDriver":
 	if profile.FileCSIDriver != nil {
-		fileCSIDriver_ARM, err := (*profile.FileCSIDriver).ConvertToARM(resolved)
+		fileCSIDriver_ARM, err := profile.FileCSIDriver.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15001,7 +15001,7 @@ func (profile *ManagedClusterStorageProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "SnapshotController":
 	if profile.SnapshotController != nil {
-		snapshotController_ARM, err := (*profile.SnapshotController).ConvertToARM(resolved)
+		snapshotController_ARM, err := profile.SnapshotController.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15510,7 +15510,7 @@ func (profile *ManagedClusterWindowsProfile) ConvertToARM(resolved genruntime.Co
 
 	// Set property "GmsaProfile":
 	if profile.GmsaProfile != nil {
-		gmsaProfile_ARM, err := (*profile.GmsaProfile).ConvertToARM(resolved)
+		gmsaProfile_ARM, err := profile.GmsaProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15895,7 +15895,7 @@ func (profile *ManagedClusterWorkloadAutoScalerProfile) ConvertToARM(resolved ge
 
 	// Set property "Keda":
 	if profile.Keda != nil {
-		keda_ARM, err := (*profile.Keda).ConvertToARM(resolved)
+		keda_ARM, err := profile.Keda.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15905,7 +15905,7 @@ func (profile *ManagedClusterWorkloadAutoScalerProfile) ConvertToARM(resolved ge
 
 	// Set property "VerticalPodAutoscaler":
 	if profile.VerticalPodAutoscaler != nil {
-		verticalPodAutoscaler_ARM, err := (*profile.VerticalPodAutoscaler).ConvertToARM(resolved)
+		verticalPodAutoscaler_ARM, err := profile.VerticalPodAutoscaler.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -16594,7 +16594,7 @@ func (profile *ServiceMeshProfile) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Istio":
 	if profile.Istio != nil {
-		istio_ARM, err := (*profile.Istio).ConvertToARM(resolved)
+		istio_ARM, err := profile.Istio.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -17116,7 +17116,7 @@ func (networking *AdvancedNetworking) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "Observability":
 	if networking.Observability != nil {
-		observability_ARM, err := (*networking.Observability).ConvertToARM(resolved)
+		observability_ARM, err := networking.Observability.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -17126,7 +17126,7 @@ func (networking *AdvancedNetworking) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "Security":
 	if networking.Security != nil {
-		security_ARM, err := (*networking.Security).ConvertToARM(resolved)
+		security_ARM, err := networking.Security.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -18581,7 +18581,7 @@ func (mesh *IstioServiceMesh) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "CertificateAuthority":
 	if mesh.CertificateAuthority != nil {
-		certificateAuthority_ARM, err := (*mesh.CertificateAuthority).ConvertToARM(resolved)
+		certificateAuthority_ARM, err := mesh.CertificateAuthority.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -18591,7 +18591,7 @@ func (mesh *IstioServiceMesh) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "Components":
 	if mesh.Components != nil {
-		components_ARM, err := (*mesh.Components).ConvertToARM(resolved)
+		components_ARM, err := mesh.Components.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -19003,7 +19003,7 @@ func (metrics *ManagedClusterAzureMonitorProfileMetrics) ConvertToARM(resolved g
 
 	// Set property "KubeStateMetrics":
 	if metrics.KubeStateMetrics != nil {
-		kubeStateMetrics_ARM, err := (*metrics.KubeStateMetrics).ConvertToARM(resolved)
+		kubeStateMetrics_ARM, err := metrics.KubeStateMetrics.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -19869,7 +19869,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 
 	// Set property "ManagedOutboundIPs":
 	if profile.ManagedOutboundIPs != nil {
-		managedOutboundIPs_ARM, err := (*profile.ManagedOutboundIPs).ConvertToARM(resolved)
+		managedOutboundIPs_ARM, err := profile.ManagedOutboundIPs.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -19879,7 +19879,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 
 	// Set property "OutboundIPPrefixes":
 	if profile.OutboundIPPrefixes != nil {
-		outboundIPPrefixes_ARM, err := (*profile.OutboundIPPrefixes).ConvertToARM(resolved)
+		outboundIPPrefixes_ARM, err := profile.OutboundIPPrefixes.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -19889,7 +19889,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 
 	// Set property "OutboundIPs":
 	if profile.OutboundIPs != nil {
-		outboundIPs_ARM, err := (*profile.OutboundIPs).ConvertToARM(resolved)
+		outboundIPs_ARM, err := profile.OutboundIPs.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -20576,7 +20576,7 @@ func (profile *ManagedClusterNATGatewayProfile) ConvertToARM(resolved genruntime
 
 	// Set property "ManagedOutboundIPProfile":
 	if profile.ManagedOutboundIPProfile != nil {
-		managedOutboundIPProfile_ARM, err := (*profile.ManagedOutboundIPProfile).ConvertToARM(resolved)
+		managedOutboundIPProfile_ARM, err := profile.ManagedOutboundIPProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -21077,7 +21077,7 @@ func (identity *ManagedClusterPodIdentity) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "Identity":
 	if identity.Identity != nil {
-		identity_ARM, err := (*identity.Identity).ConvertToARM(resolved)
+		identity_ARM, err := identity.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -21727,7 +21727,7 @@ func (defender *ManagedClusterSecurityProfileDefender) ConvertToARM(resolved gen
 
 	// Set property "SecurityMonitoring":
 	if defender.SecurityMonitoring != nil {
-		securityMonitoring_ARM, err := (*defender.SecurityMonitoring).ConvertToARM(resolved)
+		securityMonitoring_ARM, err := defender.SecurityMonitoring.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -24485,7 +24485,7 @@ func (authority *IstioCertificateAuthority) ConvertToARM(resolved genruntime.Con
 
 	// Set property "Plugin":
 	if authority.Plugin != nil {
-		plugin_ARM, err := (*authority.Plugin).ConvertToARM(resolved)
+		plugin_ARM, err := authority.Plugin.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/containerservice/v1api20240901/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/containerservice/v1api20240901/managed_clusters_agent_pool_types_gen.go
@@ -498,7 +498,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.Count = &count
 	}
 	if pool.CreationData != nil {
-		creationData_ARM, err := (*pool.CreationData).ConvertToARM(resolved)
+		creationData_ARM, err := pool.CreationData.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -540,7 +540,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.HostGroupID = &hostGroupID
 	}
 	if pool.KubeletConfig != nil {
-		kubeletConfig_ARM, err := (*pool.KubeletConfig).ConvertToARM(resolved)
+		kubeletConfig_ARM, err := pool.KubeletConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -554,7 +554,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.KubeletDiskType = &kubeletDiskType
 	}
 	if pool.LinuxOSConfig != nil {
-		linuxOSConfig_ARM, err := (*pool.LinuxOSConfig).ConvertToARM(resolved)
+		linuxOSConfig_ARM, err := pool.LinuxOSConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -580,7 +580,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.Mode = &mode
 	}
 	if pool.NetworkProfile != nil {
-		networkProfile_ARM, err := (*pool.NetworkProfile).ConvertToARM(resolved)
+		networkProfile_ARM, err := pool.NetworkProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -646,7 +646,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.PodSubnetID = &podSubnetID
 	}
 	if pool.PowerState != nil {
-		powerState_ARM, err := (*pool.PowerState).ConvertToARM(resolved)
+		powerState_ARM, err := pool.PowerState.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -680,7 +680,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.ScaleSetPriority = &scaleSetPriority
 	}
 	if pool.SecurityProfile != nil {
-		securityProfile_ARM, err := (*pool.SecurityProfile).ConvertToARM(resolved)
+		securityProfile_ARM, err := pool.SecurityProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -707,7 +707,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.Type = &typeVar
 	}
 	if pool.UpgradeSettings != nil {
-		upgradeSettings_ARM, err := (*pool.UpgradeSettings).ConvertToARM(resolved)
+		upgradeSettings_ARM, err := pool.UpgradeSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -727,7 +727,7 @@ func (pool *ManagedClustersAgentPool_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.VnetSubnetID = &vnetSubnetID
 	}
 	if pool.WindowsProfile != nil {
-		windowsProfile_ARM, err := (*pool.WindowsProfile).ConvertToARM(resolved)
+		windowsProfile_ARM, err := pool.WindowsProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5601,7 +5601,7 @@ func (config *LinuxOSConfig) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Sysctls":
 	if config.Sysctls != nil {
-		sysctls_ARM, err := (*config.Sysctls).ConvertToARM(resolved)
+		sysctls_ARM, err := config.Sysctls.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/datafactory/v1api20180601/factory_types_gen.go
+++ b/v2/api/datafactory/v1api20180601/factory_types_gen.go
@@ -316,7 +316,7 @@ func (factory *Factory_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Identity":
 	if factory.Identity != nil {
-		identity_ARM, err := (*factory.Identity).ConvertToARM(resolved)
+		identity_ARM, err := factory.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -342,7 +342,7 @@ func (factory *Factory_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties = &arm.FactoryProperties{}
 	}
 	if factory.Encryption != nil {
-		encryption_ARM, err := (*factory.Encryption).ConvertToARM(resolved)
+		encryption_ARM, err := factory.Encryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -366,7 +366,7 @@ func (factory *Factory_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.PublicNetworkAccess = &publicNetworkAccess
 	}
 	if factory.PurviewConfiguration != nil {
-		purviewConfiguration_ARM, err := (*factory.PurviewConfiguration).ConvertToARM(resolved)
+		purviewConfiguration_ARM, err := factory.PurviewConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -374,7 +374,7 @@ func (factory *Factory_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.PurviewConfiguration = &purviewConfiguration
 	}
 	if factory.RepoConfiguration != nil {
-		repoConfiguration_ARM, err := (*factory.RepoConfiguration).ConvertToARM(resolved)
+		repoConfiguration_ARM, err := factory.RepoConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1501,7 +1501,7 @@ func (configuration *EncryptionConfiguration) ConvertToARM(resolved genruntime.C
 
 	// Set property "Identity":
 	if configuration.Identity != nil {
-		identity_ARM, err := (*configuration.Identity).ConvertToARM(resolved)
+		identity_ARM, err := configuration.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2253,7 +2253,7 @@ func (configuration *FactoryRepoConfiguration) ConvertToARM(resolved genruntime.
 
 	// Set property "FactoryGitHub":
 	if configuration.FactoryGitHub != nil {
-		factoryGitHub_ARM, err := (*configuration.FactoryGitHub).ConvertToARM(resolved)
+		factoryGitHub_ARM, err := configuration.FactoryGitHub.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2263,7 +2263,7 @@ func (configuration *FactoryRepoConfiguration) ConvertToARM(resolved genruntime.
 
 	// Set property "FactoryVSTS":
 	if configuration.FactoryVSTS != nil {
-		factoryVSTS_ARM, err := (*configuration.FactoryVSTS).ConvertToARM(resolved)
+		factoryVSTS_ARM, err := configuration.FactoryVSTS.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3173,7 +3173,7 @@ func (configuration *FactoryGitHubConfiguration) ConvertToARM(resolved genruntim
 
 	// Set property "ClientSecret":
 	if configuration.ClientSecret != nil {
-		clientSecret_ARM, err := (*configuration.ClientSecret).ConvertToARM(resolved)
+		clientSecret_ARM, err := configuration.ClientSecret.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/dataprotection/v1api20230101/backup_vault_types_gen.go
+++ b/v2/api/dataprotection/v1api20230101/backup_vault_types_gen.go
@@ -317,7 +317,7 @@ func (vault *BackupVault_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "Identity":
 	if vault.Identity != nil {
-		identity_ARM, err := (*vault.Identity).ConvertToARM(resolved)
+		identity_ARM, err := vault.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -336,7 +336,7 @@ func (vault *BackupVault_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "Properties":
 	if vault.Properties != nil {
-		properties_ARM, err := (*vault.Properties).ConvertToARM(resolved)
+		properties_ARM, err := vault.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1402,7 +1402,7 @@ func (vault *BackupVaultSpec) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "FeatureSettings":
 	if vault.FeatureSettings != nil {
-		featureSettings_ARM, err := (*vault.FeatureSettings).ConvertToARM(resolved)
+		featureSettings_ARM, err := vault.FeatureSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1412,7 +1412,7 @@ func (vault *BackupVaultSpec) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "MonitoringSettings":
 	if vault.MonitoringSettings != nil {
-		monitoringSettings_ARM, err := (*vault.MonitoringSettings).ConvertToARM(resolved)
+		monitoringSettings_ARM, err := vault.MonitoringSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1422,7 +1422,7 @@ func (vault *BackupVaultSpec) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "SecuritySettings":
 	if vault.SecuritySettings != nil {
-		securitySettings_ARM, err := (*vault.SecuritySettings).ConvertToARM(resolved)
+		securitySettings_ARM, err := vault.SecuritySettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2064,7 +2064,7 @@ func (settings *FeatureSettings) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "CrossSubscriptionRestoreSettings":
 	if settings.CrossSubscriptionRestoreSettings != nil {
-		crossSubscriptionRestoreSettings_ARM, err := (*settings.CrossSubscriptionRestoreSettings).ConvertToARM(resolved)
+		crossSubscriptionRestoreSettings_ARM, err := settings.CrossSubscriptionRestoreSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2247,7 +2247,7 @@ func (settings *MonitoringSettings) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "AzureMonitorAlertSettings":
 	if settings.AzureMonitorAlertSettings != nil {
-		azureMonitorAlertSettings_ARM, err := (*settings.AzureMonitorAlertSettings).ConvertToARM(resolved)
+		azureMonitorAlertSettings_ARM, err := settings.AzureMonitorAlertSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2552,7 +2552,7 @@ func (settings *SecuritySettings) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "ImmutabilitySettings":
 	if settings.ImmutabilitySettings != nil {
-		immutabilitySettings_ARM, err := (*settings.ImmutabilitySettings).ConvertToARM(resolved)
+		immutabilitySettings_ARM, err := settings.ImmutabilitySettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2562,7 +2562,7 @@ func (settings *SecuritySettings) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "SoftDeleteSettings":
 	if settings.SoftDeleteSettings != nil {
-		softDeleteSettings_ARM, err := (*settings.SoftDeleteSettings).ConvertToARM(resolved)
+		softDeleteSettings_ARM, err := settings.SoftDeleteSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/dataprotection/v1api20230101/backup_vaults_backup_policy_types_gen.go
+++ b/v2/api/dataprotection/v1api20230101/backup_vaults_backup_policy_types_gen.go
@@ -282,7 +282,7 @@ func (policy *BackupVaultsBackupPolicy_Spec) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Properties":
 	if policy.Properties != nil {
-		properties_ARM, err := (*policy.Properties).ConvertToARM(resolved)
+		properties_ARM, err := policy.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -831,7 +831,7 @@ func (policy *BaseBackupPolicy) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "BackupPolicy":
 	if policy.BackupPolicy != nil {
-		backupPolicy_ARM, err := (*policy.BackupPolicy).ConvertToARM(resolved)
+		backupPolicy_ARM, err := policy.BackupPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1332,7 +1332,7 @@ func (rule *BasePolicyRule) ConvertToARM(resolved genruntime.ConvertToARMResolve
 
 	// Set property "AzureBackup":
 	if rule.AzureBackup != nil {
-		azureBackup_ARM, err := (*rule.AzureBackup).ConvertToARM(resolved)
+		azureBackup_ARM, err := rule.AzureBackup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1342,7 +1342,7 @@ func (rule *BasePolicyRule) ConvertToARM(resolved genruntime.ConvertToARMResolve
 
 	// Set property "AzureRetention":
 	if rule.AzureRetention != nil {
-		azureRetention_ARM, err := (*rule.AzureRetention).ConvertToARM(resolved)
+		azureRetention_ARM, err := rule.AzureRetention.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1608,7 +1608,7 @@ func (rule *AzureBackupRule) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "BackupParameters":
 	if rule.BackupParameters != nil {
-		backupParameters_ARM, err := (*rule.BackupParameters).ConvertToARM(resolved)
+		backupParameters_ARM, err := rule.BackupParameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1618,7 +1618,7 @@ func (rule *AzureBackupRule) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "DataStore":
 	if rule.DataStore != nil {
-		dataStore_ARM, err := (*rule.DataStore).ConvertToARM(resolved)
+		dataStore_ARM, err := rule.DataStore.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1643,7 +1643,7 @@ func (rule *AzureBackupRule) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Trigger":
 	if rule.Trigger != nil {
-		trigger_ARM, err := (*rule.Trigger).ConvertToARM(resolved)
+		trigger_ARM, err := rule.Trigger.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2428,7 +2428,7 @@ func (parameters *BackupParameters) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "AzureBackupParams":
 	if parameters.AzureBackupParams != nil {
-		azureBackupParams_ARM, err := (*parameters.AzureBackupParams).ConvertToARM(resolved)
+		azureBackupParams_ARM, err := parameters.AzureBackupParams.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2814,7 +2814,7 @@ func (cycle *SourceLifeCycle) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "DeleteAfter":
 	if cycle.DeleteAfter != nil {
-		deleteAfter_ARM, err := (*cycle.DeleteAfter).ConvertToARM(resolved)
+		deleteAfter_ARM, err := cycle.DeleteAfter.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2824,7 +2824,7 @@ func (cycle *SourceLifeCycle) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "SourceDataStore":
 	if cycle.SourceDataStore != nil {
-		sourceDataStore_ARM, err := (*cycle.SourceDataStore).ConvertToARM(resolved)
+		sourceDataStore_ARM, err := cycle.SourceDataStore.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3183,7 +3183,7 @@ func (context *TriggerContext) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "Adhoc":
 	if context.Adhoc != nil {
-		adhoc_ARM, err := (*context.Adhoc).ConvertToARM(resolved)
+		adhoc_ARM, err := context.Adhoc.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3193,7 +3193,7 @@ func (context *TriggerContext) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "Schedule":
 	if context.Schedule != nil {
-		schedule_ARM, err := (*context.Schedule).ConvertToARM(resolved)
+		schedule_ARM, err := context.Schedule.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3461,7 +3461,7 @@ func (context *AdhocBasedTriggerContext) ConvertToARM(resolved genruntime.Conver
 
 	// Set property "TaggingCriteria":
 	if context.TaggingCriteria != nil {
-		taggingCriteria_ARM, err := (*context.TaggingCriteria).ConvertToARM(resolved)
+		taggingCriteria_ARM, err := context.TaggingCriteria.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3920,7 +3920,7 @@ func (option *DeleteOption) ConvertToARM(resolved genruntime.ConvertToARMResolve
 
 	// Set property "AbsoluteDeleteOption":
 	if option.AbsoluteDeleteOption != nil {
-		absoluteDeleteOption_ARM, err := (*option.AbsoluteDeleteOption).ConvertToARM(resolved)
+		absoluteDeleteOption_ARM, err := option.AbsoluteDeleteOption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4119,7 +4119,7 @@ func (context *ScheduleBasedTriggerContext) ConvertToARM(resolved genruntime.Con
 
 	// Set property "Schedule":
 	if context.Schedule != nil {
-		schedule_ARM, err := (*context.Schedule).ConvertToARM(resolved)
+		schedule_ARM, err := context.Schedule.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4461,7 +4461,7 @@ func (setting *TargetCopySetting) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "CopyAfter":
 	if setting.CopyAfter != nil {
-		copyAfter_ARM, err := (*setting.CopyAfter).ConvertToARM(resolved)
+		copyAfter_ARM, err := setting.CopyAfter.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4471,7 +4471,7 @@ func (setting *TargetCopySetting) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "DataStore":
 	if setting.DataStore != nil {
-		dataStore_ARM, err := (*setting.DataStore).ConvertToARM(resolved)
+		dataStore_ARM, err := setting.DataStore.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4923,7 +4923,7 @@ func (criteria *AdhocBasedTaggingCriteria) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "TagInfo":
 	if criteria.TagInfo != nil {
-		tagInfo_ARM, err := (*criteria.TagInfo).ConvertToARM(resolved)
+		tagInfo_ARM, err := criteria.TagInfo.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5316,7 +5316,7 @@ func (option *CopyOption) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "CopyOnExpiry":
 	if option.CopyOnExpiry != nil {
-		copyOnExpiry_ARM, err := (*option.CopyOnExpiry).ConvertToARM(resolved)
+		copyOnExpiry_ARM, err := option.CopyOnExpiry.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5326,7 +5326,7 @@ func (option *CopyOption) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "CustomCopy":
 	if option.CustomCopy != nil {
-		customCopy_ARM, err := (*option.CustomCopy).ConvertToARM(resolved)
+		customCopy_ARM, err := option.CustomCopy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5336,7 +5336,7 @@ func (option *CopyOption) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "ImmediateCopy":
 	if option.ImmediateCopy != nil {
-		immediateCopy_ARM, err := (*option.ImmediateCopy).ConvertToARM(resolved)
+		immediateCopy_ARM, err := option.ImmediateCopy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5710,7 +5710,7 @@ func (criteria *TaggingCriteria) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "TagInfo":
 	if criteria.TagInfo != nil {
-		tagInfo_ARM, err := (*criteria.TagInfo).ConvertToARM(resolved)
+		tagInfo_ARM, err := criteria.TagInfo.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6086,7 +6086,7 @@ func (criteria *BackupCriteria) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "ScheduleBasedBackupCriteria":
 	if criteria.ScheduleBasedBackupCriteria != nil {
-		scheduleBasedBackupCriteria_ARM, err := (*criteria.ScheduleBasedBackupCriteria).ConvertToARM(resolved)
+		scheduleBasedBackupCriteria_ARM, err := criteria.ScheduleBasedBackupCriteria.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/dataprotection/v1api20231101/backup_vault_types_gen.go
+++ b/v2/api/dataprotection/v1api20231101/backup_vault_types_gen.go
@@ -314,7 +314,7 @@ func (vault *BackupVault_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "Identity":
 	if vault.Identity != nil {
-		identity_ARM, err := (*vault.Identity).ConvertToARM(resolved)
+		identity_ARM, err := vault.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -333,7 +333,7 @@ func (vault *BackupVault_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "Properties":
 	if vault.Properties != nil {
-		properties_ARM, err := (*vault.Properties).ConvertToARM(resolved)
+		properties_ARM, err := vault.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1481,7 +1481,7 @@ func (vault *BackupVaultSpec) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "FeatureSettings":
 	if vault.FeatureSettings != nil {
-		featureSettings_ARM, err := (*vault.FeatureSettings).ConvertToARM(resolved)
+		featureSettings_ARM, err := vault.FeatureSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1491,7 +1491,7 @@ func (vault *BackupVaultSpec) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "MonitoringSettings":
 	if vault.MonitoringSettings != nil {
-		monitoringSettings_ARM, err := (*vault.MonitoringSettings).ConvertToARM(resolved)
+		monitoringSettings_ARM, err := vault.MonitoringSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1506,7 +1506,7 @@ func (vault *BackupVaultSpec) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "SecuritySettings":
 	if vault.SecuritySettings != nil {
-		securitySettings_ARM, err := (*vault.SecuritySettings).ConvertToARM(resolved)
+		securitySettings_ARM, err := vault.SecuritySettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2370,7 +2370,7 @@ func (settings *FeatureSettings) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "CrossRegionRestoreSettings":
 	if settings.CrossRegionRestoreSettings != nil {
-		crossRegionRestoreSettings_ARM, err := (*settings.CrossRegionRestoreSettings).ConvertToARM(resolved)
+		crossRegionRestoreSettings_ARM, err := settings.CrossRegionRestoreSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2380,7 +2380,7 @@ func (settings *FeatureSettings) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "CrossSubscriptionRestoreSettings":
 	if settings.CrossSubscriptionRestoreSettings != nil {
-		crossSubscriptionRestoreSettings_ARM, err := (*settings.CrossSubscriptionRestoreSettings).ConvertToARM(resolved)
+		crossSubscriptionRestoreSettings_ARM, err := settings.CrossSubscriptionRestoreSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2666,7 +2666,7 @@ func (settings *MonitoringSettings) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "AzureMonitorAlertSettings":
 	if settings.AzureMonitorAlertSettings != nil {
-		azureMonitorAlertSettings_ARM, err := (*settings.AzureMonitorAlertSettings).ConvertToARM(resolved)
+		azureMonitorAlertSettings_ARM, err := settings.AzureMonitorAlertSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2990,7 +2990,7 @@ func (settings *SecuritySettings) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "ImmutabilitySettings":
 	if settings.ImmutabilitySettings != nil {
-		immutabilitySettings_ARM, err := (*settings.ImmutabilitySettings).ConvertToARM(resolved)
+		immutabilitySettings_ARM, err := settings.ImmutabilitySettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3000,7 +3000,7 @@ func (settings *SecuritySettings) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "SoftDeleteSettings":
 	if settings.SoftDeleteSettings != nil {
-		softDeleteSettings_ARM, err := (*settings.SoftDeleteSettings).ConvertToARM(resolved)
+		softDeleteSettings_ARM, err := settings.SoftDeleteSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/dataprotection/v1api20231101/backup_vaults_backup_instance_types_gen.go
+++ b/v2/api/dataprotection/v1api20231101/backup_vaults_backup_instance_types_gen.go
@@ -282,7 +282,7 @@ func (instance *BackupVaultsBackupInstance_Spec) ConvertToARM(resolved genruntim
 
 	// Set property "Properties":
 	if instance.Properties != nil {
-		properties_ARM, err := (*instance.Properties).ConvertToARM(resolved)
+		properties_ARM, err := instance.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -814,7 +814,7 @@ func (instance *BackupInstance) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "DataSourceInfo":
 	if instance.DataSourceInfo != nil {
-		dataSourceInfo_ARM, err := (*instance.DataSourceInfo).ConvertToARM(resolved)
+		dataSourceInfo_ARM, err := instance.DataSourceInfo.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -824,7 +824,7 @@ func (instance *BackupInstance) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "DataSourceSetInfo":
 	if instance.DataSourceSetInfo != nil {
-		dataSourceSetInfo_ARM, err := (*instance.DataSourceSetInfo).ConvertToARM(resolved)
+		dataSourceSetInfo_ARM, err := instance.DataSourceSetInfo.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -834,7 +834,7 @@ func (instance *BackupInstance) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "DatasourceAuthCredentials":
 	if instance.DatasourceAuthCredentials != nil {
-		datasourceAuthCredentials_ARM, err := (*instance.DatasourceAuthCredentials).ConvertToARM(resolved)
+		datasourceAuthCredentials_ARM, err := instance.DatasourceAuthCredentials.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -850,7 +850,7 @@ func (instance *BackupInstance) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "IdentityDetails":
 	if instance.IdentityDetails != nil {
-		identityDetails_ARM, err := (*instance.IdentityDetails).ConvertToARM(resolved)
+		identityDetails_ARM, err := instance.IdentityDetails.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -866,7 +866,7 @@ func (instance *BackupInstance) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "PolicyInfo":
 	if instance.PolicyInfo != nil {
-		policyInfo_ARM, err := (*instance.PolicyInfo).ConvertToARM(resolved)
+		policyInfo_ARM, err := instance.PolicyInfo.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1759,7 +1759,7 @@ func (credentials *AuthCredentials) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "SecretStoreBasedAuthCredentials":
 	if credentials.SecretStoreBasedAuthCredentials != nil {
-		secretStoreBasedAuthCredentials_ARM, err := (*credentials.SecretStoreBasedAuthCredentials).ConvertToARM(resolved)
+		secretStoreBasedAuthCredentials_ARM, err := credentials.SecretStoreBasedAuthCredentials.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2077,7 +2077,7 @@ func (datasource *Datasource) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "ResourceProperties":
 	if datasource.ResourceProperties != nil {
-		resourceProperties_ARM, err := (*datasource.ResourceProperties).ConvertToARM(resolved)
+		resourceProperties_ARM, err := datasource.ResourceProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2562,7 +2562,7 @@ func (datasourceSet *DatasourceSet) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "ResourceProperties":
 	if datasourceSet.ResourceProperties != nil {
-		resourceProperties_ARM, err := (*datasourceSet.ResourceProperties).ConvertToARM(resolved)
+		resourceProperties_ARM, err := datasourceSet.ResourceProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3208,7 +3208,7 @@ func (info *PolicyInfo) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 
 	// Set property "PolicyParameters":
 	if info.PolicyParameters != nil {
-		policyParameters_ARM, err := (*info.PolicyParameters).ConvertToARM(resolved)
+		policyParameters_ARM, err := info.PolicyParameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3827,7 +3827,7 @@ func (properties *BaseResourceProperties) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "DefaultResourceProperties":
 	if properties.DefaultResourceProperties != nil {
-		defaultResourceProperties_ARM, err := (*properties.DefaultResourceProperties).ConvertToARM(resolved)
+		defaultResourceProperties_ARM, err := properties.DefaultResourceProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4529,7 +4529,7 @@ func (credentials *SecretStoreBasedAuthCredentials) ConvertToARM(resolved genrun
 
 	// Set property "SecretStoreResource":
 	if credentials.SecretStoreResource != nil {
-		secretStoreResource_ARM, err := (*credentials.SecretStoreResource).ConvertToARM(resolved)
+		secretStoreResource_ARM, err := credentials.SecretStoreResource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4996,7 +4996,7 @@ func (parameters *BackupDatasourceParameters) ConvertToARM(resolved genruntime.C
 
 	// Set property "Blob":
 	if parameters.Blob != nil {
-		blob_ARM, err := (*parameters.Blob).ConvertToARM(resolved)
+		blob_ARM, err := parameters.Blob.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5006,7 +5006,7 @@ func (parameters *BackupDatasourceParameters) ConvertToARM(resolved genruntime.C
 
 	// Set property "KubernetesCluster":
 	if parameters.KubernetesCluster != nil {
-		kubernetesCluster_ARM, err := (*parameters.KubernetesCluster).ConvertToARM(resolved)
+		kubernetesCluster_ARM, err := parameters.KubernetesCluster.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5291,7 +5291,7 @@ func (parameters *DataStoreParameters) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "AzureOperationalStoreParameters":
 	if parameters.AzureOperationalStoreParameters != nil {
-		azureOperationalStoreParameters_ARM, err := (*parameters.AzureOperationalStoreParameters).ConvertToARM(resolved)
+		azureOperationalStoreParameters_ARM, err := parameters.AzureOperationalStoreParameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/dataprotection/v1api20231101/backup_vaults_backup_policy_types_gen.go
+++ b/v2/api/dataprotection/v1api20231101/backup_vaults_backup_policy_types_gen.go
@@ -279,7 +279,7 @@ func (policy *BackupVaultsBackupPolicy_Spec) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Properties":
 	if policy.Properties != nil {
-		properties_ARM, err := (*policy.Properties).ConvertToARM(resolved)
+		properties_ARM, err := policy.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -847,7 +847,7 @@ func (policy *BaseBackupPolicy) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "BackupPolicy":
 	if policy.BackupPolicy != nil {
-		backupPolicy_ARM, err := (*policy.BackupPolicy).ConvertToARM(resolved)
+		backupPolicy_ARM, err := policy.BackupPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1403,7 +1403,7 @@ func (rule *BasePolicyRule) ConvertToARM(resolved genruntime.ConvertToARMResolve
 
 	// Set property "AzureBackup":
 	if rule.AzureBackup != nil {
-		azureBackup_ARM, err := (*rule.AzureBackup).ConvertToARM(resolved)
+		azureBackup_ARM, err := rule.AzureBackup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1413,7 +1413,7 @@ func (rule *BasePolicyRule) ConvertToARM(resolved genruntime.ConvertToARMResolve
 
 	// Set property "AzureRetention":
 	if rule.AzureRetention != nil {
-		azureRetention_ARM, err := (*rule.AzureRetention).ConvertToARM(resolved)
+		azureRetention_ARM, err := rule.AzureRetention.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1710,7 +1710,7 @@ func (rule *AzureBackupRule) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "BackupParameters":
 	if rule.BackupParameters != nil {
-		backupParameters_ARM, err := (*rule.BackupParameters).ConvertToARM(resolved)
+		backupParameters_ARM, err := rule.BackupParameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1720,7 +1720,7 @@ func (rule *AzureBackupRule) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "DataStore":
 	if rule.DataStore != nil {
-		dataStore_ARM, err := (*rule.DataStore).ConvertToARM(resolved)
+		dataStore_ARM, err := rule.DataStore.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1745,7 +1745,7 @@ func (rule *AzureBackupRule) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Trigger":
 	if rule.Trigger != nil {
-		trigger_ARM, err := (*rule.Trigger).ConvertToARM(resolved)
+		trigger_ARM, err := rule.Trigger.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2628,7 +2628,7 @@ func (parameters *BackupParameters) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "AzureBackupParams":
 	if parameters.AzureBackupParams != nil {
-		azureBackupParams_ARM, err := (*parameters.AzureBackupParams).ConvertToARM(resolved)
+		azureBackupParams_ARM, err := parameters.AzureBackupParams.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3051,7 +3051,7 @@ func (cycle *SourceLifeCycle) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "DeleteAfter":
 	if cycle.DeleteAfter != nil {
-		deleteAfter_ARM, err := (*cycle.DeleteAfter).ConvertToARM(resolved)
+		deleteAfter_ARM, err := cycle.DeleteAfter.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3061,7 +3061,7 @@ func (cycle *SourceLifeCycle) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "SourceDataStore":
 	if cycle.SourceDataStore != nil {
-		sourceDataStore_ARM, err := (*cycle.SourceDataStore).ConvertToARM(resolved)
+		sourceDataStore_ARM, err := cycle.SourceDataStore.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3469,7 +3469,7 @@ func (context *TriggerContext) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "Adhoc":
 	if context.Adhoc != nil {
-		adhoc_ARM, err := (*context.Adhoc).ConvertToARM(resolved)
+		adhoc_ARM, err := context.Adhoc.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3479,7 +3479,7 @@ func (context *TriggerContext) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "Schedule":
 	if context.Schedule != nil {
-		schedule_ARM, err := (*context.Schedule).ConvertToARM(resolved)
+		schedule_ARM, err := context.Schedule.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3778,7 +3778,7 @@ func (context *AdhocBasedTriggerContext) ConvertToARM(resolved genruntime.Conver
 
 	// Set property "TaggingCriteria":
 	if context.TaggingCriteria != nil {
-		taggingCriteria_ARM, err := (*context.TaggingCriteria).ConvertToARM(resolved)
+		taggingCriteria_ARM, err := context.TaggingCriteria.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4282,7 +4282,7 @@ func (option *DeleteOption) ConvertToARM(resolved genruntime.ConvertToARMResolve
 
 	// Set property "AbsoluteDeleteOption":
 	if option.AbsoluteDeleteOption != nil {
-		absoluteDeleteOption_ARM, err := (*option.AbsoluteDeleteOption).ConvertToARM(resolved)
+		absoluteDeleteOption_ARM, err := option.AbsoluteDeleteOption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4500,7 +4500,7 @@ func (context *ScheduleBasedTriggerContext) ConvertToARM(resolved genruntime.Con
 
 	// Set property "Schedule":
 	if context.Schedule != nil {
-		schedule_ARM, err := (*context.Schedule).ConvertToARM(resolved)
+		schedule_ARM, err := context.Schedule.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4887,7 +4887,7 @@ func (setting *TargetCopySetting) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "CopyAfter":
 	if setting.CopyAfter != nil {
-		copyAfter_ARM, err := (*setting.CopyAfter).ConvertToARM(resolved)
+		copyAfter_ARM, err := setting.CopyAfter.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4897,7 +4897,7 @@ func (setting *TargetCopySetting) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "DataStore":
 	if setting.DataStore != nil {
-		dataStore_ARM, err := (*setting.DataStore).ConvertToARM(resolved)
+		dataStore_ARM, err := setting.DataStore.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5398,7 +5398,7 @@ func (criteria *AdhocBasedTaggingCriteria) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "TagInfo":
 	if criteria.TagInfo != nil {
-		tagInfo_ARM, err := (*criteria.TagInfo).ConvertToARM(resolved)
+		tagInfo_ARM, err := criteria.TagInfo.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5823,7 +5823,7 @@ func (option *CopyOption) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "CopyOnExpiry":
 	if option.CopyOnExpiry != nil {
-		copyOnExpiry_ARM, err := (*option.CopyOnExpiry).ConvertToARM(resolved)
+		copyOnExpiry_ARM, err := option.CopyOnExpiry.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5833,7 +5833,7 @@ func (option *CopyOption) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "CustomCopy":
 	if option.CustomCopy != nil {
-		customCopy_ARM, err := (*option.CustomCopy).ConvertToARM(resolved)
+		customCopy_ARM, err := option.CustomCopy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5843,7 +5843,7 @@ func (option *CopyOption) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "ImmediateCopy":
 	if option.ImmediateCopy != nil {
-		immediateCopy_ARM, err := (*option.ImmediateCopy).ConvertToARM(resolved)
+		immediateCopy_ARM, err := option.ImmediateCopy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6260,7 +6260,7 @@ func (criteria *TaggingCriteria) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "TagInfo":
 	if criteria.TagInfo != nil {
-		tagInfo_ARM, err := (*criteria.TagInfo).ConvertToARM(resolved)
+		tagInfo_ARM, err := criteria.TagInfo.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6684,7 +6684,7 @@ func (criteria *BackupCriteria) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "ScheduleBasedBackupCriteria":
 	if criteria.ScheduleBasedBackupCriteria != nil {
-		scheduleBasedBackupCriteria_ARM, err := (*criteria.ScheduleBasedBackupCriteria).ConvertToARM(resolved)
+		scheduleBasedBackupCriteria_ARM, err := criteria.ScheduleBasedBackupCriteria.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/dbformariadb/v1api20180601/server_types_gen.go
+++ b/v2/api/dbformariadb/v1api20180601/server_types_gen.go
@@ -296,7 +296,7 @@ func (server *Server_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 
 	// Set property "Properties":
 	if server.Properties != nil {
-		properties_ARM, err := (*server.Properties).ConvertToARM(resolved)
+		properties_ARM, err := server.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -306,7 +306,7 @@ func (server *Server_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 
 	// Set property "Sku":
 	if server.Sku != nil {
-		sku_ARM, err := (*server.Sku).ConvertToARM(resolved)
+		sku_ARM, err := server.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1482,7 +1482,7 @@ func (create *ServerPropertiesForCreate) ConvertToARM(resolved genruntime.Conver
 
 	// Set property "Default":
 	if create.Default != nil {
-		default_ARM, err := (*create.Default).ConvertToARM(resolved)
+		default_ARM, err := create.Default.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1492,7 +1492,7 @@ func (create *ServerPropertiesForCreate) ConvertToARM(resolved genruntime.Conver
 
 	// Set property "GeoRestore":
 	if create.GeoRestore != nil {
-		geoRestore_ARM, err := (*create.GeoRestore).ConvertToARM(resolved)
+		geoRestore_ARM, err := create.GeoRestore.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1502,7 +1502,7 @@ func (create *ServerPropertiesForCreate) ConvertToARM(resolved genruntime.Conver
 
 	// Set property "PointInTimeRestore":
 	if create.PointInTimeRestore != nil {
-		pointInTimeRestore_ARM, err := (*create.PointInTimeRestore).ConvertToARM(resolved)
+		pointInTimeRestore_ARM, err := create.PointInTimeRestore.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1512,7 +1512,7 @@ func (create *ServerPropertiesForCreate) ConvertToARM(resolved genruntime.Conver
 
 	// Set property "Replica":
 	if create.Replica != nil {
-		replica_ARM, err := (*create.Replica).ConvertToARM(resolved)
+		replica_ARM, err := create.Replica.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2477,7 +2477,7 @@ func (create *ServerPropertiesForDefaultCreate) ConvertToARM(resolved genruntime
 
 	// Set property "StorageProfile":
 	if create.StorageProfile != nil {
-		storageProfile_ARM, err := (*create.StorageProfile).ConvertToARM(resolved)
+		storageProfile_ARM, err := create.StorageProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2799,7 +2799,7 @@ func (restore *ServerPropertiesForGeoRestore) ConvertToARM(resolved genruntime.C
 
 	// Set property "StorageProfile":
 	if restore.StorageProfile != nil {
-		storageProfile_ARM, err := (*restore.StorageProfile).ConvertToARM(resolved)
+		storageProfile_ARM, err := restore.StorageProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3103,7 +3103,7 @@ func (replica *ServerPropertiesForReplica) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "StorageProfile":
 	if replica.StorageProfile != nil {
-		storageProfile_ARM, err := (*replica.StorageProfile).ConvertToARM(resolved)
+		storageProfile_ARM, err := replica.StorageProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3417,7 +3417,7 @@ func (restore *ServerPropertiesForRestore) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "StorageProfile":
 	if restore.StorageProfile != nil {
-		storageProfile_ARM, err := (*restore.StorageProfile).ConvertToARM(resolved)
+		storageProfile_ARM, err := restore.StorageProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/dbformysql/v1api20210501/flexible_server_types_gen.go
+++ b/v2/api/dbformysql/v1api20210501/flexible_server_types_gen.go
@@ -364,7 +364,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Identity":
 	if server.Identity != nil {
-		identity_ARM, err := (*server.Identity).ConvertToARM(resolved)
+		identity_ARM, err := server.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -415,7 +415,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.AvailabilityZone = &availabilityZone
 	}
 	if server.Backup != nil {
-		backup_ARM, err := (*server.Backup).ConvertToARM(resolved)
+		backup_ARM, err := server.Backup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -429,7 +429,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.CreateMode = &createMode
 	}
 	if server.DataEncryption != nil {
-		dataEncryption_ARM, err := (*server.DataEncryption).ConvertToARM(resolved)
+		dataEncryption_ARM, err := server.DataEncryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -437,7 +437,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.DataEncryption = &dataEncryption
 	}
 	if server.HighAvailability != nil {
-		highAvailability_ARM, err := (*server.HighAvailability).ConvertToARM(resolved)
+		highAvailability_ARM, err := server.HighAvailability.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -445,7 +445,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.HighAvailability = &highAvailability
 	}
 	if server.MaintenanceWindow != nil {
-		maintenanceWindow_ARM, err := (*server.MaintenanceWindow).ConvertToARM(resolved)
+		maintenanceWindow_ARM, err := server.MaintenanceWindow.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -453,7 +453,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.MaintenanceWindow = &maintenanceWindow
 	}
 	if server.Network != nil {
-		network_ARM, err := (*server.Network).ConvertToARM(resolved)
+		network_ARM, err := server.Network.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -475,7 +475,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.SourceServerResourceId = &sourceServerResourceId
 	}
 	if server.Storage != nil {
-		storage_ARM, err := (*server.Storage).ConvertToARM(resolved)
+		storage_ARM, err := server.Storage.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -491,7 +491,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Sku":
 	if server.Sku != nil {
-		sku_ARM, err := (*server.Sku).ConvertToARM(resolved)
+		sku_ARM, err := server.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/dbformysql/v1api20230630/flexible_server_types_gen.go
+++ b/v2/api/dbformysql/v1api20230630/flexible_server_types_gen.go
@@ -367,7 +367,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Identity":
 	if server.Identity != nil {
-		identity_ARM, err := (*server.Identity).ConvertToARM(resolved)
+		identity_ARM, err := server.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -419,7 +419,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.AvailabilityZone = &availabilityZone
 	}
 	if server.Backup != nil {
-		backup_ARM, err := (*server.Backup).ConvertToARM(resolved)
+		backup_ARM, err := server.Backup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -433,7 +433,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.CreateMode = &createMode
 	}
 	if server.DataEncryption != nil {
-		dataEncryption_ARM, err := (*server.DataEncryption).ConvertToARM(resolved)
+		dataEncryption_ARM, err := server.DataEncryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -441,7 +441,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.DataEncryption = &dataEncryption
 	}
 	if server.HighAvailability != nil {
-		highAvailability_ARM, err := (*server.HighAvailability).ConvertToARM(resolved)
+		highAvailability_ARM, err := server.HighAvailability.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -449,7 +449,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.HighAvailability = &highAvailability
 	}
 	if server.ImportSourceProperties != nil {
-		importSourceProperties_ARM, err := (*server.ImportSourceProperties).ConvertToARM(resolved)
+		importSourceProperties_ARM, err := server.ImportSourceProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -457,7 +457,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.ImportSourceProperties = &importSourceProperties
 	}
 	if server.MaintenanceWindow != nil {
-		maintenanceWindow_ARM, err := (*server.MaintenanceWindow).ConvertToARM(resolved)
+		maintenanceWindow_ARM, err := server.MaintenanceWindow.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -465,7 +465,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.MaintenanceWindow = &maintenanceWindow
 	}
 	if server.Network != nil {
-		network_ARM, err := (*server.Network).ConvertToARM(resolved)
+		network_ARM, err := server.Network.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -491,7 +491,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.SourceServerResourceId = &sourceServerResourceId
 	}
 	if server.Storage != nil {
-		storage_ARM, err := (*server.Storage).ConvertToARM(resolved)
+		storage_ARM, err := server.Storage.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -507,7 +507,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Sku":
 	if server.Sku != nil {
-		sku_ARM, err := (*server.Sku).ConvertToARM(resolved)
+		sku_ARM, err := server.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/dbformysql/v1api20231230/flexible_server_types_gen.go
+++ b/v2/api/dbformysql/v1api20231230/flexible_server_types_gen.go
@@ -364,7 +364,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Identity":
 	if server.Identity != nil {
-		identity_ARM, err := (*server.Identity).ConvertToARM(resolved)
+		identity_ARM, err := server.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -416,7 +416,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.AvailabilityZone = &availabilityZone
 	}
 	if server.Backup != nil {
-		backup_ARM, err := (*server.Backup).ConvertToARM(resolved)
+		backup_ARM, err := server.Backup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -430,7 +430,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.CreateMode = &createMode
 	}
 	if server.DataEncryption != nil {
-		dataEncryption_ARM, err := (*server.DataEncryption).ConvertToARM(resolved)
+		dataEncryption_ARM, err := server.DataEncryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -438,7 +438,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.DataEncryption = &dataEncryption
 	}
 	if server.HighAvailability != nil {
-		highAvailability_ARM, err := (*server.HighAvailability).ConvertToARM(resolved)
+		highAvailability_ARM, err := server.HighAvailability.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -446,7 +446,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.HighAvailability = &highAvailability
 	}
 	if server.ImportSourceProperties != nil {
-		importSourceProperties_ARM, err := (*server.ImportSourceProperties).ConvertToARM(resolved)
+		importSourceProperties_ARM, err := server.ImportSourceProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -454,7 +454,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.ImportSourceProperties = &importSourceProperties
 	}
 	if server.MaintenanceWindow != nil {
-		maintenanceWindow_ARM, err := (*server.MaintenanceWindow).ConvertToARM(resolved)
+		maintenanceWindow_ARM, err := server.MaintenanceWindow.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -462,7 +462,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.MaintenanceWindow = &maintenanceWindow
 	}
 	if server.Network != nil {
-		network_ARM, err := (*server.Network).ConvertToARM(resolved)
+		network_ARM, err := server.Network.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -488,7 +488,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.SourceServerResourceId = &sourceServerResourceId
 	}
 	if server.Storage != nil {
-		storage_ARM, err := (*server.Storage).ConvertToARM(resolved)
+		storage_ARM, err := server.Storage.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -504,7 +504,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Sku":
 	if server.Sku != nil {
-		sku_ARM, err := (*server.Sku).ConvertToARM(resolved)
+		sku_ARM, err := server.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/dbforpostgresql/v1api20210601/flexible_server_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20210601/flexible_server_types_gen.go
@@ -369,7 +369,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.AvailabilityZone = &availabilityZone
 	}
 	if server.Backup != nil {
-		backup_ARM, err := (*server.Backup).ConvertToARM(resolved)
+		backup_ARM, err := server.Backup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -383,7 +383,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.CreateMode = &createMode
 	}
 	if server.HighAvailability != nil {
-		highAvailability_ARM, err := (*server.HighAvailability).ConvertToARM(resolved)
+		highAvailability_ARM, err := server.HighAvailability.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -391,7 +391,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.HighAvailability = &highAvailability
 	}
 	if server.MaintenanceWindow != nil {
-		maintenanceWindow_ARM, err := (*server.MaintenanceWindow).ConvertToARM(resolved)
+		maintenanceWindow_ARM, err := server.MaintenanceWindow.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -399,7 +399,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.MaintenanceWindow = &maintenanceWindow
 	}
 	if server.Network != nil {
-		network_ARM, err := (*server.Network).ConvertToARM(resolved)
+		network_ARM, err := server.Network.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -419,7 +419,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.SourceServerResourceId = &sourceServerResourceId
 	}
 	if server.Storage != nil {
-		storage_ARM, err := (*server.Storage).ConvertToARM(resolved)
+		storage_ARM, err := server.Storage.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -435,7 +435,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Sku":
 	if server.Sku != nil {
-		sku_ARM, err := (*server.Sku).ConvertToARM(resolved)
+		sku_ARM, err := server.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/dbforpostgresql/v1api20220120preview/flexible_server_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20220120preview/flexible_server_types_gen.go
@@ -390,7 +390,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.AvailabilityZone = &availabilityZone
 	}
 	if server.Backup != nil {
-		backup_ARM, err := (*server.Backup).ConvertToARM(resolved)
+		backup_ARM, err := server.Backup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -404,7 +404,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.CreateMode = &createMode
 	}
 	if server.HighAvailability != nil {
-		highAvailability_ARM, err := (*server.HighAvailability).ConvertToARM(resolved)
+		highAvailability_ARM, err := server.HighAvailability.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -412,7 +412,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.HighAvailability = &highAvailability
 	}
 	if server.MaintenanceWindow != nil {
-		maintenanceWindow_ARM, err := (*server.MaintenanceWindow).ConvertToARM(resolved)
+		maintenanceWindow_ARM, err := server.MaintenanceWindow.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -420,7 +420,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.MaintenanceWindow = &maintenanceWindow
 	}
 	if server.Network != nil {
-		network_ARM, err := (*server.Network).ConvertToARM(resolved)
+		network_ARM, err := server.Network.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -440,7 +440,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.SourceServerResourceId = &sourceServerResourceId
 	}
 	if server.Storage != nil {
-		storage_ARM, err := (*server.Storage).ConvertToARM(resolved)
+		storage_ARM, err := server.Storage.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -456,7 +456,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Sku":
 	if server.Sku != nil {
-		sku_ARM, err := (*server.Sku).ConvertToARM(resolved)
+		sku_ARM, err := server.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/dbforpostgresql/v1api20221201/flexible_server_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20221201/flexible_server_types_gen.go
@@ -367,7 +367,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Identity":
 	if server.Identity != nil {
-		identity_ARM, err := (*server.Identity).ConvertToARM(resolved)
+		identity_ARM, err := server.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -415,7 +415,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.AdministratorLoginPassword = &administratorLoginPassword
 	}
 	if server.AuthConfig != nil {
-		authConfig_ARM, err := (*server.AuthConfig).ConvertToARM(resolved)
+		authConfig_ARM, err := server.AuthConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -427,7 +427,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.AvailabilityZone = &availabilityZone
 	}
 	if server.Backup != nil {
-		backup_ARM, err := (*server.Backup).ConvertToARM(resolved)
+		backup_ARM, err := server.Backup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -441,7 +441,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.CreateMode = &createMode
 	}
 	if server.DataEncryption != nil {
-		dataEncryption_ARM, err := (*server.DataEncryption).ConvertToARM(resolved)
+		dataEncryption_ARM, err := server.DataEncryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -449,7 +449,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.DataEncryption = &dataEncryption
 	}
 	if server.HighAvailability != nil {
-		highAvailability_ARM, err := (*server.HighAvailability).ConvertToARM(resolved)
+		highAvailability_ARM, err := server.HighAvailability.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -457,7 +457,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.HighAvailability = &highAvailability
 	}
 	if server.MaintenanceWindow != nil {
-		maintenanceWindow_ARM, err := (*server.MaintenanceWindow).ConvertToARM(resolved)
+		maintenanceWindow_ARM, err := server.MaintenanceWindow.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -465,7 +465,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.MaintenanceWindow = &maintenanceWindow
 	}
 	if server.Network != nil {
-		network_ARM, err := (*server.Network).ConvertToARM(resolved)
+		network_ARM, err := server.Network.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -491,7 +491,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.SourceServerResourceId = &sourceServerResourceId
 	}
 	if server.Storage != nil {
-		storage_ARM, err := (*server.Storage).ConvertToARM(resolved)
+		storage_ARM, err := server.Storage.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -507,7 +507,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Sku":
 	if server.Sku != nil {
-		sku_ARM, err := (*server.Sku).ConvertToARM(resolved)
+		sku_ARM, err := server.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/dbforpostgresql/v1api20230601preview/flexible_server_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20230601preview/flexible_server_types_gen.go
@@ -371,7 +371,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Identity":
 	if server.Identity != nil {
-		identity_ARM, err := (*server.Identity).ConvertToARM(resolved)
+		identity_ARM, err := server.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -420,7 +420,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.AdministratorLoginPassword = &administratorLoginPassword
 	}
 	if server.AuthConfig != nil {
-		authConfig_ARM, err := (*server.AuthConfig).ConvertToARM(resolved)
+		authConfig_ARM, err := server.AuthConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -432,7 +432,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.AvailabilityZone = &availabilityZone
 	}
 	if server.Backup != nil {
-		backup_ARM, err := (*server.Backup).ConvertToARM(resolved)
+		backup_ARM, err := server.Backup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -446,7 +446,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.CreateMode = &createMode
 	}
 	if server.DataEncryption != nil {
-		dataEncryption_ARM, err := (*server.DataEncryption).ConvertToARM(resolved)
+		dataEncryption_ARM, err := server.DataEncryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -454,7 +454,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.DataEncryption = &dataEncryption
 	}
 	if server.HighAvailability != nil {
-		highAvailability_ARM, err := (*server.HighAvailability).ConvertToARM(resolved)
+		highAvailability_ARM, err := server.HighAvailability.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -462,7 +462,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.HighAvailability = &highAvailability
 	}
 	if server.MaintenanceWindow != nil {
-		maintenanceWindow_ARM, err := (*server.MaintenanceWindow).ConvertToARM(resolved)
+		maintenanceWindow_ARM, err := server.MaintenanceWindow.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -470,7 +470,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.MaintenanceWindow = &maintenanceWindow
 	}
 	if server.Network != nil {
-		network_ARM, err := (*server.Network).ConvertToARM(resolved)
+		network_ARM, err := server.Network.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -482,7 +482,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.PointInTimeUTC = &pointInTimeUTC
 	}
 	if server.Replica != nil {
-		replica_ARM, err := (*server.Replica).ConvertToARM(resolved)
+		replica_ARM, err := server.Replica.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -504,7 +504,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.SourceServerResourceId = &sourceServerResourceId
 	}
 	if server.Storage != nil {
-		storage_ARM, err := (*server.Storage).ConvertToARM(resolved)
+		storage_ARM, err := server.Storage.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -520,7 +520,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Sku":
 	if server.Sku != nil {
-		sku_ARM, err := (*server.Sku).ConvertToARM(resolved)
+		sku_ARM, err := server.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/dbforpostgresql/v1api20240801/flexible_server_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20240801/flexible_server_types_gen.go
@@ -371,7 +371,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Identity":
 	if server.Identity != nil {
-		identity_ARM, err := (*server.Identity).ConvertToARM(resolved)
+		identity_ARM, err := server.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -420,7 +420,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.AdministratorLoginPassword = &administratorLoginPassword
 	}
 	if server.AuthConfig != nil {
-		authConfig_ARM, err := (*server.AuthConfig).ConvertToARM(resolved)
+		authConfig_ARM, err := server.AuthConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -432,7 +432,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.AvailabilityZone = &availabilityZone
 	}
 	if server.Backup != nil {
-		backup_ARM, err := (*server.Backup).ConvertToARM(resolved)
+		backup_ARM, err := server.Backup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -446,7 +446,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.CreateMode = &createMode
 	}
 	if server.DataEncryption != nil {
-		dataEncryption_ARM, err := (*server.DataEncryption).ConvertToARM(resolved)
+		dataEncryption_ARM, err := server.DataEncryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -454,7 +454,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.DataEncryption = &dataEncryption
 	}
 	if server.HighAvailability != nil {
-		highAvailability_ARM, err := (*server.HighAvailability).ConvertToARM(resolved)
+		highAvailability_ARM, err := server.HighAvailability.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -462,7 +462,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.HighAvailability = &highAvailability
 	}
 	if server.MaintenanceWindow != nil {
-		maintenanceWindow_ARM, err := (*server.MaintenanceWindow).ConvertToARM(resolved)
+		maintenanceWindow_ARM, err := server.MaintenanceWindow.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -470,7 +470,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.MaintenanceWindow = &maintenanceWindow
 	}
 	if server.Network != nil {
-		network_ARM, err := (*server.Network).ConvertToARM(resolved)
+		network_ARM, err := server.Network.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -482,7 +482,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.PointInTimeUTC = &pointInTimeUTC
 	}
 	if server.Replica != nil {
-		replica_ARM, err := (*server.Replica).ConvertToARM(resolved)
+		replica_ARM, err := server.Replica.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -504,7 +504,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.SourceServerResourceId = &sourceServerResourceId
 	}
 	if server.Storage != nil {
-		storage_ARM, err := (*server.Storage).ConvertToARM(resolved)
+		storage_ARM, err := server.Storage.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -520,7 +520,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Sku":
 	if server.Sku != nil {
-		sku_ARM, err := (*server.Sku).ConvertToARM(resolved)
+		sku_ARM, err := server.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/devices/v1api20210702/iot_hub_types_gen.go
+++ b/v2/api/devices/v1api20210702/iot_hub_types_gen.go
@@ -295,7 +295,7 @@ func (iotHub *IotHub_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 
 	// Set property "Identity":
 	if iotHub.Identity != nil {
-		identity_ARM, err := (*iotHub.Identity).ConvertToARM(resolved)
+		identity_ARM, err := iotHub.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -314,7 +314,7 @@ func (iotHub *IotHub_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 
 	// Set property "Properties":
 	if iotHub.Properties != nil {
-		properties_ARM, err := (*iotHub.Properties).ConvertToARM(resolved)
+		properties_ARM, err := iotHub.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -324,7 +324,7 @@ func (iotHub *IotHub_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 
 	// Set property "Sku":
 	if iotHub.Sku != nil {
-		sku_ARM, err := (*iotHub.Sku).ConvertToARM(resolved)
+		sku_ARM, err := iotHub.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1570,7 +1570,7 @@ func (properties *IotHubProperties) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "CloudToDevice":
 	if properties.CloudToDevice != nil {
-		cloudToDevice_ARM, err := (*properties.CloudToDevice).ConvertToARM(resolved)
+		cloudToDevice_ARM, err := properties.CloudToDevice.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1663,7 +1663,7 @@ func (properties *IotHubProperties) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "NetworkRuleSets":
 	if properties.NetworkRuleSets != nil {
-		networkRuleSets_ARM, err := (*properties.NetworkRuleSets).ConvertToARM(resolved)
+		networkRuleSets_ARM, err := properties.NetworkRuleSets.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1687,7 +1687,7 @@ func (properties *IotHubProperties) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Routing":
 	if properties.Routing != nil {
-		routing_ARM, err := (*properties.Routing).ConvertToARM(resolved)
+		routing_ARM, err := properties.Routing.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3872,7 +3872,7 @@ func (properties *CloudToDeviceProperties) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "Feedback":
 	if properties.Feedback != nil {
-		feedback_ARM, err := (*properties.Feedback).ConvertToARM(resolved)
+		feedback_ARM, err := properties.Feedback.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5728,7 +5728,7 @@ func (properties *RoutingProperties) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "Endpoints":
 	if properties.Endpoints != nil {
-		endpoints_ARM, err := (*properties.Endpoints).ConvertToARM(resolved)
+		endpoints_ARM, err := properties.Endpoints.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5747,7 +5747,7 @@ func (properties *RoutingProperties) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "FallbackRoute":
 	if properties.FallbackRoute != nil {
-		fallbackRoute_ARM, err := (*properties.FallbackRoute).ConvertToARM(resolved)
+		fallbackRoute_ARM, err := properties.FallbackRoute.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6533,7 +6533,7 @@ func (properties *StorageEndpointProperties) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Identity":
 	if properties.Identity != nil {
-		identity_ARM, err := (*properties.Identity).ConvertToARM(resolved)
+		identity_ARM, err := properties.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9470,7 +9470,7 @@ func (properties *RoutingEventHubProperties) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Identity":
 	if properties.Identity != nil {
-		identity_ARM, err := (*properties.Identity).ConvertToARM(resolved)
+		identity_ARM, err := properties.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10030,7 +10030,7 @@ func (properties *RoutingServiceBusQueueEndpointProperties) ConvertToARM(resolve
 
 	// Set property "Identity":
 	if properties.Identity != nil {
-		identity_ARM, err := (*properties.Identity).ConvertToARM(resolved)
+		identity_ARM, err := properties.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10590,7 +10590,7 @@ func (properties *RoutingServiceBusTopicEndpointProperties) ConvertToARM(resolve
 
 	// Set property "Identity":
 	if properties.Identity != nil {
-		identity_ARM, err := (*properties.Identity).ConvertToARM(resolved)
+		identity_ARM, err := properties.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11191,7 +11191,7 @@ func (properties *RoutingStorageContainerProperties) ConvertToARM(resolved genru
 
 	// Set property "Identity":
 	if properties.Identity != nil {
-		identity_ARM, err := (*properties.Identity).ConvertToARM(resolved)
+		identity_ARM, err := properties.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20210515/database_account_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/database_account_types_gen.go
@@ -369,7 +369,7 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "Identity":
 	if account.Identity != nil {
-		identity_ARM, err := (*account.Identity).ConvertToARM(resolved)
+		identity_ARM, err := account.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -421,7 +421,7 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties = &arm.DatabaseAccountCreateUpdateProperties{}
 	}
 	if account.AnalyticalStorageConfiguration != nil {
-		analyticalStorageConfiguration_ARM, err := (*account.AnalyticalStorageConfiguration).ConvertToARM(resolved)
+		analyticalStorageConfiguration_ARM, err := account.AnalyticalStorageConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -429,7 +429,7 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.AnalyticalStorageConfiguration = &analyticalStorageConfiguration
 	}
 	if account.ApiProperties != nil {
-		apiProperties_ARM, err := (*account.ApiProperties).ConvertToARM(resolved)
+		apiProperties_ARM, err := account.ApiProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -437,7 +437,7 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.ApiProperties = &apiProperties
 	}
 	if account.BackupPolicy != nil {
-		backupPolicy_ARM, err := (*account.BackupPolicy).ConvertToARM(resolved)
+		backupPolicy_ARM, err := account.BackupPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -458,7 +458,7 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.ConnectorOffer = &connectorOffer
 	}
 	if account.ConsistencyPolicy != nil {
-		consistencyPolicy_ARM, err := (*account.ConsistencyPolicy).ConvertToARM(resolved)
+		consistencyPolicy_ARM, err := account.ConsistencyPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3159,7 +3159,7 @@ func (policy *BackupPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolve
 
 	// Set property "Continuous":
 	if policy.Continuous != nil {
-		continuous_ARM, err := (*policy.Continuous).ConvertToARM(resolved)
+		continuous_ARM, err := policy.Continuous.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3169,7 +3169,7 @@ func (policy *BackupPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolve
 
 	// Set property "Periodic":
 	if policy.Periodic != nil {
-		periodic_ARM, err := (*policy.Periodic).ConvertToARM(resolved)
+		periodic_ARM, err := policy.Periodic.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5909,7 +5909,7 @@ func (policy *PeriodicModeBackupPolicy) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "PeriodicModeProperties":
 	if policy.PeriodicModeProperties != nil {
-		periodicModeProperties_ARM, err := (*policy.PeriodicModeProperties).ConvertToARM(resolved)
+		periodicModeProperties_ARM, err := policy.PeriodicModeProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20210515/mongodb_database_collection_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/mongodb_database_collection_throughput_setting_types_gen.go
@@ -291,7 +291,7 @@ func (setting *MongodbDatabaseCollectionThroughputSetting_Spec) ConvertToARM(res
 		result.Properties = &arm.ThroughputSettingsUpdateProperties{}
 	}
 	if setting.Resource != nil {
-		resource_ARM, err := (*setting.Resource).ConvertToARM(resolved)
+		resource_ARM, err := setting.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1045,7 +1045,7 @@ func (resource *ThroughputSettingsResource) ConvertToARM(resolved genruntime.Con
 
 	// Set property "AutoscaleSettings":
 	if resource.AutoscaleSettings != nil {
-		autoscaleSettings_ARM, err := (*resource.AutoscaleSettings).ConvertToARM(resolved)
+		autoscaleSettings_ARM, err := resource.AutoscaleSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1168,7 +1168,7 @@ func (resource *AutoscaleSettingsResource) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "AutoUpgradePolicy":
 	if resource.AutoUpgradePolicy != nil {
-		autoUpgradePolicy_ARM, err := (*resource.AutoUpgradePolicy).ConvertToARM(resolved)
+		autoUpgradePolicy_ARM, err := resource.AutoUpgradePolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1400,7 +1400,7 @@ func (resource *AutoUpgradePolicyResource) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "ThroughputPolicy":
 	if resource.ThroughputPolicy != nil {
-		throughputPolicy_ARM, err := (*resource.ThroughputPolicy).ConvertToARM(resolved)
+		throughputPolicy_ARM, err := resource.ThroughputPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20210515/mongodb_database_collection_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/mongodb_database_collection_types_gen.go
@@ -300,7 +300,7 @@ func (collection *MongodbDatabaseCollection_Spec) ConvertToARM(resolved genrunti
 		result.Properties = &arm.MongoDBCollectionCreateUpdateProperties{}
 	}
 	if collection.Options != nil {
-		options_ARM, err := (*collection.Options).ConvertToARM(resolved)
+		options_ARM, err := collection.Options.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -308,7 +308,7 @@ func (collection *MongodbDatabaseCollection_Spec) ConvertToARM(resolved genrunti
 		result.Properties.Options = &options
 	}
 	if collection.Resource != nil {
-		resource_ARM, err := (*collection.Resource).ConvertToARM(resolved)
+		resource_ARM, err := collection.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1343,7 +1343,7 @@ func (index *MongoIndex) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 
 	// Set property "Key":
 	if index.Key != nil {
-		key_ARM, err := (*index.Key).ConvertToARM(resolved)
+		key_ARM, err := index.Key.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1353,7 +1353,7 @@ func (index *MongoIndex) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 
 	// Set property "Options":
 	if index.Options != nil {
-		options_ARM, err := (*index.Options).ConvertToARM(resolved)
+		options_ARM, err := index.Options.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20210515/mongodb_database_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/mongodb_database_throughput_setting_types_gen.go
@@ -291,7 +291,7 @@ func (setting *MongodbDatabaseThroughputSetting_Spec) ConvertToARM(resolved genr
 		result.Properties = &arm.ThroughputSettingsUpdateProperties{}
 	}
 	if setting.Resource != nil {
-		resource_ARM, err := (*setting.Resource).ConvertToARM(resolved)
+		resource_ARM, err := setting.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20210515/mongodb_database_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/mongodb_database_types_gen.go
@@ -300,7 +300,7 @@ func (database *MongodbDatabase_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties = &arm.MongoDBDatabaseCreateUpdateProperties{}
 	}
 	if database.Options != nil {
-		options_ARM, err := (*database.Options).ConvertToARM(resolved)
+		options_ARM, err := database.Options.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -308,7 +308,7 @@ func (database *MongodbDatabase_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties.Options = &options
 	}
 	if database.Resource != nil {
-		resource_ARM, err := (*database.Resource).ConvertToARM(resolved)
+		resource_ARM, err := database.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -865,7 +865,7 @@ func (options *CreateUpdateOptions) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "AutoscaleSettings":
 	if options.AutoscaleSettings != nil {
-		autoscaleSettings_ARM, err := (*options.AutoscaleSettings).ConvertToARM(resolved)
+		autoscaleSettings_ARM, err := options.AutoscaleSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20210515/sql_database_container_stored_procedure_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/sql_database_container_stored_procedure_types_gen.go
@@ -300,7 +300,7 @@ func (procedure *SqlDatabaseContainerStoredProcedure_Spec) ConvertToARM(resolved
 		result.Properties = &arm.SqlStoredProcedureCreateUpdateProperties{}
 	}
 	if procedure.Options != nil {
-		options_ARM, err := (*procedure.Options).ConvertToARM(resolved)
+		options_ARM, err := procedure.Options.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -308,7 +308,7 @@ func (procedure *SqlDatabaseContainerStoredProcedure_Spec) ConvertToARM(resolved
 		result.Properties.Options = &options
 	}
 	if procedure.Resource != nil {
-		resource_ARM, err := (*procedure.Resource).ConvertToARM(resolved)
+		resource_ARM, err := procedure.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20210515/sql_database_container_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/sql_database_container_throughput_setting_types_gen.go
@@ -291,7 +291,7 @@ func (setting *SqlDatabaseContainerThroughputSetting_Spec) ConvertToARM(resolved
 		result.Properties = &arm.ThroughputSettingsUpdateProperties{}
 	}
 	if setting.Resource != nil {
-		resource_ARM, err := (*setting.Resource).ConvertToARM(resolved)
+		resource_ARM, err := setting.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20210515/sql_database_container_trigger_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/sql_database_container_trigger_types_gen.go
@@ -300,7 +300,7 @@ func (trigger *SqlDatabaseContainerTrigger_Spec) ConvertToARM(resolved genruntim
 		result.Properties = &arm.SqlTriggerCreateUpdateProperties{}
 	}
 	if trigger.Options != nil {
-		options_ARM, err := (*trigger.Options).ConvertToARM(resolved)
+		options_ARM, err := trigger.Options.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -308,7 +308,7 @@ func (trigger *SqlDatabaseContainerTrigger_Spec) ConvertToARM(resolved genruntim
 		result.Properties.Options = &options
 	}
 	if trigger.Resource != nil {
-		resource_ARM, err := (*trigger.Resource).ConvertToARM(resolved)
+		resource_ARM, err := trigger.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20210515/sql_database_container_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/sql_database_container_types_gen.go
@@ -300,7 +300,7 @@ func (container *SqlDatabaseContainer_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties = &arm.SqlContainerCreateUpdateProperties{}
 	}
 	if container.Options != nil {
-		options_ARM, err := (*container.Options).ConvertToARM(resolved)
+		options_ARM, err := container.Options.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -308,7 +308,7 @@ func (container *SqlDatabaseContainer_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties.Options = &options
 	}
 	if container.Resource != nil {
-		resource_ARM, err := (*container.Resource).ConvertToARM(resolved)
+		resource_ARM, err := container.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1187,7 +1187,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "ConflictResolutionPolicy":
 	if resource.ConflictResolutionPolicy != nil {
-		conflictResolutionPolicy_ARM, err := (*resource.ConflictResolutionPolicy).ConvertToARM(resolved)
+		conflictResolutionPolicy_ARM, err := resource.ConflictResolutionPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1209,7 +1209,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "IndexingPolicy":
 	if resource.IndexingPolicy != nil {
-		indexingPolicy_ARM, err := (*resource.IndexingPolicy).ConvertToARM(resolved)
+		indexingPolicy_ARM, err := resource.IndexingPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1219,7 +1219,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "PartitionKey":
 	if resource.PartitionKey != nil {
-		partitionKey_ARM, err := (*resource.PartitionKey).ConvertToARM(resolved)
+		partitionKey_ARM, err := resource.PartitionKey.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1229,7 +1229,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "UniqueKeyPolicy":
 	if resource.UniqueKeyPolicy != nil {
-		uniqueKeyPolicy_ARM, err := (*resource.UniqueKeyPolicy).ConvertToARM(resolved)
+		uniqueKeyPolicy_ARM, err := resource.UniqueKeyPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20210515/sql_database_container_user_defined_function_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/sql_database_container_user_defined_function_types_gen.go
@@ -300,7 +300,7 @@ func (function *SqlDatabaseContainerUserDefinedFunction_Spec) ConvertToARM(resol
 		result.Properties = &arm.SqlUserDefinedFunctionCreateUpdateProperties{}
 	}
 	if function.Options != nil {
-		options_ARM, err := (*function.Options).ConvertToARM(resolved)
+		options_ARM, err := function.Options.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -308,7 +308,7 @@ func (function *SqlDatabaseContainerUserDefinedFunction_Spec) ConvertToARM(resol
 		result.Properties.Options = &options
 	}
 	if function.Resource != nil {
-		resource_ARM, err := (*function.Resource).ConvertToARM(resolved)
+		resource_ARM, err := function.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20210515/sql_database_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/sql_database_throughput_setting_types_gen.go
@@ -291,7 +291,7 @@ func (setting *SqlDatabaseThroughputSetting_Spec) ConvertToARM(resolved genrunti
 		result.Properties = &arm.ThroughputSettingsUpdateProperties{}
 	}
 	if setting.Resource != nil {
-		resource_ARM, err := (*setting.Resource).ConvertToARM(resolved)
+		resource_ARM, err := setting.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20210515/sql_database_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/sql_database_types_gen.go
@@ -300,7 +300,7 @@ func (database *SqlDatabase_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Properties = &arm.SqlDatabaseCreateUpdateProperties{}
 	}
 	if database.Options != nil {
-		options_ARM, err := (*database.Options).ConvertToARM(resolved)
+		options_ARM, err := database.Options.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -308,7 +308,7 @@ func (database *SqlDatabase_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Properties.Options = &options
 	}
 	if database.Resource != nil {
-		resource_ARM, err := (*database.Resource).ConvertToARM(resolved)
+		resource_ARM, err := database.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20231115/database_account_types_gen.go
+++ b/v2/api/documentdb/v1api20231115/database_account_types_gen.go
@@ -396,7 +396,7 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "Identity":
 	if account.Identity != nil {
-		identity_ARM, err := (*account.Identity).ConvertToARM(resolved)
+		identity_ARM, err := account.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -456,7 +456,7 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties = &arm.DatabaseAccountCreateUpdateProperties{}
 	}
 	if account.AnalyticalStorageConfiguration != nil {
-		analyticalStorageConfiguration_ARM, err := (*account.AnalyticalStorageConfiguration).ConvertToARM(resolved)
+		analyticalStorageConfiguration_ARM, err := account.AnalyticalStorageConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -464,7 +464,7 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.AnalyticalStorageConfiguration = &analyticalStorageConfiguration
 	}
 	if account.ApiProperties != nil {
-		apiProperties_ARM, err := (*account.ApiProperties).ConvertToARM(resolved)
+		apiProperties_ARM, err := account.ApiProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -472,7 +472,7 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.ApiProperties = &apiProperties
 	}
 	if account.BackupPolicy != nil {
-		backupPolicy_ARM, err := (*account.BackupPolicy).ConvertToARM(resolved)
+		backupPolicy_ARM, err := account.BackupPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -487,7 +487,7 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.Capabilities = append(result.Properties.Capabilities, *item_ARM.(*arm.Capability))
 	}
 	if account.Capacity != nil {
-		capacity_ARM, err := (*account.Capacity).ConvertToARM(resolved)
+		capacity_ARM, err := account.Capacity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -501,7 +501,7 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.ConnectorOffer = &connectorOffer
 	}
 	if account.ConsistencyPolicy != nil {
-		consistencyPolicy_ARM, err := (*account.ConsistencyPolicy).ConvertToARM(resolved)
+		consistencyPolicy_ARM, err := account.ConsistencyPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -619,7 +619,7 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.PublicNetworkAccess = &publicNetworkAccess
 	}
 	if account.RestoreParameters != nil {
-		restoreParameters_ARM, err := (*account.RestoreParameters).ConvertToARM(resolved)
+		restoreParameters_ARM, err := account.RestoreParameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3823,7 +3823,7 @@ func (policy *BackupPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolve
 
 	// Set property "Continuous":
 	if policy.Continuous != nil {
-		continuous_ARM, err := (*policy.Continuous).ConvertToARM(resolved)
+		continuous_ARM, err := policy.Continuous.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3833,7 +3833,7 @@ func (policy *BackupPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolve
 
 	// Set property "Periodic":
 	if policy.Periodic != nil {
-		periodic_ARM, err := (*policy.Periodic).ConvertToARM(resolved)
+		periodic_ARM, err := policy.Periodic.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7293,7 +7293,7 @@ func (policy *ContinuousModeBackupPolicy) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "ContinuousModeProperties":
 	if policy.ContinuousModeProperties != nil {
-		continuousModeProperties_ARM, err := (*policy.ContinuousModeProperties).ConvertToARM(resolved)
+		continuousModeProperties_ARM, err := policy.ContinuousModeProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7303,7 +7303,7 @@ func (policy *ContinuousModeBackupPolicy) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "MigrationState":
 	if policy.MigrationState != nil {
-		migrationState_ARM, err := (*policy.MigrationState).ConvertToARM(resolved)
+		migrationState_ARM, err := policy.MigrationState.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8189,7 +8189,7 @@ func (policy *PeriodicModeBackupPolicy) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "MigrationState":
 	if policy.MigrationState != nil {
-		migrationState_ARM, err := (*policy.MigrationState).ConvertToARM(resolved)
+		migrationState_ARM, err := policy.MigrationState.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8199,7 +8199,7 @@ func (policy *PeriodicModeBackupPolicy) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "PeriodicModeProperties":
 	if policy.PeriodicModeProperties != nil {
-		periodicModeProperties_ARM, err := (*policy.PeriodicModeProperties).ConvertToARM(resolved)
+		periodicModeProperties_ARM, err := policy.PeriodicModeProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20231115/mongodb_database_collection_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1api20231115/mongodb_database_collection_throughput_setting_types_gen.go
@@ -291,7 +291,7 @@ func (setting *MongodbDatabaseCollectionThroughputSetting_Spec) ConvertToARM(res
 		result.Properties = &arm.ThroughputSettingsUpdateProperties{}
 	}
 	if setting.Resource != nil {
-		resource_ARM, err := (*setting.Resource).ConvertToARM(resolved)
+		resource_ARM, err := setting.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1076,7 +1076,7 @@ func (resource *ThroughputSettingsResource) ConvertToARM(resolved genruntime.Con
 
 	// Set property "AutoscaleSettings":
 	if resource.AutoscaleSettings != nil {
-		autoscaleSettings_ARM, err := (*resource.AutoscaleSettings).ConvertToARM(resolved)
+		autoscaleSettings_ARM, err := resource.AutoscaleSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1199,7 +1199,7 @@ func (resource *AutoscaleSettingsResource) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "AutoUpgradePolicy":
 	if resource.AutoUpgradePolicy != nil {
-		autoUpgradePolicy_ARM, err := (*resource.AutoUpgradePolicy).ConvertToARM(resolved)
+		autoUpgradePolicy_ARM, err := resource.AutoUpgradePolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1431,7 +1431,7 @@ func (resource *AutoUpgradePolicyResource) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "ThroughputPolicy":
 	if resource.ThroughputPolicy != nil {
-		throughputPolicy_ARM, err := (*resource.ThroughputPolicy).ConvertToARM(resolved)
+		throughputPolicy_ARM, err := resource.ThroughputPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20231115/mongodb_database_collection_types_gen.go
+++ b/v2/api/documentdb/v1api20231115/mongodb_database_collection_types_gen.go
@@ -300,7 +300,7 @@ func (collection *MongodbDatabaseCollection_Spec) ConvertToARM(resolved genrunti
 		result.Properties = &arm.MongoDBCollectionCreateUpdateProperties{}
 	}
 	if collection.Options != nil {
-		options_ARM, err := (*collection.Options).ConvertToARM(resolved)
+		options_ARM, err := collection.Options.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -308,7 +308,7 @@ func (collection *MongodbDatabaseCollection_Spec) ConvertToARM(resolved genrunti
 		result.Properties.Options = &options
 	}
 	if collection.Resource != nil {
-		resource_ARM, err := (*collection.Resource).ConvertToARM(resolved)
+		resource_ARM, err := collection.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1168,7 +1168,7 @@ func (resource *MongoDBCollectionResource) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "RestoreParameters":
 	if resource.RestoreParameters != nil {
-		restoreParameters_ARM, err := (*resource.RestoreParameters).ConvertToARM(resolved)
+		restoreParameters_ARM, err := resource.RestoreParameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1493,7 +1493,7 @@ func (index *MongoIndex) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 
 	// Set property "Key":
 	if index.Key != nil {
-		key_ARM, err := (*index.Key).ConvertToARM(resolved)
+		key_ARM, err := index.Key.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1503,7 +1503,7 @@ func (index *MongoIndex) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 
 	// Set property "Options":
 	if index.Options != nil {
-		options_ARM, err := (*index.Options).ConvertToARM(resolved)
+		options_ARM, err := index.Options.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20231115/mongodb_database_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1api20231115/mongodb_database_throughput_setting_types_gen.go
@@ -291,7 +291,7 @@ func (setting *MongodbDatabaseThroughputSetting_Spec) ConvertToARM(resolved genr
 		result.Properties = &arm.ThroughputSettingsUpdateProperties{}
 	}
 	if setting.Resource != nil {
-		resource_ARM, err := (*setting.Resource).ConvertToARM(resolved)
+		resource_ARM, err := setting.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20231115/mongodb_database_types_gen.go
+++ b/v2/api/documentdb/v1api20231115/mongodb_database_types_gen.go
@@ -300,7 +300,7 @@ func (database *MongodbDatabase_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties = &arm.MongoDBDatabaseCreateUpdateProperties{}
 	}
 	if database.Options != nil {
-		options_ARM, err := (*database.Options).ConvertToARM(resolved)
+		options_ARM, err := database.Options.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -308,7 +308,7 @@ func (database *MongodbDatabase_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties.Options = &options
 	}
 	if database.Resource != nil {
-		resource_ARM, err := (*database.Resource).ConvertToARM(resolved)
+		resource_ARM, err := database.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -866,7 +866,7 @@ func (options *CreateUpdateOptions) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "AutoscaleSettings":
 	if options.AutoscaleSettings != nil {
-		autoscaleSettings_ARM, err := (*options.AutoscaleSettings).ConvertToARM(resolved)
+		autoscaleSettings_ARM, err := options.AutoscaleSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1289,7 +1289,7 @@ func (resource *MongoDBDatabaseResource) ConvertToARM(resolved genruntime.Conver
 
 	// Set property "RestoreParameters":
 	if resource.RestoreParameters != nil {
-		restoreParameters_ARM, err := (*resource.RestoreParameters).ConvertToARM(resolved)
+		restoreParameters_ARM, err := resource.RestoreParameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20231115/sql_database_container_stored_procedure_types_gen.go
+++ b/v2/api/documentdb/v1api20231115/sql_database_container_stored_procedure_types_gen.go
@@ -300,7 +300,7 @@ func (procedure *SqlDatabaseContainerStoredProcedure_Spec) ConvertToARM(resolved
 		result.Properties = &arm.SqlStoredProcedureCreateUpdateProperties{}
 	}
 	if procedure.Options != nil {
-		options_ARM, err := (*procedure.Options).ConvertToARM(resolved)
+		options_ARM, err := procedure.Options.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -308,7 +308,7 @@ func (procedure *SqlDatabaseContainerStoredProcedure_Spec) ConvertToARM(resolved
 		result.Properties.Options = &options
 	}
 	if procedure.Resource != nil {
-		resource_ARM, err := (*procedure.Resource).ConvertToARM(resolved)
+		resource_ARM, err := procedure.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20231115/sql_database_container_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1api20231115/sql_database_container_throughput_setting_types_gen.go
@@ -291,7 +291,7 @@ func (setting *SqlDatabaseContainerThroughputSetting_Spec) ConvertToARM(resolved
 		result.Properties = &arm.ThroughputSettingsUpdateProperties{}
 	}
 	if setting.Resource != nil {
-		resource_ARM, err := (*setting.Resource).ConvertToARM(resolved)
+		resource_ARM, err := setting.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20231115/sql_database_container_trigger_types_gen.go
+++ b/v2/api/documentdb/v1api20231115/sql_database_container_trigger_types_gen.go
@@ -300,7 +300,7 @@ func (trigger *SqlDatabaseContainerTrigger_Spec) ConvertToARM(resolved genruntim
 		result.Properties = &arm.SqlTriggerCreateUpdateProperties{}
 	}
 	if trigger.Options != nil {
-		options_ARM, err := (*trigger.Options).ConvertToARM(resolved)
+		options_ARM, err := trigger.Options.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -308,7 +308,7 @@ func (trigger *SqlDatabaseContainerTrigger_Spec) ConvertToARM(resolved genruntim
 		result.Properties.Options = &options
 	}
 	if trigger.Resource != nil {
-		resource_ARM, err := (*trigger.Resource).ConvertToARM(resolved)
+		resource_ARM, err := trigger.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20231115/sql_database_container_types_gen.go
+++ b/v2/api/documentdb/v1api20231115/sql_database_container_types_gen.go
@@ -300,7 +300,7 @@ func (container *SqlDatabaseContainer_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties = &arm.SqlContainerCreateUpdateProperties{}
 	}
 	if container.Options != nil {
-		options_ARM, err := (*container.Options).ConvertToARM(resolved)
+		options_ARM, err := container.Options.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -308,7 +308,7 @@ func (container *SqlDatabaseContainer_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties.Options = &options
 	}
 	if container.Resource != nil {
-		resource_ARM, err := (*container.Resource).ConvertToARM(resolved)
+		resource_ARM, err := container.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1352,7 +1352,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "ClientEncryptionPolicy":
 	if resource.ClientEncryptionPolicy != nil {
-		clientEncryptionPolicy_ARM, err := (*resource.ClientEncryptionPolicy).ConvertToARM(resolved)
+		clientEncryptionPolicy_ARM, err := resource.ClientEncryptionPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1371,7 +1371,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "ConflictResolutionPolicy":
 	if resource.ConflictResolutionPolicy != nil {
-		conflictResolutionPolicy_ARM, err := (*resource.ConflictResolutionPolicy).ConvertToARM(resolved)
+		conflictResolutionPolicy_ARM, err := resource.ConflictResolutionPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1401,7 +1401,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "IndexingPolicy":
 	if resource.IndexingPolicy != nil {
-		indexingPolicy_ARM, err := (*resource.IndexingPolicy).ConvertToARM(resolved)
+		indexingPolicy_ARM, err := resource.IndexingPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1411,7 +1411,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "PartitionKey":
 	if resource.PartitionKey != nil {
-		partitionKey_ARM, err := (*resource.PartitionKey).ConvertToARM(resolved)
+		partitionKey_ARM, err := resource.PartitionKey.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1421,7 +1421,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "RestoreParameters":
 	if resource.RestoreParameters != nil {
-		restoreParameters_ARM, err := (*resource.RestoreParameters).ConvertToARM(resolved)
+		restoreParameters_ARM, err := resource.RestoreParameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1431,7 +1431,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "UniqueKeyPolicy":
 	if resource.UniqueKeyPolicy != nil {
-		uniqueKeyPolicy_ARM, err := (*resource.UniqueKeyPolicy).ConvertToARM(resolved)
+		uniqueKeyPolicy_ARM, err := resource.UniqueKeyPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20231115/sql_database_container_user_defined_function_types_gen.go
+++ b/v2/api/documentdb/v1api20231115/sql_database_container_user_defined_function_types_gen.go
@@ -300,7 +300,7 @@ func (function *SqlDatabaseContainerUserDefinedFunction_Spec) ConvertToARM(resol
 		result.Properties = &arm.SqlUserDefinedFunctionCreateUpdateProperties{}
 	}
 	if function.Options != nil {
-		options_ARM, err := (*function.Options).ConvertToARM(resolved)
+		options_ARM, err := function.Options.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -308,7 +308,7 @@ func (function *SqlDatabaseContainerUserDefinedFunction_Spec) ConvertToARM(resol
 		result.Properties.Options = &options
 	}
 	if function.Resource != nil {
-		resource_ARM, err := (*function.Resource).ConvertToARM(resolved)
+		resource_ARM, err := function.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20231115/sql_database_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1api20231115/sql_database_throughput_setting_types_gen.go
@@ -291,7 +291,7 @@ func (setting *SqlDatabaseThroughputSetting_Spec) ConvertToARM(resolved genrunti
 		result.Properties = &arm.ThroughputSettingsUpdateProperties{}
 	}
 	if setting.Resource != nil {
-		resource_ARM, err := (*setting.Resource).ConvertToARM(resolved)
+		resource_ARM, err := setting.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20231115/sql_database_types_gen.go
+++ b/v2/api/documentdb/v1api20231115/sql_database_types_gen.go
@@ -300,7 +300,7 @@ func (database *SqlDatabase_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Properties = &arm.SqlDatabaseCreateUpdateProperties{}
 	}
 	if database.Options != nil {
-		options_ARM, err := (*database.Options).ConvertToARM(resolved)
+		options_ARM, err := database.Options.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -308,7 +308,7 @@ func (database *SqlDatabase_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Properties.Options = &options
 	}
 	if database.Resource != nil {
-		resource_ARM, err := (*database.Resource).ConvertToARM(resolved)
+		resource_ARM, err := database.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1195,7 +1195,7 @@ func (resource *SqlDatabaseResource) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "RestoreParameters":
 	if resource.RestoreParameters != nil {
-		restoreParameters_ARM, err := (*resource.RestoreParameters).ConvertToARM(resolved)
+		restoreParameters_ARM, err := resource.RestoreParameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20240701/firewall_rule_types_gen.go
+++ b/v2/api/documentdb/v1api20240701/firewall_rule_types_gen.go
@@ -287,7 +287,7 @@ func (rule *FirewallRule_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "Properties":
 	if rule.Properties != nil {
-		properties_ARM, err := (*rule.Properties).ConvertToARM(resolved)
+		properties_ARM, err := rule.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20240701/mongo_cluster_types_gen.go
+++ b/v2/api/documentdb/v1api20240701/mongo_cluster_types_gen.go
@@ -295,7 +295,7 @@ func (cluster *MongoCluster_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "Properties":
 	if cluster.Properties != nil {
-		properties_ARM, err := (*cluster.Properties).ConvertToARM(resolved)
+		properties_ARM, err := cluster.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -966,7 +966,7 @@ func (properties *MongoClusterProperties) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "Administrator":
 	if properties.Administrator != nil {
-		administrator_ARM, err := (*properties.Administrator).ConvertToARM(resolved)
+		administrator_ARM, err := properties.Administrator.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -976,7 +976,7 @@ func (properties *MongoClusterProperties) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "Compute":
 	if properties.Compute != nil {
-		compute_ARM, err := (*properties.Compute).ConvertToARM(resolved)
+		compute_ARM, err := properties.Compute.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -994,7 +994,7 @@ func (properties *MongoClusterProperties) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "HighAvailability":
 	if properties.HighAvailability != nil {
-		highAvailability_ARM, err := (*properties.HighAvailability).ConvertToARM(resolved)
+		highAvailability_ARM, err := properties.HighAvailability.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1019,7 +1019,7 @@ func (properties *MongoClusterProperties) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "ReplicaParameters":
 	if properties.ReplicaParameters != nil {
-		replicaParameters_ARM, err := (*properties.ReplicaParameters).ConvertToARM(resolved)
+		replicaParameters_ARM, err := properties.ReplicaParameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1029,7 +1029,7 @@ func (properties *MongoClusterProperties) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "RestoreParameters":
 	if properties.RestoreParameters != nil {
-		restoreParameters_ARM, err := (*properties.RestoreParameters).ConvertToARM(resolved)
+		restoreParameters_ARM, err := properties.RestoreParameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1045,7 +1045,7 @@ func (properties *MongoClusterProperties) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "Sharding":
 	if properties.Sharding != nil {
-		sharding_ARM, err := (*properties.Sharding).ConvertToARM(resolved)
+		sharding_ARM, err := properties.Sharding.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1055,7 +1055,7 @@ func (properties *MongoClusterProperties) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "Storage":
 	if properties.Storage != nil {
-		storage_ARM, err := (*properties.Storage).ConvertToARM(resolved)
+		storage_ARM, err := properties.Storage.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20240815/database_account_types_gen.go
+++ b/v2/api/documentdb/v1api20240815/database_account_types_gen.go
@@ -393,7 +393,7 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "Identity":
 	if account.Identity != nil {
-		identity_ARM, err := (*account.Identity).ConvertToARM(resolved)
+		identity_ARM, err := account.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -453,7 +453,7 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties = &arm.DatabaseAccountCreateUpdateProperties{}
 	}
 	if account.AnalyticalStorageConfiguration != nil {
-		analyticalStorageConfiguration_ARM, err := (*account.AnalyticalStorageConfiguration).ConvertToARM(resolved)
+		analyticalStorageConfiguration_ARM, err := account.AnalyticalStorageConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -461,7 +461,7 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.AnalyticalStorageConfiguration = &analyticalStorageConfiguration
 	}
 	if account.ApiProperties != nil {
-		apiProperties_ARM, err := (*account.ApiProperties).ConvertToARM(resolved)
+		apiProperties_ARM, err := account.ApiProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -469,7 +469,7 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.ApiProperties = &apiProperties
 	}
 	if account.BackupPolicy != nil {
-		backupPolicy_ARM, err := (*account.BackupPolicy).ConvertToARM(resolved)
+		backupPolicy_ARM, err := account.BackupPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -484,7 +484,7 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.Capabilities = append(result.Properties.Capabilities, *item_ARM.(*arm.Capability))
 	}
 	if account.Capacity != nil {
-		capacity_ARM, err := (*account.Capacity).ConvertToARM(resolved)
+		capacity_ARM, err := account.Capacity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -498,7 +498,7 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.ConnectorOffer = &connectorOffer
 	}
 	if account.ConsistencyPolicy != nil {
-		consistencyPolicy_ARM, err := (*account.ConsistencyPolicy).ConvertToARM(resolved)
+		consistencyPolicy_ARM, err := account.ConsistencyPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -616,7 +616,7 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.PublicNetworkAccess = &publicNetworkAccess
 	}
 	if account.RestoreParameters != nil {
-		restoreParameters_ARM, err := (*account.RestoreParameters).ConvertToARM(resolved)
+		restoreParameters_ARM, err := account.RestoreParameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4182,7 +4182,7 @@ func (policy *BackupPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolve
 
 	// Set property "Continuous":
 	if policy.Continuous != nil {
-		continuous_ARM, err := (*policy.Continuous).ConvertToARM(resolved)
+		continuous_ARM, err := policy.Continuous.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4192,7 +4192,7 @@ func (policy *BackupPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolve
 
 	// Set property "Periodic":
 	if policy.Periodic != nil {
-		periodic_ARM, err := (*policy.Periodic).ConvertToARM(resolved)
+		periodic_ARM, err := policy.Periodic.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7965,7 +7965,7 @@ func (policy *ContinuousModeBackupPolicy) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "ContinuousModeProperties":
 	if policy.ContinuousModeProperties != nil {
-		continuousModeProperties_ARM, err := (*policy.ContinuousModeProperties).ConvertToARM(resolved)
+		continuousModeProperties_ARM, err := policy.ContinuousModeProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7975,7 +7975,7 @@ func (policy *ContinuousModeBackupPolicy) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "MigrationState":
 	if policy.MigrationState != nil {
-		migrationState_ARM, err := (*policy.MigrationState).ConvertToARM(resolved)
+		migrationState_ARM, err := policy.MigrationState.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8926,7 +8926,7 @@ func (policy *PeriodicModeBackupPolicy) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "MigrationState":
 	if policy.MigrationState != nil {
-		migrationState_ARM, err := (*policy.MigrationState).ConvertToARM(resolved)
+		migrationState_ARM, err := policy.MigrationState.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8936,7 +8936,7 @@ func (policy *PeriodicModeBackupPolicy) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "PeriodicModeProperties":
 	if policy.PeriodicModeProperties != nil {
-		periodicModeProperties_ARM, err := (*policy.PeriodicModeProperties).ConvertToARM(resolved)
+		periodicModeProperties_ARM, err := policy.PeriodicModeProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20240815/mongodb_database_collection_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1api20240815/mongodb_database_collection_throughput_setting_types_gen.go
@@ -288,7 +288,7 @@ func (setting *MongodbDatabaseCollectionThroughputSetting_Spec) ConvertToARM(res
 		result.Properties = &arm.ThroughputSettingsUpdateProperties{}
 	}
 	if setting.Resource != nil {
-		resource_ARM, err := (*setting.Resource).ConvertToARM(resolved)
+		resource_ARM, err := setting.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1098,7 +1098,7 @@ func (resource *ThroughputSettingsResource) ConvertToARM(resolved genruntime.Con
 
 	// Set property "AutoscaleSettings":
 	if resource.AutoscaleSettings != nil {
-		autoscaleSettings_ARM, err := (*resource.AutoscaleSettings).ConvertToARM(resolved)
+		autoscaleSettings_ARM, err := resource.AutoscaleSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1243,7 +1243,7 @@ func (resource *AutoscaleSettingsResource) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "AutoUpgradePolicy":
 	if resource.AutoUpgradePolicy != nil {
-		autoUpgradePolicy_ARM, err := (*resource.AutoUpgradePolicy).ConvertToARM(resolved)
+		autoUpgradePolicy_ARM, err := resource.AutoUpgradePolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1497,7 +1497,7 @@ func (resource *AutoUpgradePolicyResource) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "ThroughputPolicy":
 	if resource.ThroughputPolicy != nil {
-		throughputPolicy_ARM, err := (*resource.ThroughputPolicy).ConvertToARM(resolved)
+		throughputPolicy_ARM, err := resource.ThroughputPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20240815/mongodb_database_collection_types_gen.go
+++ b/v2/api/documentdb/v1api20240815/mongodb_database_collection_types_gen.go
@@ -297,7 +297,7 @@ func (collection *MongodbDatabaseCollection_Spec) ConvertToARM(resolved genrunti
 		result.Properties = &arm.MongoDBCollectionCreateUpdateProperties{}
 	}
 	if collection.Options != nil {
-		options_ARM, err := (*collection.Options).ConvertToARM(resolved)
+		options_ARM, err := collection.Options.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -305,7 +305,7 @@ func (collection *MongodbDatabaseCollection_Spec) ConvertToARM(resolved genrunti
 		result.Properties.Options = &options
 	}
 	if collection.Resource != nil {
-		resource_ARM, err := (*collection.Resource).ConvertToARM(resolved)
+		resource_ARM, err := collection.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1202,7 +1202,7 @@ func (resource *MongoDBCollectionResource) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "RestoreParameters":
 	if resource.RestoreParameters != nil {
-		restoreParameters_ARM, err := (*resource.RestoreParameters).ConvertToARM(resolved)
+		restoreParameters_ARM, err := resource.RestoreParameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1581,7 +1581,7 @@ func (index *MongoIndex) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 
 	// Set property "Key":
 	if index.Key != nil {
-		key_ARM, err := (*index.Key).ConvertToARM(resolved)
+		key_ARM, err := index.Key.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1591,7 +1591,7 @@ func (index *MongoIndex) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 
 	// Set property "Options":
 	if index.Options != nil {
-		options_ARM, err := (*index.Options).ConvertToARM(resolved)
+		options_ARM, err := index.Options.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20240815/mongodb_database_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1api20240815/mongodb_database_throughput_setting_types_gen.go
@@ -288,7 +288,7 @@ func (setting *MongodbDatabaseThroughputSetting_Spec) ConvertToARM(resolved genr
 		result.Properties = &arm.ThroughputSettingsUpdateProperties{}
 	}
 	if setting.Resource != nil {
-		resource_ARM, err := (*setting.Resource).ConvertToARM(resolved)
+		resource_ARM, err := setting.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20240815/mongodb_database_types_gen.go
+++ b/v2/api/documentdb/v1api20240815/mongodb_database_types_gen.go
@@ -297,7 +297,7 @@ func (database *MongodbDatabase_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties = &arm.MongoDBDatabaseCreateUpdateProperties{}
 	}
 	if database.Options != nil {
-		options_ARM, err := (*database.Options).ConvertToARM(resolved)
+		options_ARM, err := database.Options.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -305,7 +305,7 @@ func (database *MongodbDatabase_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties.Options = &options
 	}
 	if database.Resource != nil {
-		resource_ARM, err := (*database.Resource).ConvertToARM(resolved)
+		resource_ARM, err := database.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -900,7 +900,7 @@ func (options *CreateUpdateOptions) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "AutoscaleSettings":
 	if options.AutoscaleSettings != nil {
-		autoscaleSettings_ARM, err := (*options.AutoscaleSettings).ConvertToARM(resolved)
+		autoscaleSettings_ARM, err := options.AutoscaleSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1345,7 +1345,7 @@ func (resource *MongoDBDatabaseResource) ConvertToARM(resolved genruntime.Conver
 
 	// Set property "RestoreParameters":
 	if resource.RestoreParameters != nil {
-		restoreParameters_ARM, err := (*resource.RestoreParameters).ConvertToARM(resolved)
+		restoreParameters_ARM, err := resource.RestoreParameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20240815/mongodb_role_definition_types_gen.go
+++ b/v2/api/documentdb/v1api20240815/mongodb_role_definition_types_gen.go
@@ -1128,7 +1128,7 @@ func (privilege *Privilege) ConvertToARM(resolved genruntime.ConvertToARMResolve
 
 	// Set property "Resource":
 	if privilege.Resource != nil {
-		resource_ARM, err := (*privilege.Resource).ConvertToARM(resolved)
+		resource_ARM, err := privilege.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20240815/sql_database_container_stored_procedure_types_gen.go
+++ b/v2/api/documentdb/v1api20240815/sql_database_container_stored_procedure_types_gen.go
@@ -297,7 +297,7 @@ func (procedure *SqlDatabaseContainerStoredProcedure_Spec) ConvertToARM(resolved
 		result.Properties = &arm.SqlStoredProcedureCreateUpdateProperties{}
 	}
 	if procedure.Options != nil {
-		options_ARM, err := (*procedure.Options).ConvertToARM(resolved)
+		options_ARM, err := procedure.Options.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -305,7 +305,7 @@ func (procedure *SqlDatabaseContainerStoredProcedure_Spec) ConvertToARM(resolved
 		result.Properties.Options = &options
 	}
 	if procedure.Resource != nil {
-		resource_ARM, err := (*procedure.Resource).ConvertToARM(resolved)
+		resource_ARM, err := procedure.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20240815/sql_database_container_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1api20240815/sql_database_container_throughput_setting_types_gen.go
@@ -288,7 +288,7 @@ func (setting *SqlDatabaseContainerThroughputSetting_Spec) ConvertToARM(resolved
 		result.Properties = &arm.ThroughputSettingsUpdateProperties{}
 	}
 	if setting.Resource != nil {
-		resource_ARM, err := (*setting.Resource).ConvertToARM(resolved)
+		resource_ARM, err := setting.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20240815/sql_database_container_trigger_types_gen.go
+++ b/v2/api/documentdb/v1api20240815/sql_database_container_trigger_types_gen.go
@@ -297,7 +297,7 @@ func (trigger *SqlDatabaseContainerTrigger_Spec) ConvertToARM(resolved genruntim
 		result.Properties = &arm.SqlTriggerCreateUpdateProperties{}
 	}
 	if trigger.Options != nil {
-		options_ARM, err := (*trigger.Options).ConvertToARM(resolved)
+		options_ARM, err := trigger.Options.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -305,7 +305,7 @@ func (trigger *SqlDatabaseContainerTrigger_Spec) ConvertToARM(resolved genruntim
 		result.Properties.Options = &options
 	}
 	if trigger.Resource != nil {
-		resource_ARM, err := (*trigger.Resource).ConvertToARM(resolved)
+		resource_ARM, err := trigger.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20240815/sql_database_container_types_gen.go
+++ b/v2/api/documentdb/v1api20240815/sql_database_container_types_gen.go
@@ -297,7 +297,7 @@ func (container *SqlDatabaseContainer_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties = &arm.SqlContainerCreateUpdateProperties{}
 	}
 	if container.Options != nil {
-		options_ARM, err := (*container.Options).ConvertToARM(resolved)
+		options_ARM, err := container.Options.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -305,7 +305,7 @@ func (container *SqlDatabaseContainer_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties.Options = &options
 	}
 	if container.Resource != nil {
-		resource_ARM, err := (*container.Resource).ConvertToARM(resolved)
+		resource_ARM, err := container.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1386,7 +1386,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "ClientEncryptionPolicy":
 	if resource.ClientEncryptionPolicy != nil {
-		clientEncryptionPolicy_ARM, err := (*resource.ClientEncryptionPolicy).ConvertToARM(resolved)
+		clientEncryptionPolicy_ARM, err := resource.ClientEncryptionPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1405,7 +1405,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "ConflictResolutionPolicy":
 	if resource.ConflictResolutionPolicy != nil {
-		conflictResolutionPolicy_ARM, err := (*resource.ConflictResolutionPolicy).ConvertToARM(resolved)
+		conflictResolutionPolicy_ARM, err := resource.ConflictResolutionPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1435,7 +1435,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "IndexingPolicy":
 	if resource.IndexingPolicy != nil {
-		indexingPolicy_ARM, err := (*resource.IndexingPolicy).ConvertToARM(resolved)
+		indexingPolicy_ARM, err := resource.IndexingPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1445,7 +1445,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "PartitionKey":
 	if resource.PartitionKey != nil {
-		partitionKey_ARM, err := (*resource.PartitionKey).ConvertToARM(resolved)
+		partitionKey_ARM, err := resource.PartitionKey.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1455,7 +1455,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "RestoreParameters":
 	if resource.RestoreParameters != nil {
-		restoreParameters_ARM, err := (*resource.RestoreParameters).ConvertToARM(resolved)
+		restoreParameters_ARM, err := resource.RestoreParameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1465,7 +1465,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "UniqueKeyPolicy":
 	if resource.UniqueKeyPolicy != nil {
-		uniqueKeyPolicy_ARM, err := (*resource.UniqueKeyPolicy).ConvertToARM(resolved)
+		uniqueKeyPolicy_ARM, err := resource.UniqueKeyPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20240815/sql_database_container_user_defined_function_types_gen.go
+++ b/v2/api/documentdb/v1api20240815/sql_database_container_user_defined_function_types_gen.go
@@ -297,7 +297,7 @@ func (function *SqlDatabaseContainerUserDefinedFunction_Spec) ConvertToARM(resol
 		result.Properties = &arm.SqlUserDefinedFunctionCreateUpdateProperties{}
 	}
 	if function.Options != nil {
-		options_ARM, err := (*function.Options).ConvertToARM(resolved)
+		options_ARM, err := function.Options.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -305,7 +305,7 @@ func (function *SqlDatabaseContainerUserDefinedFunction_Spec) ConvertToARM(resol
 		result.Properties.Options = &options
 	}
 	if function.Resource != nil {
-		resource_ARM, err := (*function.Resource).ConvertToARM(resolved)
+		resource_ARM, err := function.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20240815/sql_database_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1api20240815/sql_database_throughput_setting_types_gen.go
@@ -288,7 +288,7 @@ func (setting *SqlDatabaseThroughputSetting_Spec) ConvertToARM(resolved genrunti
 		result.Properties = &arm.ThroughputSettingsUpdateProperties{}
 	}
 	if setting.Resource != nil {
-		resource_ARM, err := (*setting.Resource).ConvertToARM(resolved)
+		resource_ARM, err := setting.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/documentdb/v1api20240815/sql_database_types_gen.go
+++ b/v2/api/documentdb/v1api20240815/sql_database_types_gen.go
@@ -297,7 +297,7 @@ func (database *SqlDatabase_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Properties = &arm.SqlDatabaseCreateUpdateProperties{}
 	}
 	if database.Options != nil {
-		options_ARM, err := (*database.Options).ConvertToARM(resolved)
+		options_ARM, err := database.Options.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -305,7 +305,7 @@ func (database *SqlDatabase_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Properties.Options = &options
 	}
 	if database.Resource != nil {
-		resource_ARM, err := (*database.Resource).ConvertToARM(resolved)
+		resource_ARM, err := database.Resource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1229,7 +1229,7 @@ func (resource *SqlDatabaseResource) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "RestoreParameters":
 	if resource.RestoreParameters != nil {
-		restoreParameters_ARM, err := (*resource.RestoreParameters).ConvertToARM(resolved)
+		restoreParameters_ARM, err := resource.RestoreParameters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/eventgrid/v1api20200601/domain_types_gen.go
+++ b/v2/api/eventgrid/v1api20200601/domain_types_gen.go
@@ -328,7 +328,7 @@ func (domain *Domain_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.Properties.InputSchema = &inputSchema
 	}
 	if domain.InputSchemaMapping != nil {
-		inputSchemaMapping_ARM, err := (*domain.InputSchemaMapping).ConvertToARM(resolved)
+		inputSchemaMapping_ARM, err := domain.InputSchemaMapping.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1646,7 +1646,7 @@ func (mapping *InputSchemaMapping) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Json":
 	if mapping.Json != nil {
-		json_ARM, err := (*mapping.Json).ConvertToARM(resolved)
+		json_ARM, err := mapping.Json.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2119,7 +2119,7 @@ func (mapping *JsonInputSchemaMapping) ConvertToARM(resolved genruntime.ConvertT
 		result.Properties = &arm.JsonInputSchemaMappingProperties{}
 	}
 	if mapping.DataVersion != nil {
-		dataVersion_ARM, err := (*mapping.DataVersion).ConvertToARM(resolved)
+		dataVersion_ARM, err := mapping.DataVersion.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2127,7 +2127,7 @@ func (mapping *JsonInputSchemaMapping) ConvertToARM(resolved genruntime.ConvertT
 		result.Properties.DataVersion = &dataVersion
 	}
 	if mapping.EventTime != nil {
-		eventTime_ARM, err := (*mapping.EventTime).ConvertToARM(resolved)
+		eventTime_ARM, err := mapping.EventTime.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2135,7 +2135,7 @@ func (mapping *JsonInputSchemaMapping) ConvertToARM(resolved genruntime.ConvertT
 		result.Properties.EventTime = &eventTime
 	}
 	if mapping.EventType != nil {
-		eventType_ARM, err := (*mapping.EventType).ConvertToARM(resolved)
+		eventType_ARM, err := mapping.EventType.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2143,7 +2143,7 @@ func (mapping *JsonInputSchemaMapping) ConvertToARM(resolved genruntime.ConvertT
 		result.Properties.EventType = &eventType
 	}
 	if mapping.Id != nil {
-		id_ARM, err := (*mapping.Id).ConvertToARM(resolved)
+		id_ARM, err := mapping.Id.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2151,7 +2151,7 @@ func (mapping *JsonInputSchemaMapping) ConvertToARM(resolved genruntime.ConvertT
 		result.Properties.Id = &id
 	}
 	if mapping.Subject != nil {
-		subject_ARM, err := (*mapping.Subject).ConvertToARM(resolved)
+		subject_ARM, err := mapping.Subject.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2159,7 +2159,7 @@ func (mapping *JsonInputSchemaMapping) ConvertToARM(resolved genruntime.ConvertT
 		result.Properties.Subject = &subject
 	}
 	if mapping.Topic != nil {
-		topic_ARM, err := (*mapping.Topic).ConvertToARM(resolved)
+		topic_ARM, err := mapping.Topic.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/eventgrid/v1api20200601/event_subscription_types_gen.go
+++ b/v2/api/eventgrid/v1api20200601/event_subscription_types_gen.go
@@ -306,7 +306,7 @@ func (subscription *EventSubscription_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties = &arm.EventSubscriptionProperties{}
 	}
 	if subscription.DeadLetterDestination != nil {
-		deadLetterDestination_ARM, err := (*subscription.DeadLetterDestination).ConvertToARM(resolved)
+		deadLetterDestination_ARM, err := subscription.DeadLetterDestination.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -314,7 +314,7 @@ func (subscription *EventSubscription_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties.DeadLetterDestination = &deadLetterDestination
 	}
 	if subscription.Destination != nil {
-		destination_ARM, err := (*subscription.Destination).ConvertToARM(resolved)
+		destination_ARM, err := subscription.Destination.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -332,7 +332,7 @@ func (subscription *EventSubscription_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties.ExpirationTimeUtc = &expirationTimeUtc
 	}
 	if subscription.Filter != nil {
-		filter_ARM, err := (*subscription.Filter).ConvertToARM(resolved)
+		filter_ARM, err := subscription.Filter.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -343,7 +343,7 @@ func (subscription *EventSubscription_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties.Labels = append(result.Properties.Labels, item)
 	}
 	if subscription.RetryPolicy != nil {
-		retryPolicy_ARM, err := (*subscription.RetryPolicy).ConvertToARM(resolved)
+		retryPolicy_ARM, err := subscription.RetryPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1271,7 +1271,7 @@ func (destination *DeadLetterDestination) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "StorageBlob":
 	if destination.StorageBlob != nil {
-		storageBlob_ARM, err := (*destination.StorageBlob).ConvertToARM(resolved)
+		storageBlob_ARM, err := destination.StorageBlob.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1489,7 +1489,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 
 	// Set property "AzureFunction":
 	if destination.AzureFunction != nil {
-		azureFunction_ARM, err := (*destination.AzureFunction).ConvertToARM(resolved)
+		azureFunction_ARM, err := destination.AzureFunction.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1499,7 +1499,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 
 	// Set property "EventHub":
 	if destination.EventHub != nil {
-		eventHub_ARM, err := (*destination.EventHub).ConvertToARM(resolved)
+		eventHub_ARM, err := destination.EventHub.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1509,7 +1509,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 
 	// Set property "HybridConnection":
 	if destination.HybridConnection != nil {
-		hybridConnection_ARM, err := (*destination.HybridConnection).ConvertToARM(resolved)
+		hybridConnection_ARM, err := destination.HybridConnection.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1519,7 +1519,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 
 	// Set property "ServiceBusQueue":
 	if destination.ServiceBusQueue != nil {
-		serviceBusQueue_ARM, err := (*destination.ServiceBusQueue).ConvertToARM(resolved)
+		serviceBusQueue_ARM, err := destination.ServiceBusQueue.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1529,7 +1529,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 
 	// Set property "ServiceBusTopic":
 	if destination.ServiceBusTopic != nil {
-		serviceBusTopic_ARM, err := (*destination.ServiceBusTopic).ConvertToARM(resolved)
+		serviceBusTopic_ARM, err := destination.ServiceBusTopic.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1539,7 +1539,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 
 	// Set property "StorageQueue":
 	if destination.StorageQueue != nil {
-		storageQueue_ARM, err := (*destination.StorageQueue).ConvertToARM(resolved)
+		storageQueue_ARM, err := destination.StorageQueue.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1549,7 +1549,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 
 	// Set property "WebHook":
 	if destination.WebHook != nil {
-		webHook_ARM, err := (*destination.WebHook).ConvertToARM(resolved)
+		webHook_ARM, err := destination.WebHook.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3049,7 +3049,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "BoolEquals":
 	if filter.BoolEquals != nil {
-		boolEquals_ARM, err := (*filter.BoolEquals).ConvertToARM(resolved)
+		boolEquals_ARM, err := filter.BoolEquals.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3059,7 +3059,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "NumberGreaterThan":
 	if filter.NumberGreaterThan != nil {
-		numberGreaterThan_ARM, err := (*filter.NumberGreaterThan).ConvertToARM(resolved)
+		numberGreaterThan_ARM, err := filter.NumberGreaterThan.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3069,7 +3069,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "NumberGreaterThanOrEquals":
 	if filter.NumberGreaterThanOrEquals != nil {
-		numberGreaterThanOrEquals_ARM, err := (*filter.NumberGreaterThanOrEquals).ConvertToARM(resolved)
+		numberGreaterThanOrEquals_ARM, err := filter.NumberGreaterThanOrEquals.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3079,7 +3079,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "NumberIn":
 	if filter.NumberIn != nil {
-		numberIn_ARM, err := (*filter.NumberIn).ConvertToARM(resolved)
+		numberIn_ARM, err := filter.NumberIn.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3089,7 +3089,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "NumberLessThan":
 	if filter.NumberLessThan != nil {
-		numberLessThan_ARM, err := (*filter.NumberLessThan).ConvertToARM(resolved)
+		numberLessThan_ARM, err := filter.NumberLessThan.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3099,7 +3099,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "NumberLessThanOrEquals":
 	if filter.NumberLessThanOrEquals != nil {
-		numberLessThanOrEquals_ARM, err := (*filter.NumberLessThanOrEquals).ConvertToARM(resolved)
+		numberLessThanOrEquals_ARM, err := filter.NumberLessThanOrEquals.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3109,7 +3109,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "NumberNotIn":
 	if filter.NumberNotIn != nil {
-		numberNotIn_ARM, err := (*filter.NumberNotIn).ConvertToARM(resolved)
+		numberNotIn_ARM, err := filter.NumberNotIn.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3119,7 +3119,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "StringBeginsWith":
 	if filter.StringBeginsWith != nil {
-		stringBeginsWith_ARM, err := (*filter.StringBeginsWith).ConvertToARM(resolved)
+		stringBeginsWith_ARM, err := filter.StringBeginsWith.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3129,7 +3129,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "StringContains":
 	if filter.StringContains != nil {
-		stringContains_ARM, err := (*filter.StringContains).ConvertToARM(resolved)
+		stringContains_ARM, err := filter.StringContains.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3139,7 +3139,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "StringEndsWith":
 	if filter.StringEndsWith != nil {
-		stringEndsWith_ARM, err := (*filter.StringEndsWith).ConvertToARM(resolved)
+		stringEndsWith_ARM, err := filter.StringEndsWith.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3149,7 +3149,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "StringIn":
 	if filter.StringIn != nil {
-		stringIn_ARM, err := (*filter.StringIn).ConvertToARM(resolved)
+		stringIn_ARM, err := filter.StringIn.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3159,7 +3159,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "StringNotIn":
 	if filter.StringNotIn != nil {
-		stringNotIn_ARM, err := (*filter.StringNotIn).ConvertToARM(resolved)
+		stringNotIn_ARM, err := filter.StringNotIn.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/eventgrid/v1api20200601/topic_types_gen.go
+++ b/v2/api/eventgrid/v1api20200601/topic_types_gen.go
@@ -345,7 +345,7 @@ func (topic *Topic_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.Properties.InputSchema = &inputSchema
 	}
 	if topic.InputSchemaMapping != nil {
-		inputSchemaMapping_ARM, err := (*topic.InputSchemaMapping).ConvertToARM(resolved)
+		inputSchemaMapping_ARM, err := topic.InputSchemaMapping.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/eventhub/v1api20211101/namespace_types_gen.go
+++ b/v2/api/eventhub/v1api20211101/namespace_types_gen.go
@@ -321,7 +321,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Identity":
 	if namespace.Identity != nil {
-		identity_ARM, err := (*namespace.Identity).ConvertToARM(resolved)
+		identity_ARM, err := namespace.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -366,7 +366,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.DisableLocalAuth = &disableLocalAuth
 	}
 	if namespace.Encryption != nil {
-		encryption_ARM, err := (*namespace.Encryption).ConvertToARM(resolved)
+		encryption_ARM, err := namespace.Encryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -392,7 +392,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Sku":
 	if namespace.Sku != nil {
-		sku_ARM, err := (*namespace.Sku).ConvertToARM(resolved)
+		sku_ARM, err := namespace.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2827,7 +2827,7 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "Identity":
 	if properties.Identity != nil {
-		identity_ARM, err := (*properties.Identity).ConvertToARM(resolved)
+		identity_ARM, err := properties.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/eventhub/v1api20211101/namespaces_eventhub_types_gen.go
+++ b/v2/api/eventhub/v1api20211101/namespaces_eventhub_types_gen.go
@@ -297,7 +297,7 @@ func (eventhub *NamespacesEventhub_Spec) ConvertToARM(resolved genruntime.Conver
 		result.Properties = &arm.Namespaces_Eventhub_Properties_Spec{}
 	}
 	if eventhub.CaptureDescription != nil {
-		captureDescription_ARM, err := (*eventhub.CaptureDescription).ConvertToARM(resolved)
+		captureDescription_ARM, err := eventhub.CaptureDescription.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -941,7 +941,7 @@ func (description *CaptureDescription) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "Destination":
 	if description.Destination != nil {
-		destination_ARM, err := (*description.Destination).ConvertToARM(resolved)
+		destination_ARM, err := description.Destination.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/eventhub/v1api20240101/namespace_types_gen.go
+++ b/v2/api/eventhub/v1api20240101/namespace_types_gen.go
@@ -325,7 +325,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Identity":
 	if namespace.Identity != nil {
-		identity_ARM, err := (*namespace.Identity).ConvertToARM(resolved)
+		identity_ARM, err := namespace.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -372,7 +372,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.DisableLocalAuth = &disableLocalAuth
 	}
 	if namespace.Encryption != nil {
-		encryption_ARM, err := (*namespace.Encryption).ConvertToARM(resolved)
+		encryption_ARM, err := namespace.Encryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -410,7 +410,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Sku":
 	if namespace.Sku != nil {
-		sku_ARM, err := (*namespace.Sku).ConvertToARM(resolved)
+		sku_ARM, err := namespace.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3230,7 +3230,7 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "Identity":
 	if properties.Identity != nil {
-		identity_ARM, err := (*properties.Identity).ConvertToARM(resolved)
+		identity_ARM, err := properties.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/eventhub/v1api20240101/namespaces_eventhub_types_gen.go
+++ b/v2/api/eventhub/v1api20240101/namespaces_eventhub_types_gen.go
@@ -302,7 +302,7 @@ func (eventhub *NamespacesEventhub_Spec) ConvertToARM(resolved genruntime.Conver
 		result.Properties = &arm.Namespaces_Eventhub_Properties_Spec{}
 	}
 	if eventhub.CaptureDescription != nil {
-		captureDescription_ARM, err := (*eventhub.CaptureDescription).ConvertToARM(resolved)
+		captureDescription_ARM, err := eventhub.CaptureDescription.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -318,7 +318,7 @@ func (eventhub *NamespacesEventhub_Spec) ConvertToARM(resolved genruntime.Conver
 		result.Properties.PartitionCount = &partitionCount
 	}
 	if eventhub.RetentionDescription != nil {
-		retentionDescription_ARM, err := (*eventhub.RetentionDescription).ConvertToARM(resolved)
+		retentionDescription_ARM, err := eventhub.RetentionDescription.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1110,7 +1110,7 @@ func (description *CaptureDescription) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "Destination":
 	if description.Destination != nil {
-		destination_ARM, err := (*description.Destination).ConvertToARM(resolved)
+		destination_ARM, err := description.Destination.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2022,7 +2022,7 @@ func (destination *Destination) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "Identity":
 	if destination.Identity != nil {
-		identity_ARM, err := (*destination.Identity).ConvertToARM(resolved)
+		identity_ARM, err := destination.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/insights/v1api20180301/metric_alert_types_gen.go
+++ b/v2/api/insights/v1api20180301/metric_alert_types_gen.go
@@ -363,7 +363,7 @@ func (alert *MetricAlert_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.AutoMitigate = &autoMitigate
 	}
 	if alert.Criteria != nil {
-		criteria_ARM, err := (*alert.Criteria).ConvertToARM(resolved)
+		criteria_ARM, err := alert.Criteria.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1649,7 +1649,7 @@ func (criteria *MetricAlertCriteria) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "MicrosoftAzureMonitorMultipleResourceMultipleMetric":
 	if criteria.MicrosoftAzureMonitorMultipleResourceMultipleMetric != nil {
-		microsoftAzureMonitorMultipleResourceMultipleMetric_ARM, err := (*criteria.MicrosoftAzureMonitorMultipleResourceMultipleMetric).ConvertToARM(resolved)
+		microsoftAzureMonitorMultipleResourceMultipleMetric_ARM, err := criteria.MicrosoftAzureMonitorMultipleResourceMultipleMetric.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1659,7 +1659,7 @@ func (criteria *MetricAlertCriteria) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "MicrosoftAzureMonitorSingleResourceMultipleMetric":
 	if criteria.MicrosoftAzureMonitorSingleResourceMultipleMetric != nil {
-		microsoftAzureMonitorSingleResourceMultipleMetric_ARM, err := (*criteria.MicrosoftAzureMonitorSingleResourceMultipleMetric).ConvertToARM(resolved)
+		microsoftAzureMonitorSingleResourceMultipleMetric_ARM, err := criteria.MicrosoftAzureMonitorSingleResourceMultipleMetric.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1669,7 +1669,7 @@ func (criteria *MetricAlertCriteria) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "MicrosoftAzureMonitorWebtestLocationAvailability":
 	if criteria.MicrosoftAzureMonitorWebtestLocationAvailability != nil {
-		microsoftAzureMonitorWebtestLocationAvailability_ARM, err := (*criteria.MicrosoftAzureMonitorWebtestLocationAvailability).ConvertToARM(resolved)
+		microsoftAzureMonitorWebtestLocationAvailability_ARM, err := criteria.MicrosoftAzureMonitorWebtestLocationAvailability.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4183,7 +4183,7 @@ func (criteria *MultiMetricCriteria) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "Dynamic":
 	if criteria.Dynamic != nil {
-		dynamic_ARM, err := (*criteria.Dynamic).ConvertToARM(resolved)
+		dynamic_ARM, err := criteria.Dynamic.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4193,7 +4193,7 @@ func (criteria *MultiMetricCriteria) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "Static":
 	if criteria.Static != nil {
-		static_ARM, err := (*criteria.Static).ConvertToARM(resolved)
+		static_ARM, err := criteria.Static.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4574,7 +4574,7 @@ func (criteria *DynamicMetricCriteria) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "FailingPeriods":
 	if criteria.FailingPeriods != nil {
-		failingPeriods_ARM, err := (*criteria.FailingPeriods).ConvertToARM(resolved)
+		failingPeriods_ARM, err := criteria.FailingPeriods.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/insights/v1api20180501preview/webtest_types_gen.go
+++ b/v2/api/insights/v1api20180501preview/webtest_types_gen.go
@@ -352,7 +352,7 @@ func (webtest *Webtest_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties = &arm.WebTestProperties{}
 	}
 	if webtest.Configuration != nil {
-		configuration_ARM, err := (*webtest.Configuration).ConvertToARM(resolved)
+		configuration_ARM, err := webtest.Configuration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -389,7 +389,7 @@ func (webtest *Webtest_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.Name = &name
 	}
 	if webtest.Request != nil {
-		request_ARM, err := (*webtest.Request).ConvertToARM(resolved)
+		request_ARM, err := webtest.Request.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -409,7 +409,7 @@ func (webtest *Webtest_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.Timeout = &timeout
 	}
 	if webtest.ValidationRules != nil {
-		validationRules_ARM, err := (*webtest.ValidationRules).ConvertToARM(resolved)
+		validationRules_ARM, err := webtest.ValidationRules.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2334,7 +2334,7 @@ func (rules *WebTestProperties_ValidationRules) ConvertToARM(resolved genruntime
 
 	// Set property "ContentValidation":
 	if rules.ContentValidation != nil {
-		contentValidation_ARM, err := (*rules.ContentValidation).ConvertToARM(resolved)
+		contentValidation_ARM, err := rules.ContentValidation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/insights/v1api20201001/activity_log_alert_types_gen.go
+++ b/v2/api/insights/v1api20201001/activity_log_alert_types_gen.go
@@ -316,7 +316,7 @@ func (alert *ActivityLogAlert_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties = &arm.AlertRuleProperties{}
 	}
 	if alert.Actions != nil {
-		actions_ARM, err := (*alert.Actions).ConvertToARM(resolved)
+		actions_ARM, err := alert.Actions.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -324,7 +324,7 @@ func (alert *ActivityLogAlert_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.Actions = &actions
 	}
 	if alert.Condition != nil {
-		condition_ARM, err := (*alert.Condition).ConvertToARM(resolved)
+		condition_ARM, err := alert.Condition.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/insights/v1api20210501preview/diagnostic_setting_types_gen.go
+++ b/v2/api/insights/v1api20210501preview/diagnostic_setting_types_gen.go
@@ -1410,7 +1410,7 @@ func (settings *LogSettings) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "RetentionPolicy":
 	if settings.RetentionPolicy != nil {
-		retentionPolicy_ARM, err := (*settings.RetentionPolicy).ConvertToARM(resolved)
+		retentionPolicy_ARM, err := settings.RetentionPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1752,7 +1752,7 @@ func (settings *MetricSettings) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "RetentionPolicy":
 	if settings.RetentionPolicy != nil {
-		retentionPolicy_ARM, err := (*settings.RetentionPolicy).ConvertToARM(resolved)
+		retentionPolicy_ARM, err := settings.RetentionPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/insights/v1api20220615/scheduled_query_rule_types_gen.go
+++ b/v2/api/insights/v1api20220615/scheduled_query_rule_types_gen.go
@@ -379,7 +379,7 @@ func (rule *ScheduledQueryRule_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties = &arm.ScheduledQueryRuleProperties{}
 	}
 	if rule.Actions != nil {
-		actions_ARM, err := (*rule.Actions).ConvertToARM(resolved)
+		actions_ARM, err := rule.Actions.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -395,7 +395,7 @@ func (rule *ScheduledQueryRule_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.CheckWorkspaceAlertsStorageConfigured = &checkWorkspaceAlertsStorageConfigured
 	}
 	if rule.Criteria != nil {
-		criteria_ARM, err := (*rule.Criteria).ConvertToARM(resolved)
+		criteria_ARM, err := rule.Criteria.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2625,7 +2625,7 @@ func (condition *Condition) ConvertToARM(resolved genruntime.ConvertToARMResolve
 
 	// Set property "FailingPeriods":
 	if condition.FailingPeriods != nil {
-		failingPeriods_ARM, err := (*condition.FailingPeriods).ConvertToARM(resolved)
+		failingPeriods_ARM, err := condition.FailingPeriods.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/insights/v1api20220615/webtest_types_gen.go
+++ b/v2/api/insights/v1api20220615/webtest_types_gen.go
@@ -344,7 +344,7 @@ func (webtest *Webtest_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties = &arm.WebTestProperties{}
 	}
 	if webtest.Configuration != nil {
-		configuration_ARM, err := (*webtest.Configuration).ConvertToARM(resolved)
+		configuration_ARM, err := webtest.Configuration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -381,7 +381,7 @@ func (webtest *Webtest_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.Name = &name
 	}
 	if webtest.Request != nil {
-		request_ARM, err := (*webtest.Request).ConvertToARM(resolved)
+		request_ARM, err := webtest.Request.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -401,7 +401,7 @@ func (webtest *Webtest_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.Timeout = &timeout
 	}
 	if webtest.ValidationRules != nil {
-		validationRules_ARM, err := (*webtest.ValidationRules).ConvertToARM(resolved)
+		validationRules_ARM, err := webtest.ValidationRules.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2498,7 +2498,7 @@ func (rules *WebTestProperties_ValidationRules) ConvertToARM(resolved genruntime
 
 	// Set property "ContentValidation":
 	if rules.ContentValidation != nil {
-		contentValidation_ARM, err := (*rules.ContentValidation).ConvertToARM(resolved)
+		contentValidation_ARM, err := rules.ContentValidation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/insights/v1api20221001/autoscale_setting_types_gen.go
+++ b/v2/api/insights/v1api20221001/autoscale_setting_types_gen.go
@@ -344,7 +344,7 @@ func (setting *AutoscaleSetting_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties.Notifications = append(result.Properties.Notifications, *item_ARM.(*arm.AutoscaleNotification))
 	}
 	if setting.PredictiveAutoscalePolicy != nil {
-		predictiveAutoscalePolicy_ARM, err := (*setting.PredictiveAutoscalePolicy).ConvertToARM(resolved)
+		predictiveAutoscalePolicy_ARM, err := setting.PredictiveAutoscalePolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1321,7 +1321,7 @@ func (notification *AutoscaleNotification) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "Email":
 	if notification.Email != nil {
-		email_ARM, err := (*notification.Email).ConvertToARM(resolved)
+		email_ARM, err := notification.Email.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1730,7 +1730,7 @@ func (profile *AutoscaleProfile) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Capacity":
 	if profile.Capacity != nil {
-		capacity_ARM, err := (*profile.Capacity).ConvertToARM(resolved)
+		capacity_ARM, err := profile.Capacity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1740,7 +1740,7 @@ func (profile *AutoscaleProfile) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "FixedDate":
 	if profile.FixedDate != nil {
-		fixedDate_ARM, err := (*profile.FixedDate).ConvertToARM(resolved)
+		fixedDate_ARM, err := profile.FixedDate.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1756,7 +1756,7 @@ func (profile *AutoscaleProfile) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Recurrence":
 	if profile.Recurrence != nil {
-		recurrence_ARM, err := (*profile.Recurrence).ConvertToARM(resolved)
+		recurrence_ARM, err := profile.Recurrence.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3099,7 +3099,7 @@ func (recurrence *Recurrence) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "Schedule":
 	if recurrence.Schedule != nil {
-		schedule_ARM, err := (*recurrence.Schedule).ConvertToARM(resolved)
+		schedule_ARM, err := recurrence.Schedule.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3602,7 +3602,7 @@ func (rule *ScaleRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 
 	// Set property "MetricTrigger":
 	if rule.MetricTrigger != nil {
-		metricTrigger_ARM, err := (*rule.MetricTrigger).ConvertToARM(resolved)
+		metricTrigger_ARM, err := rule.MetricTrigger.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3612,7 +3612,7 @@ func (rule *ScaleRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 
 	// Set property "ScaleAction":
 	if rule.ScaleAction != nil {
-		scaleAction_ARM, err := (*rule.ScaleAction).ConvertToARM(resolved)
+		scaleAction_ARM, err := rule.ScaleAction.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/insights/v1api20230311/data_collection_endpoint_types_gen.go
+++ b/v2/api/insights/v1api20230311/data_collection_endpoint_types_gen.go
@@ -297,7 +297,7 @@ func (endpoint *DataCollectionEndpoint_Spec) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Identity":
 	if endpoint.Identity != nil {
-		identity_ARM, err := (*endpoint.Identity).ConvertToARM(resolved)
+		identity_ARM, err := endpoint.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -331,7 +331,7 @@ func (endpoint *DataCollectionEndpoint_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.Description = &description
 	}
 	if endpoint.NetworkAcls != nil {
-		networkAcls_ARM, err := (*endpoint.NetworkAcls).ConvertToARM(resolved)
+		networkAcls_ARM, err := endpoint.NetworkAcls.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/insights/v1api20230311/data_collection_rule_types_gen.go
+++ b/v2/api/insights/v1api20230311/data_collection_rule_types_gen.go
@@ -313,7 +313,7 @@ func (rule *DataCollectionRule_Spec) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "Identity":
 	if rule.Identity != nil {
-		identity_ARM, err := (*rule.Identity).ConvertToARM(resolved)
+		identity_ARM, err := rule.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -350,7 +350,7 @@ func (rule *DataCollectionRule_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties = &arm.DataCollectionRuleSpec{}
 	}
 	if rule.AgentSettings != nil {
-		agentSettings_ARM, err := (*rule.AgentSettings).ConvertToARM(resolved)
+		agentSettings_ARM, err := rule.AgentSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -373,7 +373,7 @@ func (rule *DataCollectionRule_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.DataFlows = append(result.Properties.DataFlows, *item_ARM.(*arm.DataFlow))
 	}
 	if rule.DataSources != nil {
-		dataSources_ARM, err := (*rule.DataSources).ConvertToARM(resolved)
+		dataSources_ARM, err := rule.DataSources.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -385,7 +385,7 @@ func (rule *DataCollectionRule_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.Description = &description
 	}
 	if rule.Destinations != nil {
-		destinations_ARM, err := (*rule.Destinations).ConvertToARM(resolved)
+		destinations_ARM, err := rule.Destinations.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -393,7 +393,7 @@ func (rule *DataCollectionRule_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.Destinations = &destinations
 	}
 	if rule.References != nil {
-		references_ARM, err := (*rule.References).ConvertToARM(resolved)
+		references_ARM, err := rule.References.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2658,7 +2658,7 @@ func (sources *DataSourcesSpec) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "DataImports":
 	if sources.DataImports != nil {
-		dataImports_ARM, err := (*sources.DataImports).ConvertToARM(resolved)
+		dataImports_ARM, err := sources.DataImports.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3995,7 +3995,7 @@ func (destinations *DestinationsSpec) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "AzureMonitorMetrics":
 	if destinations.AzureMonitorMetrics != nil {
-		azureMonitorMetrics_ARM, err := (*destinations.AzureMonitorMetrics).ConvertToARM(resolved)
+		azureMonitorMetrics_ARM, err := destinations.AzureMonitorMetrics.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5361,7 +5361,7 @@ func (references *ReferencesSpec) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "EnrichmentData":
 	if references.EnrichmentData != nil {
-		enrichmentData_ARM, err := (*references.EnrichmentData).ConvertToARM(resolved)
+		enrichmentData_ARM, err := references.EnrichmentData.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6660,7 +6660,7 @@ func (sources *DataImportSources) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "EventHub":
 	if sources.EventHub != nil {
-		eventHub_ARM, err := (*sources.EventHub).ConvertToARM(resolved)
+		eventHub_ARM, err := sources.EventHub.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8411,7 +8411,7 @@ func (source *LogFilesDataSource) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "Settings":
 	if source.Settings != nil {
-		settings_ARM, err := (*source.Settings).ConvertToARM(resolved)
+		settings_ARM, err := source.Settings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12049,7 +12049,7 @@ func (settings *LogFileSettings) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Text":
 	if settings.Text != nil {
-		text_ARM, err := (*settings.Text).ConvertToARM(resolved)
+		text_ARM, err := settings.Text.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/insights/v1api20230601/workbook_types_gen.go
+++ b/v2/api/insights/v1api20230601/workbook_types_gen.go
@@ -318,7 +318,7 @@ func (workbook *Workbook_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "Identity":
 	if workbook.Identity != nil {
-		identity_ARM, err := (*workbook.Identity).ConvertToARM(resolved)
+		identity_ARM, err := workbook.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/insights/v1api20240101preview/scheduled_query_rule_types_gen.go
+++ b/v2/api/insights/v1api20240101preview/scheduled_query_rule_types_gen.go
@@ -354,7 +354,7 @@ func (rule *ScheduledQueryRule_Spec) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "Identity":
 	if rule.Identity != nil {
-		identity_ARM, err := (*rule.Identity).ConvertToARM(resolved)
+		identity_ARM, err := rule.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -399,7 +399,7 @@ func (rule *ScheduledQueryRule_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties = &arm.ScheduledQueryRuleProperties{}
 	}
 	if rule.Actions != nil {
-		actions_ARM, err := (*rule.Actions).ConvertToARM(resolved)
+		actions_ARM, err := rule.Actions.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -415,7 +415,7 @@ func (rule *ScheduledQueryRule_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.CheckWorkspaceAlertsStorageConfigured = &checkWorkspaceAlertsStorageConfigured
 	}
 	if rule.Criteria != nil {
-		criteria_ARM, err := (*rule.Criteria).ConvertToARM(resolved)
+		criteria_ARM, err := rule.Criteria.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -447,7 +447,7 @@ func (rule *ScheduledQueryRule_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.OverrideQueryTimeRange = &overrideQueryTimeRange
 	}
 	if rule.ResolveConfiguration != nil {
-		resolveConfiguration_ARM, err := (*rule.ResolveConfiguration).ConvertToARM(resolved)
+		resolveConfiguration_ARM, err := rule.ResolveConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3227,7 +3227,7 @@ func (condition *Condition) ConvertToARM(resolved genruntime.ConvertToARMResolve
 
 	// Set property "FailingPeriods":
 	if condition.FailingPeriods != nil {
-		failingPeriods_ARM, err := (*condition.FailingPeriods).ConvertToARM(resolved)
+		failingPeriods_ARM, err := condition.FailingPeriods.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/keyvault/v1api20210401preview/vault_types_gen.go
+++ b/v2/api/keyvault/v1api20210401preview/vault_types_gen.go
@@ -302,7 +302,7 @@ func (vault *Vault_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 
 	// Set property "Properties":
 	if vault.Properties != nil {
-		properties_ARM, err := (*vault.Properties).ConvertToARM(resolved)
+		properties_ARM, err := vault.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1189,7 +1189,7 @@ func (properties *VaultProperties) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "NetworkAcls":
 	if properties.NetworkAcls != nil {
-		networkAcls_ARM, err := (*properties.NetworkAcls).ConvertToARM(resolved)
+		networkAcls_ARM, err := properties.NetworkAcls.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1207,7 +1207,7 @@ func (properties *VaultProperties) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Sku":
 	if properties.Sku != nil {
-		sku_ARM, err := (*properties.Sku).ConvertToARM(resolved)
+		sku_ARM, err := properties.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2202,7 +2202,7 @@ func (entry *AccessPolicyEntry) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "Permissions":
 	if entry.Permissions != nil {
-		permissions_ARM, err := (*entry.Permissions).ConvertToARM(resolved)
+		permissions_ARM, err := entry.Permissions.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/keyvault/v1api20230701/vault_types_gen.go
+++ b/v2/api/keyvault/v1api20230701/vault_types_gen.go
@@ -299,7 +299,7 @@ func (vault *Vault_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 
 	// Set property "Properties":
 	if vault.Properties != nil {
-		properties_ARM, err := (*vault.Properties).ConvertToARM(resolved)
+		properties_ARM, err := vault.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1217,7 +1217,7 @@ func (properties *VaultProperties) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "NetworkAcls":
 	if properties.NetworkAcls != nil {
-		networkAcls_ARM, err := (*properties.NetworkAcls).ConvertToARM(resolved)
+		networkAcls_ARM, err := properties.NetworkAcls.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1241,7 +1241,7 @@ func (properties *VaultProperties) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Sku":
 	if properties.Sku != nil {
-		sku_ARM, err := (*properties.Sku).ConvertToARM(resolved)
+		sku_ARM, err := properties.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2391,7 +2391,7 @@ func (entry *AccessPolicyEntry) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "Permissions":
 	if entry.Permissions != nil {
-		permissions_ARM, err := (*entry.Permissions).ConvertToARM(resolved)
+		permissions_ARM, err := entry.Permissions.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/kubernetesconfiguration/v1api20230501/extension_types_gen.go
+++ b/v2/api/kubernetesconfiguration/v1api20230501/extension_types_gen.go
@@ -342,7 +342,7 @@ func (extension *Extension_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Identity":
 	if extension.Identity != nil {
-		identity_ARM, err := (*extension.Identity).ConvertToARM(resolved)
+		identity_ARM, err := extension.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -355,7 +355,7 @@ func (extension *Extension_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Plan":
 	if extension.Plan != nil {
-		plan_ARM, err := (*extension.Plan).ConvertToARM(resolved)
+		plan_ARM, err := extension.Plan.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -375,7 +375,7 @@ func (extension *Extension_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties = &arm.Extension_Properties_Spec{}
 	}
 	if extension.AksAssignedIdentity != nil {
-		aksAssignedIdentity_ARM, err := (*extension.AksAssignedIdentity).ConvertToARM(resolved)
+		aksAssignedIdentity_ARM, err := extension.AksAssignedIdentity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -410,7 +410,7 @@ func (extension *Extension_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.ReleaseTrain = &releaseTrain
 	}
 	if extension.Scope != nil {
-		scope_ARM, err := (*extension.Scope).ConvertToARM(resolved)
+		scope_ARM, err := extension.Scope.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -424,7 +424,7 @@ func (extension *Extension_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "SystemData":
 	if extension.SystemData != nil {
-		systemData_ARM, err := (*extension.SystemData).ConvertToARM(resolved)
+		systemData_ARM, err := extension.SystemData.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2710,7 +2710,7 @@ func (scope *Scope) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 
 	// Set property "Cluster":
 	if scope.Cluster != nil {
-		cluster_ARM, err := (*scope.Cluster).ConvertToARM(resolved)
+		cluster_ARM, err := scope.Cluster.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2720,7 +2720,7 @@ func (scope *Scope) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 
 	// Set property "Namespace":
 	if scope.Namespace != nil {
-		namespace_ARM, err := (*scope.Namespace).ConvertToARM(resolved)
+		namespace_ARM, err := scope.Namespace.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/kubernetesconfiguration/v1api20230501/flux_configuration_types_gen.go
+++ b/v2/api/kubernetesconfiguration/v1api20230501/flux_configuration_types_gen.go
@@ -325,7 +325,7 @@ func (configuration *FluxConfiguration_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties = &arm.FluxConfiguration_Properties_Spec{}
 	}
 	if configuration.AzureBlob != nil {
-		azureBlob_ARM, err := (*configuration.AzureBlob).ConvertToARM(resolved)
+		azureBlob_ARM, err := configuration.AzureBlob.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -333,7 +333,7 @@ func (configuration *FluxConfiguration_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.AzureBlob = &azureBlob
 	}
 	if configuration.Bucket != nil {
-		bucket_ARM, err := (*configuration.Bucket).ConvertToARM(resolved)
+		bucket_ARM, err := configuration.Bucket.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -350,7 +350,7 @@ func (configuration *FluxConfiguration_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.ConfigurationProtectedSettings = temp
 	}
 	if configuration.GitRepository != nil {
-		gitRepository_ARM, err := (*configuration.GitRepository).ConvertToARM(resolved)
+		gitRepository_ARM, err := configuration.GitRepository.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1649,7 +1649,7 @@ func (definition *AzureBlobDefinition) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "ManagedIdentity":
 	if definition.ManagedIdentity != nil {
-		managedIdentity_ARM, err := (*definition.ManagedIdentity).ConvertToARM(resolved)
+		managedIdentity_ARM, err := definition.ManagedIdentity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1669,7 +1669,7 @@ func (definition *AzureBlobDefinition) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "ServicePrincipal":
 	if definition.ServicePrincipal != nil {
-		servicePrincipal_ARM, err := (*definition.ServicePrincipal).ConvertToARM(resolved)
+		servicePrincipal_ARM, err := definition.ServicePrincipal.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2650,7 +2650,7 @@ func (definition *GitRepositoryDefinition) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "RepositoryRef":
 	if definition.RepositoryRef != nil {
-		repositoryRef_ARM, err := (*definition.RepositoryRef).ConvertToARM(resolved)
+		repositoryRef_ARM, err := definition.RepositoryRef.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3083,7 +3083,7 @@ func (definition *KustomizationDefinition) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "PostBuild":
 	if definition.PostBuild != nil {
-		postBuild_ARM, err := (*definition.PostBuild).ConvertToARM(resolved)
+		postBuild_ARM, err := definition.PostBuild.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/kubernetesconfiguration/v1api20241101/extension_types_gen.go
+++ b/v2/api/kubernetesconfiguration/v1api20241101/extension_types_gen.go
@@ -339,7 +339,7 @@ func (extension *Extension_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Identity":
 	if extension.Identity != nil {
-		identity_ARM, err := (*extension.Identity).ConvertToARM(resolved)
+		identity_ARM, err := extension.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -352,7 +352,7 @@ func (extension *Extension_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Plan":
 	if extension.Plan != nil {
-		plan_ARM, err := (*extension.Plan).ConvertToARM(resolved)
+		plan_ARM, err := extension.Plan.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -372,7 +372,7 @@ func (extension *Extension_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties = &arm.Extension_Properties_Spec{}
 	}
 	if extension.AksAssignedIdentity != nil {
-		aksAssignedIdentity_ARM, err := (*extension.AksAssignedIdentity).ConvertToARM(resolved)
+		aksAssignedIdentity_ARM, err := extension.AksAssignedIdentity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -407,7 +407,7 @@ func (extension *Extension_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.ReleaseTrain = &releaseTrain
 	}
 	if extension.Scope != nil {
-		scope_ARM, err := (*extension.Scope).ConvertToARM(resolved)
+		scope_ARM, err := extension.Scope.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -421,7 +421,7 @@ func (extension *Extension_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "SystemData":
 	if extension.SystemData != nil {
-		systemData_ARM, err := (*extension.SystemData).ConvertToARM(resolved)
+		systemData_ARM, err := extension.SystemData.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2793,7 +2793,7 @@ func (scope *Scope) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 
 	// Set property "Cluster":
 	if scope.Cluster != nil {
-		cluster_ARM, err := (*scope.Cluster).ConvertToARM(resolved)
+		cluster_ARM, err := scope.Cluster.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2803,7 +2803,7 @@ func (scope *Scope) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 
 	// Set property "Namespace":
 	if scope.Namespace != nil {
-		namespace_ARM, err := (*scope.Namespace).ConvertToARM(resolved)
+		namespace_ARM, err := scope.Namespace.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/kubernetesconfiguration/v1api20241101/flux_configuration_types_gen.go
+++ b/v2/api/kubernetesconfiguration/v1api20241101/flux_configuration_types_gen.go
@@ -326,7 +326,7 @@ func (configuration *FluxConfiguration_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties = &arm.FluxConfiguration_Properties_Spec{}
 	}
 	if configuration.AzureBlob != nil {
-		azureBlob_ARM, err := (*configuration.AzureBlob).ConvertToARM(resolved)
+		azureBlob_ARM, err := configuration.AzureBlob.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -334,7 +334,7 @@ func (configuration *FluxConfiguration_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.AzureBlob = &azureBlob
 	}
 	if configuration.Bucket != nil {
-		bucket_ARM, err := (*configuration.Bucket).ConvertToARM(resolved)
+		bucket_ARM, err := configuration.Bucket.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -351,7 +351,7 @@ func (configuration *FluxConfiguration_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.ConfigurationProtectedSettings = temp
 	}
 	if configuration.GitRepository != nil {
-		gitRepository_ARM, err := (*configuration.GitRepository).ConvertToARM(resolved)
+		gitRepository_ARM, err := configuration.GitRepository.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -373,7 +373,7 @@ func (configuration *FluxConfiguration_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.Namespace = &namespace
 	}
 	if configuration.OciRepository != nil {
-		ociRepository_ARM, err := (*configuration.OciRepository).ConvertToARM(resolved)
+		ociRepository_ARM, err := configuration.OciRepository.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1817,7 +1817,7 @@ func (definition *AzureBlobDefinition) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "ManagedIdentity":
 	if definition.ManagedIdentity != nil {
-		managedIdentity_ARM, err := (*definition.ManagedIdentity).ConvertToARM(resolved)
+		managedIdentity_ARM, err := definition.ManagedIdentity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1837,7 +1837,7 @@ func (definition *AzureBlobDefinition) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "ServicePrincipal":
 	if definition.ServicePrincipal != nil {
-		servicePrincipal_ARM, err := (*definition.ServicePrincipal).ConvertToARM(resolved)
+		servicePrincipal_ARM, err := definition.ServicePrincipal.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2905,7 +2905,7 @@ func (definition *GitRepositoryDefinition) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "RepositoryRef":
 	if definition.RepositoryRef != nil {
-		repositoryRef_ARM, err := (*definition.RepositoryRef).ConvertToARM(resolved)
+		repositoryRef_ARM, err := definition.RepositoryRef.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3436,7 +3436,7 @@ func (definition *KustomizationDefinition) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "PostBuild":
 	if definition.PostBuild != nil {
-		postBuild_ARM, err := (*definition.PostBuild).ConvertToARM(resolved)
+		postBuild_ARM, err := definition.PostBuild.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4280,7 +4280,7 @@ func (definition *OCIRepositoryDefinition) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "LayerSelector":
 	if definition.LayerSelector != nil {
-		layerSelector_ARM, err := (*definition.LayerSelector).ConvertToARM(resolved)
+		layerSelector_ARM, err := definition.LayerSelector.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4296,7 +4296,7 @@ func (definition *OCIRepositoryDefinition) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "RepositoryRef":
 	if definition.RepositoryRef != nil {
-		repositoryRef_ARM, err := (*definition.RepositoryRef).ConvertToARM(resolved)
+		repositoryRef_ARM, err := definition.RepositoryRef.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4324,7 +4324,7 @@ func (definition *OCIRepositoryDefinition) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "TlsConfig":
 	if definition.TlsConfig != nil {
-		tlsConfig_ARM, err := (*definition.TlsConfig).ConvertToARM(resolved)
+		tlsConfig_ARM, err := definition.TlsConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4346,7 +4346,7 @@ func (definition *OCIRepositoryDefinition) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "Verify":
 	if definition.Verify != nil {
-		verify_ARM, err := (*definition.Verify).ConvertToARM(resolved)
+		verify_ARM, err := definition.Verify.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/kusto/v1api20230815/cluster_types_gen.go
+++ b/v2/api/kusto/v1api20230815/cluster_types_gen.go
@@ -356,7 +356,7 @@ func (cluster *Cluster_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Identity":
 	if cluster.Identity != nil {
-		identity_ARM, err := (*cluster.Identity).ConvertToARM(resolved)
+		identity_ARM, err := cluster.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -434,7 +434,7 @@ func (cluster *Cluster_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.EngineType = &engineType
 	}
 	if cluster.KeyVaultProperties != nil {
-		keyVaultProperties_ARM, err := (*cluster.KeyVaultProperties).ConvertToARM(resolved)
+		keyVaultProperties_ARM, err := cluster.KeyVaultProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -442,7 +442,7 @@ func (cluster *Cluster_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.KeyVaultProperties = &keyVaultProperties
 	}
 	if cluster.LanguageExtensions != nil {
-		languageExtensions_ARM, err := (*cluster.LanguageExtensions).ConvertToARM(resolved)
+		languageExtensions_ARM, err := cluster.LanguageExtensions.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -450,7 +450,7 @@ func (cluster *Cluster_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.LanguageExtensions = &languageExtensions
 	}
 	if cluster.OptimizedAutoscale != nil {
-		optimizedAutoscale_ARM, err := (*cluster.OptimizedAutoscale).ConvertToARM(resolved)
+		optimizedAutoscale_ARM, err := cluster.OptimizedAutoscale.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -491,7 +491,7 @@ func (cluster *Cluster_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.VirtualClusterGraduationProperties = &virtualClusterGraduationProperties
 	}
 	if cluster.VirtualNetworkConfiguration != nil {
-		virtualNetworkConfiguration_ARM, err := (*cluster.VirtualNetworkConfiguration).ConvertToARM(resolved)
+		virtualNetworkConfiguration_ARM, err := cluster.VirtualNetworkConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -501,7 +501,7 @@ func (cluster *Cluster_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Sku":
 	if cluster.Sku != nil {
-		sku_ARM, err := (*cluster.Sku).ConvertToARM(resolved)
+		sku_ARM, err := cluster.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/kusto/v1api20230815/data_connection_types_gen.go
+++ b/v2/api/kusto/v1api20230815/data_connection_types_gen.go
@@ -289,7 +289,7 @@ func (connection *DataConnection_Spec) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "CosmosDb":
 	if connection.CosmosDb != nil {
-		cosmosDb_ARM, err := (*connection.CosmosDb).ConvertToARM(resolved)
+		cosmosDb_ARM, err := connection.CosmosDb.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -300,7 +300,7 @@ func (connection *DataConnection_Spec) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "EventGrid":
 	if connection.EventGrid != nil {
-		eventGrid_ARM, err := (*connection.EventGrid).ConvertToARM(resolved)
+		eventGrid_ARM, err := connection.EventGrid.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -311,7 +311,7 @@ func (connection *DataConnection_Spec) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "EventHub":
 	if connection.EventHub != nil {
-		eventHub_ARM, err := (*connection.EventHub).ConvertToARM(resolved)
+		eventHub_ARM, err := connection.EventHub.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -322,7 +322,7 @@ func (connection *DataConnection_Spec) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "IotHub":
 	if connection.IotHub != nil {
-		iotHub_ARM, err := (*connection.IotHub).ConvertToARM(resolved)
+		iotHub_ARM, err := connection.IotHub.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/kusto/v1api20230815/database_types_gen.go
+++ b/v2/api/kusto/v1api20230815/database_types_gen.go
@@ -283,7 +283,7 @@ func (database *Database_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "ReadWrite":
 	if database.ReadWrite != nil {
-		readWrite_ARM, err := (*database.ReadWrite).ConvertToARM(resolved)
+		readWrite_ARM, err := database.ReadWrite.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -804,7 +804,7 @@ func (database *ReadWriteDatabase) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.HotCachePeriod = &hotCachePeriod
 	}
 	if database.KeyVaultProperties != nil {
-		keyVaultProperties_ARM, err := (*database.KeyVaultProperties).ConvertToARM(resolved)
+		keyVaultProperties_ARM, err := database.KeyVaultProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/kusto/v1api20240413/cluster_types_gen.go
+++ b/v2/api/kusto/v1api20240413/cluster_types_gen.go
@@ -386,7 +386,7 @@ func (cluster *Cluster_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Identity":
 	if cluster.Identity != nil {
-		identity_ARM, err := (*cluster.Identity).ConvertToARM(resolved)
+		identity_ARM, err := cluster.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -472,7 +472,7 @@ func (cluster *Cluster_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.EngineType = &engineType
 	}
 	if cluster.KeyVaultProperties != nil {
-		keyVaultProperties_ARM, err := (*cluster.KeyVaultProperties).ConvertToARM(resolved)
+		keyVaultProperties_ARM, err := cluster.KeyVaultProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -480,7 +480,7 @@ func (cluster *Cluster_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.KeyVaultProperties = &keyVaultProperties
 	}
 	if cluster.LanguageExtensions != nil {
-		languageExtensions_ARM, err := (*cluster.LanguageExtensions).ConvertToARM(resolved)
+		languageExtensions_ARM, err := cluster.LanguageExtensions.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -488,7 +488,7 @@ func (cluster *Cluster_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.LanguageExtensions = &languageExtensions
 	}
 	if cluster.OptimizedAutoscale != nil {
-		optimizedAutoscale_ARM, err := (*cluster.OptimizedAutoscale).ConvertToARM(resolved)
+		optimizedAutoscale_ARM, err := cluster.OptimizedAutoscale.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -529,7 +529,7 @@ func (cluster *Cluster_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.VirtualClusterGraduationProperties = &virtualClusterGraduationProperties
 	}
 	if cluster.VirtualNetworkConfiguration != nil {
-		virtualNetworkConfiguration_ARM, err := (*cluster.VirtualNetworkConfiguration).ConvertToARM(resolved)
+		virtualNetworkConfiguration_ARM, err := cluster.VirtualNetworkConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -539,7 +539,7 @@ func (cluster *Cluster_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Sku":
 	if cluster.Sku != nil {
-		sku_ARM, err := (*cluster.Sku).ConvertToARM(resolved)
+		sku_ARM, err := cluster.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/kusto/v1api20240413/data_connection_types_gen.go
+++ b/v2/api/kusto/v1api20240413/data_connection_types_gen.go
@@ -286,7 +286,7 @@ func (connection *DataConnection_Spec) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "CosmosDb":
 	if connection.CosmosDb != nil {
-		cosmosDb_ARM, err := (*connection.CosmosDb).ConvertToARM(resolved)
+		cosmosDb_ARM, err := connection.CosmosDb.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -297,7 +297,7 @@ func (connection *DataConnection_Spec) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "EventGrid":
 	if connection.EventGrid != nil {
-		eventGrid_ARM, err := (*connection.EventGrid).ConvertToARM(resolved)
+		eventGrid_ARM, err := connection.EventGrid.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -308,7 +308,7 @@ func (connection *DataConnection_Spec) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "EventHub":
 	if connection.EventHub != nil {
-		eventHub_ARM, err := (*connection.EventHub).ConvertToARM(resolved)
+		eventHub_ARM, err := connection.EventHub.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -319,7 +319,7 @@ func (connection *DataConnection_Spec) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "IotHub":
 	if connection.IotHub != nil {
-		iotHub_ARM, err := (*connection.IotHub).ConvertToARM(resolved)
+		iotHub_ARM, err := connection.IotHub.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/kusto/v1api20240413/database_types_gen.go
+++ b/v2/api/kusto/v1api20240413/database_types_gen.go
@@ -280,7 +280,7 @@ func (database *Database_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "ReadWrite":
 	if database.ReadWrite != nil {
-		readWrite_ARM, err := (*database.ReadWrite).ConvertToARM(resolved)
+		readWrite_ARM, err := database.ReadWrite.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -820,7 +820,7 @@ func (database *ReadWriteDatabase) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.HotCachePeriod = &hotCachePeriod
 	}
 	if database.KeyVaultProperties != nil {
-		keyVaultProperties_ARM, err := (*database.KeyVaultProperties).ConvertToARM(resolved)
+		keyVaultProperties_ARM, err := database.KeyVaultProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/machinelearningservices/v1api20210701/workspace_types_gen.go
+++ b/v2/api/machinelearningservices/v1api20210701/workspace_types_gen.go
@@ -345,7 +345,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Identity":
 	if workspace.Identity != nil {
-		identity_ARM, err := (*workspace.Identity).ConvertToARM(resolved)
+		identity_ARM, err := workspace.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -409,7 +409,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.DiscoveryUrl = &discoveryUrl
 	}
 	if workspace.Encryption != nil {
-		encryption_ARM, err := (*workspace.Encryption).ConvertToARM(resolved)
+		encryption_ARM, err := workspace.Encryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -451,7 +451,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.PublicNetworkAccess = &publicNetworkAccess
 	}
 	if workspace.ServiceManagedResourcesSettings != nil {
-		serviceManagedResourcesSettings_ARM, err := (*workspace.ServiceManagedResourcesSettings).ConvertToARM(resolved)
+		serviceManagedResourcesSettings_ARM, err := workspace.ServiceManagedResourcesSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -476,7 +476,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Sku":
 	if workspace.Sku != nil {
-		sku_ARM, err := (*workspace.Sku).ConvertToARM(resolved)
+		sku_ARM, err := workspace.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -486,7 +486,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "SystemData":
 	if workspace.SystemData != nil {
-		systemData_ARM, err := (*workspace.SystemData).ConvertToARM(resolved)
+		systemData_ARM, err := workspace.SystemData.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2093,7 +2093,7 @@ func (property *EncryptionProperty) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Identity":
 	if property.Identity != nil {
-		identity_ARM, err := (*property.Identity).ConvertToARM(resolved)
+		identity_ARM, err := property.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2103,7 +2103,7 @@ func (property *EncryptionProperty) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "KeyVaultProperties":
 	if property.KeyVaultProperties != nil {
-		keyVaultProperties_ARM, err := (*property.KeyVaultProperties).ConvertToARM(resolved)
+		keyVaultProperties_ARM, err := property.KeyVaultProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2850,7 +2850,7 @@ func (settings *ServiceManagedResourcesSettings) ConvertToARM(resolved genruntim
 
 	// Set property "CosmosDb":
 	if settings.CosmosDb != nil {
-		cosmosDb_ARM, err := (*settings.CosmosDb).ConvertToARM(resolved)
+		cosmosDb_ARM, err := settings.CosmosDb.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/machinelearningservices/v1api20210701/workspaces_compute_types_gen.go
+++ b/v2/api/machinelearningservices/v1api20210701/workspaces_compute_types_gen.go
@@ -295,7 +295,7 @@ func (compute *WorkspacesCompute_Spec) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "Identity":
 	if compute.Identity != nil {
-		identity_ARM, err := (*compute.Identity).ConvertToARM(resolved)
+		identity_ARM, err := compute.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -314,7 +314,7 @@ func (compute *WorkspacesCompute_Spec) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "Properties":
 	if compute.Properties != nil {
-		properties_ARM, err := (*compute.Properties).ConvertToARM(resolved)
+		properties_ARM, err := compute.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -324,7 +324,7 @@ func (compute *WorkspacesCompute_Spec) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "Sku":
 	if compute.Sku != nil {
-		sku_ARM, err := (*compute.Sku).ConvertToARM(resolved)
+		sku_ARM, err := compute.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -334,7 +334,7 @@ func (compute *WorkspacesCompute_Spec) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "SystemData":
 	if compute.SystemData != nil {
-		systemData_ARM, err := (*compute.SystemData).ConvertToARM(resolved)
+		systemData_ARM, err := compute.SystemData.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1052,7 +1052,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 
 	// Set property "AKS":
 	if compute.AKS != nil {
-		aks_ARM, err := (*compute.AKS).ConvertToARM(resolved)
+		aks_ARM, err := compute.AKS.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1062,7 +1062,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 
 	// Set property "AmlCompute":
 	if compute.AmlCompute != nil {
-		amlCompute_ARM, err := (*compute.AmlCompute).ConvertToARM(resolved)
+		amlCompute_ARM, err := compute.AmlCompute.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1072,7 +1072,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 
 	// Set property "ComputeInstance":
 	if compute.ComputeInstance != nil {
-		computeInstance_ARM, err := (*compute.ComputeInstance).ConvertToARM(resolved)
+		computeInstance_ARM, err := compute.ComputeInstance.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1082,7 +1082,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 
 	// Set property "DataFactory":
 	if compute.DataFactory != nil {
-		dataFactory_ARM, err := (*compute.DataFactory).ConvertToARM(resolved)
+		dataFactory_ARM, err := compute.DataFactory.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1092,7 +1092,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 
 	// Set property "DataLakeAnalytics":
 	if compute.DataLakeAnalytics != nil {
-		dataLakeAnalytics_ARM, err := (*compute.DataLakeAnalytics).ConvertToARM(resolved)
+		dataLakeAnalytics_ARM, err := compute.DataLakeAnalytics.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1102,7 +1102,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 
 	// Set property "Databricks":
 	if compute.Databricks != nil {
-		databricks_ARM, err := (*compute.Databricks).ConvertToARM(resolved)
+		databricks_ARM, err := compute.Databricks.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1112,7 +1112,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 
 	// Set property "HDInsight":
 	if compute.HDInsight != nil {
-		hdInsight_ARM, err := (*compute.HDInsight).ConvertToARM(resolved)
+		hdInsight_ARM, err := compute.HDInsight.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1122,7 +1122,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 
 	// Set property "Kubernetes":
 	if compute.Kubernetes != nil {
-		kubernetes_ARM, err := (*compute.Kubernetes).ConvertToARM(resolved)
+		kubernetes_ARM, err := compute.Kubernetes.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1132,7 +1132,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 
 	// Set property "SynapseSpark":
 	if compute.SynapseSpark != nil {
-		synapseSpark_ARM, err := (*compute.SynapseSpark).ConvertToARM(resolved)
+		synapseSpark_ARM, err := compute.SynapseSpark.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1142,7 +1142,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 
 	// Set property "VirtualMachine":
 	if compute.VirtualMachine != nil {
-		virtualMachine_ARM, err := (*compute.VirtualMachine).ConvertToARM(resolved)
+		virtualMachine_ARM, err := compute.VirtualMachine.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2128,7 +2128,7 @@ func (aks *AKS) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 
 	// Set property "Properties":
 	if aks.Properties != nil {
-		properties_ARM, err := (*aks.Properties).ConvertToARM(resolved)
+		properties_ARM, err := aks.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2683,7 +2683,7 @@ func (compute *AmlCompute) ConvertToARM(resolved genruntime.ConvertToARMResolved
 
 	// Set property "Properties":
 	if compute.Properties != nil {
-		properties_ARM, err := (*compute.Properties).ConvertToARM(resolved)
+		properties_ARM, err := compute.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3238,7 +3238,7 @@ func (instance *ComputeInstance) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Properties":
 	if instance.Properties != nil {
-		properties_ARM, err := (*instance.Properties).ConvertToARM(resolved)
+		properties_ARM, err := instance.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3793,7 +3793,7 @@ func (databricks *Databricks) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "Properties":
 	if databricks.Properties != nil {
-		properties_ARM, err := (*databricks.Properties).ConvertToARM(resolved)
+		properties_ARM, err := databricks.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4815,7 +4815,7 @@ func (analytics *DataLakeAnalytics) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Properties":
 	if analytics.Properties != nil {
-		properties_ARM, err := (*analytics.Properties).ConvertToARM(resolved)
+		properties_ARM, err := analytics.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5368,7 +5368,7 @@ func (insight *HDInsight) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "Properties":
 	if insight.Properties != nil {
-		properties_ARM, err := (*insight.Properties).ConvertToARM(resolved)
+		properties_ARM, err := insight.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5923,7 +5923,7 @@ func (kubernetes *Kubernetes) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "Properties":
 	if kubernetes.Properties != nil {
-		properties_ARM, err := (*kubernetes.Properties).ConvertToARM(resolved)
+		properties_ARM, err := kubernetes.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6476,7 +6476,7 @@ func (spark *SynapseSpark) ConvertToARM(resolved genruntime.ConvertToARMResolved
 
 	// Set property "Properties":
 	if spark.Properties != nil {
-		properties_ARM, err := (*spark.Properties).ConvertToARM(resolved)
+		properties_ARM, err := spark.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7027,7 +7027,7 @@ func (machine *VirtualMachine) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "Properties":
 	if machine.Properties != nil {
-		properties_ARM, err := (*machine.Properties).ConvertToARM(resolved)
+		properties_ARM, err := machine.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7589,7 +7589,7 @@ func (properties *AKS_Properties) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "AksNetworkingConfiguration":
 	if properties.AksNetworkingConfiguration != nil {
-		aksNetworkingConfiguration_ARM, err := (*properties.AksNetworkingConfiguration).ConvertToARM(resolved)
+		aksNetworkingConfiguration_ARM, err := properties.AksNetworkingConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7627,7 +7627,7 @@ func (properties *AKS_Properties) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "SslConfiguration":
 	if properties.SslConfiguration != nil {
-		sslConfiguration_ARM, err := (*properties.SslConfiguration).ConvertToARM(resolved)
+		sslConfiguration_ARM, err := properties.SslConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8271,7 +8271,7 @@ func (properties *AmlComputeProperties) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "ScaleSettings":
 	if properties.ScaleSettings != nil {
-		scaleSettings_ARM, err := (*properties.ScaleSettings).ConvertToARM(resolved)
+		scaleSettings_ARM, err := properties.ScaleSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8281,7 +8281,7 @@ func (properties *AmlComputeProperties) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "Subnet":
 	if properties.Subnet != nil {
-		subnet_ARM, err := (*properties.Subnet).ConvertToARM(resolved)
+		subnet_ARM, err := properties.Subnet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8291,7 +8291,7 @@ func (properties *AmlComputeProperties) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "UserAccountCredentials":
 	if properties.UserAccountCredentials != nil {
-		userAccountCredentials_ARM, err := (*properties.UserAccountCredentials).ConvertToARM(resolved)
+		userAccountCredentials_ARM, err := properties.UserAccountCredentials.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8301,7 +8301,7 @@ func (properties *AmlComputeProperties) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "VirtualMachineImage":
 	if properties.VirtualMachineImage != nil {
-		virtualMachineImage_ARM, err := (*properties.VirtualMachineImage).ConvertToARM(resolved)
+		virtualMachineImage_ARM, err := properties.VirtualMachineImage.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9246,7 +9246,7 @@ func (properties *ComputeInstanceProperties) ConvertToARM(resolved genruntime.Co
 
 	// Set property "PersonalComputeInstanceSettings":
 	if properties.PersonalComputeInstanceSettings != nil {
-		personalComputeInstanceSettings_ARM, err := (*properties.PersonalComputeInstanceSettings).ConvertToARM(resolved)
+		personalComputeInstanceSettings_ARM, err := properties.PersonalComputeInstanceSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9256,7 +9256,7 @@ func (properties *ComputeInstanceProperties) ConvertToARM(resolved genruntime.Co
 
 	// Set property "SetupScripts":
 	if properties.SetupScripts != nil {
-		setupScripts_ARM, err := (*properties.SetupScripts).ConvertToARM(resolved)
+		setupScripts_ARM, err := properties.SetupScripts.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9266,7 +9266,7 @@ func (properties *ComputeInstanceProperties) ConvertToARM(resolved genruntime.Co
 
 	// Set property "SshSettings":
 	if properties.SshSettings != nil {
-		sshSettings_ARM, err := (*properties.SshSettings).ConvertToARM(resolved)
+		sshSettings_ARM, err := properties.SshSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9276,7 +9276,7 @@ func (properties *ComputeInstanceProperties) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Subnet":
 	if properties.Subnet != nil {
-		subnet_ARM, err := (*properties.Subnet).ConvertToARM(resolved)
+		subnet_ARM, err := properties.Subnet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10617,7 +10617,7 @@ func (properties *HDInsightProperties) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "AdministratorAccount":
 	if properties.AdministratorAccount != nil {
-		administratorAccount_ARM, err := (*properties.AdministratorAccount).ConvertToARM(resolved)
+		administratorAccount_ARM, err := properties.AdministratorAccount.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11402,7 +11402,7 @@ func (properties *SynapseSpark_Properties) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "AutoPauseProperties":
 	if properties.AutoPauseProperties != nil {
-		autoPauseProperties_ARM, err := (*properties.AutoPauseProperties).ConvertToARM(resolved)
+		autoPauseProperties_ARM, err := properties.AutoPauseProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11412,7 +11412,7 @@ func (properties *SynapseSpark_Properties) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "AutoScaleProperties":
 	if properties.AutoScaleProperties != nil {
-		autoScaleProperties_ARM, err := (*properties.AutoScaleProperties).ConvertToARM(resolved)
+		autoScaleProperties_ARM, err := properties.AutoScaleProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -11990,7 +11990,7 @@ func (properties *VirtualMachine_Properties) ConvertToARM(resolved genruntime.Co
 
 	// Set property "AdministratorAccount":
 	if properties.AdministratorAccount != nil {
-		administratorAccount_ARM, err := (*properties.AdministratorAccount).ConvertToARM(resolved)
+		administratorAccount_ARM, err := properties.AdministratorAccount.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -14025,7 +14025,7 @@ func (schema *InstanceTypeSchema) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "Resources":
 	if schema.Resources != nil {
-		resources_ARM, err := (*schema.Resources).ConvertToARM(resolved)
+		resources_ARM, err := schema.Resources.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -14373,7 +14373,7 @@ func (settings *PersonalComputeInstanceSettings) ConvertToARM(resolved genruntim
 
 	// Set property "AssignedUser":
 	if settings.AssignedUser != nil {
-		assignedUser_ARM, err := (*settings.AssignedUser).ConvertToARM(resolved)
+		assignedUser_ARM, err := settings.AssignedUser.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -14906,7 +14906,7 @@ func (scripts *SetupScripts) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Scripts":
 	if scripts.Scripts != nil {
-		scripts_ARM, err := (*scripts.Scripts).ConvertToARM(resolved)
+		scripts_ARM, err := scripts.Scripts.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -16754,7 +16754,7 @@ func (execute *ScriptsToExecute) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "CreationScript":
 	if execute.CreationScript != nil {
-		creationScript_ARM, err := (*execute.CreationScript).ConvertToARM(resolved)
+		creationScript_ARM, err := execute.CreationScript.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -16764,7 +16764,7 @@ func (execute *ScriptsToExecute) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "StartupScript":
 	if execute.StartupScript != nil {
-		startupScript_ARM, err := (*execute.StartupScript).ConvertToARM(resolved)
+		startupScript_ARM, err := execute.StartupScript.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/machinelearningservices/v1api20240401/registry_types_gen.go
+++ b/v2/api/machinelearningservices/v1api20240401/registry_types_gen.go
@@ -343,7 +343,7 @@ func (registry *Registry_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "Identity":
 	if registry.Identity != nil {
-		identity_ARM, err := (*registry.Identity).ConvertToARM(resolved)
+		identity_ARM, err := registry.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -385,7 +385,7 @@ func (registry *Registry_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.IntellectualPropertyPublisher = &intellectualPropertyPublisher
 	}
 	if registry.ManagedResourceGroup != nil {
-		managedResourceGroup_ARM, err := (*registry.ManagedResourceGroup).ConvertToARM(resolved)
+		managedResourceGroup_ARM, err := registry.ManagedResourceGroup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -417,7 +417,7 @@ func (registry *Registry_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "Sku":
 	if registry.Sku != nil {
-		sku_ARM, err := (*registry.Sku).ConvertToARM(resolved)
+		sku_ARM, err := registry.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2200,7 +2200,7 @@ func (connection *RegistryPrivateEndpointConnection) ConvertToARM(resolved genru
 		result.Properties.GroupIds = append(result.Properties.GroupIds, item)
 	}
 	if connection.PrivateEndpoint != nil {
-		privateEndpoint_ARM, err := (*connection.PrivateEndpoint).ConvertToARM(resolved)
+		privateEndpoint_ARM, err := connection.PrivateEndpoint.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2212,7 +2212,7 @@ func (connection *RegistryPrivateEndpointConnection) ConvertToARM(resolved genru
 		result.Properties.ProvisioningState = &provisioningState
 	}
 	if connection.RegistryPrivateLinkServiceConnectionState != nil {
-		registryPrivateLinkServiceConnectionState_ARM, err := (*connection.RegistryPrivateLinkServiceConnectionState).ConvertToARM(resolved)
+		registryPrivateLinkServiceConnectionState_ARM, err := connection.RegistryPrivateLinkServiceConnectionState.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3546,7 +3546,7 @@ func (details *AcrDetails) ConvertToARM(resolved genruntime.ConvertToARMResolved
 
 	// Set property "SystemCreatedAcrAccount":
 	if details.SystemCreatedAcrAccount != nil {
-		systemCreatedAcrAccount_ARM, err := (*details.SystemCreatedAcrAccount).ConvertToARM(resolved)
+		systemCreatedAcrAccount_ARM, err := details.SystemCreatedAcrAccount.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4315,7 +4315,7 @@ func (details *StorageAccountDetails) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "SystemCreatedStorageAccount":
 	if details.SystemCreatedStorageAccount != nil {
-		systemCreatedStorageAccount_ARM, err := (*details.SystemCreatedStorageAccount).ConvertToARM(resolved)
+		systemCreatedStorageAccount_ARM, err := details.SystemCreatedStorageAccount.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/machinelearningservices/v1api20240401/workspace_types_gen.go
+++ b/v2/api/machinelearningservices/v1api20240401/workspace_types_gen.go
@@ -352,7 +352,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Identity":
 	if workspace.Identity != nil {
-		identity_ARM, err := (*workspace.Identity).ConvertToARM(resolved)
+		identity_ARM, err := workspace.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -437,7 +437,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.EnableDataIsolation = &enableDataIsolation
 	}
 	if workspace.Encryption != nil {
-		encryption_ARM, err := (*workspace.Encryption).ConvertToARM(resolved)
+		encryption_ARM, err := workspace.Encryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -445,7 +445,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.Encryption = &encryption
 	}
 	if workspace.FeatureStoreSettings != nil {
-		featureStoreSettings_ARM, err := (*workspace.FeatureStoreSettings).ConvertToARM(resolved)
+		featureStoreSettings_ARM, err := workspace.FeatureStoreSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -481,7 +481,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.KeyVault = &keyVault
 	}
 	if workspace.ManagedNetwork != nil {
-		managedNetwork_ARM, err := (*workspace.ManagedNetwork).ConvertToARM(resolved)
+		managedNetwork_ARM, err := workspace.ManagedNetwork.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -503,7 +503,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.PublicNetworkAccess = &publicNetworkAccess
 	}
 	if workspace.ServerlessComputeSettings != nil {
-		serverlessComputeSettings_ARM, err := (*workspace.ServerlessComputeSettings).ConvertToARM(resolved)
+		serverlessComputeSettings_ARM, err := workspace.ServerlessComputeSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -511,7 +511,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.ServerlessComputeSettings = &serverlessComputeSettings
 	}
 	if workspace.ServiceManagedResourcesSettings != nil {
-		serviceManagedResourcesSettings_ARM, err := (*workspace.ServiceManagedResourcesSettings).ConvertToARM(resolved)
+		serviceManagedResourcesSettings_ARM, err := workspace.ServiceManagedResourcesSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -538,7 +538,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.V1LegacyMode = &v1LegacyMode
 	}
 	if workspace.WorkspaceHubConfig != nil {
-		workspaceHubConfig_ARM, err := (*workspace.WorkspaceHubConfig).ConvertToARM(resolved)
+		workspaceHubConfig_ARM, err := workspace.WorkspaceHubConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -548,7 +548,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Sku":
 	if workspace.Sku != nil {
-		sku_ARM, err := (*workspace.Sku).ConvertToARM(resolved)
+		sku_ARM, err := workspace.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2819,7 +2819,7 @@ func (property *EncryptionProperty) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Identity":
 	if property.Identity != nil {
-		identity_ARM, err := (*property.Identity).ConvertToARM(resolved)
+		identity_ARM, err := property.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2829,7 +2829,7 @@ func (property *EncryptionProperty) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "KeyVaultProperties":
 	if property.KeyVaultProperties != nil {
-		keyVaultProperties_ARM, err := (*property.KeyVaultProperties).ConvertToARM(resolved)
+		keyVaultProperties_ARM, err := property.KeyVaultProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3145,7 +3145,7 @@ func (settings *FeatureStoreSettings) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "ComputeRuntime":
 	if settings.ComputeRuntime != nil {
-		computeRuntime_ARM, err := (*settings.ComputeRuntime).ConvertToARM(resolved)
+		computeRuntime_ARM, err := settings.ComputeRuntime.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3439,7 +3439,7 @@ func (settings *ManagedNetworkSettings) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "Status":
 	if settings.Status != nil {
-		status_ARM, err := (*settings.Status).ConvertToARM(resolved)
+		status_ARM, err := settings.Status.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4217,7 +4217,7 @@ func (settings *ServiceManagedResourcesSettings) ConvertToARM(resolved genruntim
 
 	// Set property "CosmosDb":
 	if settings.CosmosDb != nil {
-		cosmosDb_ARM, err := (*settings.CosmosDb).ConvertToARM(resolved)
+		cosmosDb_ARM, err := settings.CosmosDb.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6195,7 +6195,7 @@ func (rule *OutboundRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "FQDN":
 	if rule.FQDN != nil {
-		fqdn_ARM, err := (*rule.FQDN).ConvertToARM(resolved)
+		fqdn_ARM, err := rule.FQDN.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6205,7 +6205,7 @@ func (rule *OutboundRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "PrivateEndpoint":
 	if rule.PrivateEndpoint != nil {
-		privateEndpoint_ARM, err := (*rule.PrivateEndpoint).ConvertToARM(resolved)
+		privateEndpoint_ARM, err := rule.PrivateEndpoint.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6215,7 +6215,7 @@ func (rule *OutboundRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "ServiceTag":
 	if rule.ServiceTag != nil {
-		serviceTag_ARM, err := (*rule.ServiceTag).ConvertToARM(resolved)
+		serviceTag_ARM, err := rule.ServiceTag.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7188,7 +7188,7 @@ func (rule *PrivateEndpointOutboundRule) ConvertToARM(resolved genruntime.Conver
 
 	// Set property "Destination":
 	if rule.Destination != nil {
-		destination_ARM, err := (*rule.Destination).ConvertToARM(resolved)
+		destination_ARM, err := rule.Destination.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7603,7 +7603,7 @@ func (rule *ServiceTagOutboundRule) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Destination":
 	if rule.Destination != nil {
-		destination_ARM, err := (*rule.Destination).ConvertToARM(resolved)
+		destination_ARM, err := rule.Destination.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/machinelearningservices/v1api20240401/workspaces_compute_types_gen.go
+++ b/v2/api/machinelearningservices/v1api20240401/workspaces_compute_types_gen.go
@@ -289,7 +289,7 @@ func (compute *WorkspacesCompute_Spec) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "Identity":
 	if compute.Identity != nil {
-		identity_ARM, err := (*compute.Identity).ConvertToARM(resolved)
+		identity_ARM, err := compute.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -308,7 +308,7 @@ func (compute *WorkspacesCompute_Spec) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "Properties":
 	if compute.Properties != nil {
-		properties_ARM, err := (*compute.Properties).ConvertToARM(resolved)
+		properties_ARM, err := compute.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -318,7 +318,7 @@ func (compute *WorkspacesCompute_Spec) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "Sku":
 	if compute.Sku != nil {
-		sku_ARM, err := (*compute.Sku).ConvertToARM(resolved)
+		sku_ARM, err := compute.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1050,7 +1050,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 
 	// Set property "AKS":
 	if compute.AKS != nil {
-		aks_ARM, err := (*compute.AKS).ConvertToARM(resolved)
+		aks_ARM, err := compute.AKS.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1060,7 +1060,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 
 	// Set property "AmlCompute":
 	if compute.AmlCompute != nil {
-		amlCompute_ARM, err := (*compute.AmlCompute).ConvertToARM(resolved)
+		amlCompute_ARM, err := compute.AmlCompute.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1070,7 +1070,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 
 	// Set property "ComputeInstance":
 	if compute.ComputeInstance != nil {
-		computeInstance_ARM, err := (*compute.ComputeInstance).ConvertToARM(resolved)
+		computeInstance_ARM, err := compute.ComputeInstance.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1080,7 +1080,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 
 	// Set property "DataFactory":
 	if compute.DataFactory != nil {
-		dataFactory_ARM, err := (*compute.DataFactory).ConvertToARM(resolved)
+		dataFactory_ARM, err := compute.DataFactory.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1090,7 +1090,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 
 	// Set property "DataLakeAnalytics":
 	if compute.DataLakeAnalytics != nil {
-		dataLakeAnalytics_ARM, err := (*compute.DataLakeAnalytics).ConvertToARM(resolved)
+		dataLakeAnalytics_ARM, err := compute.DataLakeAnalytics.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1100,7 +1100,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 
 	// Set property "Databricks":
 	if compute.Databricks != nil {
-		databricks_ARM, err := (*compute.Databricks).ConvertToARM(resolved)
+		databricks_ARM, err := compute.Databricks.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1110,7 +1110,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 
 	// Set property "HDInsight":
 	if compute.HDInsight != nil {
-		hdInsight_ARM, err := (*compute.HDInsight).ConvertToARM(resolved)
+		hdInsight_ARM, err := compute.HDInsight.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1120,7 +1120,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 
 	// Set property "Kubernetes":
 	if compute.Kubernetes != nil {
-		kubernetes_ARM, err := (*compute.Kubernetes).ConvertToARM(resolved)
+		kubernetes_ARM, err := compute.Kubernetes.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1130,7 +1130,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 
 	// Set property "SynapseSpark":
 	if compute.SynapseSpark != nil {
-		synapseSpark_ARM, err := (*compute.SynapseSpark).ConvertToARM(resolved)
+		synapseSpark_ARM, err := compute.SynapseSpark.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1140,7 +1140,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 
 	// Set property "VirtualMachine":
 	if compute.VirtualMachine != nil {
-		virtualMachine_ARM, err := (*compute.VirtualMachine).ConvertToARM(resolved)
+		virtualMachine_ARM, err := compute.VirtualMachine.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2253,7 +2253,7 @@ func (aks *AKS) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 
 	// Set property "Properties":
 	if aks.Properties != nil {
-		properties_ARM, err := (*aks.Properties).ConvertToARM(resolved)
+		properties_ARM, err := aks.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2857,7 +2857,7 @@ func (compute *AmlCompute) ConvertToARM(resolved genruntime.ConvertToARMResolved
 
 	// Set property "Properties":
 	if compute.Properties != nil {
-		properties_ARM, err := (*compute.Properties).ConvertToARM(resolved)
+		properties_ARM, err := compute.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3461,7 +3461,7 @@ func (instance *ComputeInstance) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Properties":
 	if instance.Properties != nil {
-		properties_ARM, err := (*instance.Properties).ConvertToARM(resolved)
+		properties_ARM, err := instance.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4065,7 +4065,7 @@ func (databricks *Databricks) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "Properties":
 	if databricks.Properties != nil {
-		properties_ARM, err := (*databricks.Properties).ConvertToARM(resolved)
+		properties_ARM, err := databricks.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5173,7 +5173,7 @@ func (analytics *DataLakeAnalytics) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Properties":
 	if analytics.Properties != nil {
-		properties_ARM, err := (*analytics.Properties).ConvertToARM(resolved)
+		properties_ARM, err := analytics.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5775,7 +5775,7 @@ func (insight *HDInsight) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "Properties":
 	if insight.Properties != nil {
-		properties_ARM, err := (*insight.Properties).ConvertToARM(resolved)
+		properties_ARM, err := insight.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6379,7 +6379,7 @@ func (kubernetes *Kubernetes) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "Properties":
 	if kubernetes.Properties != nil {
-		properties_ARM, err := (*kubernetes.Properties).ConvertToARM(resolved)
+		properties_ARM, err := kubernetes.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6981,7 +6981,7 @@ func (spark *SynapseSpark) ConvertToARM(resolved genruntime.ConvertToARMResolved
 
 	// Set property "Properties":
 	if spark.Properties != nil {
-		properties_ARM, err := (*spark.Properties).ConvertToARM(resolved)
+		properties_ARM, err := spark.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7581,7 +7581,7 @@ func (machine *VirtualMachine) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "Properties":
 	if machine.Properties != nil {
-		properties_ARM, err := (*machine.Properties).ConvertToARM(resolved)
+		properties_ARM, err := machine.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8192,7 +8192,7 @@ func (properties *AKS_Properties) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "AksNetworkingConfiguration":
 	if properties.AksNetworkingConfiguration != nil {
-		aksNetworkingConfiguration_ARM, err := (*properties.AksNetworkingConfiguration).ConvertToARM(resolved)
+		aksNetworkingConfiguration_ARM, err := properties.AksNetworkingConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8234,7 +8234,7 @@ func (properties *AKS_Properties) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "SslConfiguration":
 	if properties.SslConfiguration != nil {
-		sslConfiguration_ARM, err := (*properties.SslConfiguration).ConvertToARM(resolved)
+		sslConfiguration_ARM, err := properties.SslConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8951,7 +8951,7 @@ func (properties *AmlComputeProperties) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "ScaleSettings":
 	if properties.ScaleSettings != nil {
-		scaleSettings_ARM, err := (*properties.ScaleSettings).ConvertToARM(resolved)
+		scaleSettings_ARM, err := properties.ScaleSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8961,7 +8961,7 @@ func (properties *AmlComputeProperties) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "Subnet":
 	if properties.Subnet != nil {
-		subnet_ARM, err := (*properties.Subnet).ConvertToARM(resolved)
+		subnet_ARM, err := properties.Subnet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8971,7 +8971,7 @@ func (properties *AmlComputeProperties) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "UserAccountCredentials":
 	if properties.UserAccountCredentials != nil {
-		userAccountCredentials_ARM, err := (*properties.UserAccountCredentials).ConvertToARM(resolved)
+		userAccountCredentials_ARM, err := properties.UserAccountCredentials.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8981,7 +8981,7 @@ func (properties *AmlComputeProperties) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "VirtualMachineImage":
 	if properties.VirtualMachineImage != nil {
-		virtualMachineImage_ARM, err := (*properties.VirtualMachineImage).ConvertToARM(resolved)
+		virtualMachineImage_ARM, err := properties.VirtualMachineImage.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10134,7 +10134,7 @@ func (properties *ComputeInstanceProperties) ConvertToARM(resolved genruntime.Co
 
 	// Set property "PersonalComputeInstanceSettings":
 	if properties.PersonalComputeInstanceSettings != nil {
-		personalComputeInstanceSettings_ARM, err := (*properties.PersonalComputeInstanceSettings).ConvertToARM(resolved)
+		personalComputeInstanceSettings_ARM, err := properties.PersonalComputeInstanceSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10144,7 +10144,7 @@ func (properties *ComputeInstanceProperties) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Schedules":
 	if properties.Schedules != nil {
-		schedules_ARM, err := (*properties.Schedules).ConvertToARM(resolved)
+		schedules_ARM, err := properties.Schedules.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10154,7 +10154,7 @@ func (properties *ComputeInstanceProperties) ConvertToARM(resolved genruntime.Co
 
 	// Set property "SetupScripts":
 	if properties.SetupScripts != nil {
-		setupScripts_ARM, err := (*properties.SetupScripts).ConvertToARM(resolved)
+		setupScripts_ARM, err := properties.SetupScripts.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10164,7 +10164,7 @@ func (properties *ComputeInstanceProperties) ConvertToARM(resolved genruntime.Co
 
 	// Set property "SshSettings":
 	if properties.SshSettings != nil {
-		sshSettings_ARM, err := (*properties.SshSettings).ConvertToARM(resolved)
+		sshSettings_ARM, err := properties.SshSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10174,7 +10174,7 @@ func (properties *ComputeInstanceProperties) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Subnet":
 	if properties.Subnet != nil {
-		subnet_ARM, err := (*properties.Subnet).ConvertToARM(resolved)
+		subnet_ARM, err := properties.Subnet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12087,7 +12087,7 @@ func (properties *HDInsightProperties) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "AdministratorAccount":
 	if properties.AdministratorAccount != nil {
-		administratorAccount_ARM, err := (*properties.AdministratorAccount).ConvertToARM(resolved)
+		administratorAccount_ARM, err := properties.AdministratorAccount.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12966,7 +12966,7 @@ func (properties *SynapseSpark_Properties) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "AutoPauseProperties":
 	if properties.AutoPauseProperties != nil {
-		autoPauseProperties_ARM, err := (*properties.AutoPauseProperties).ConvertToARM(resolved)
+		autoPauseProperties_ARM, err := properties.AutoPauseProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12976,7 +12976,7 @@ func (properties *SynapseSpark_Properties) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "AutoScaleProperties":
 	if properties.AutoScaleProperties != nil {
-		autoScaleProperties_ARM, err := (*properties.AutoScaleProperties).ConvertToARM(resolved)
+		autoScaleProperties_ARM, err := properties.AutoScaleProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -13612,7 +13612,7 @@ func (properties *VirtualMachine_Properties) ConvertToARM(resolved genruntime.Co
 
 	// Set property "AdministratorAccount":
 	if properties.AdministratorAccount != nil {
-		administratorAccount_ARM, err := (*properties.AdministratorAccount).ConvertToARM(resolved)
+		administratorAccount_ARM, err := properties.AdministratorAccount.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -16509,7 +16509,7 @@ func (service *CustomService) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "Docker":
 	if service.Docker != nil {
-		docker_ARM, err := (*service.Docker).ConvertToARM(resolved)
+		docker_ARM, err := service.Docker.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -16540,7 +16540,7 @@ func (service *CustomService) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "Image":
 	if service.Image != nil {
-		image_ARM, err := (*service.Image).ConvertToARM(resolved)
+		image_ARM, err := service.Image.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -17514,7 +17514,7 @@ func (schema *InstanceTypeSchema) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "Resources":
 	if schema.Resources != nil {
-		resources_ARM, err := (*schema.Resources).ConvertToARM(resolved)
+		resources_ARM, err := schema.Resources.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -17884,7 +17884,7 @@ func (settings *PersonalComputeInstanceSettings) ConvertToARM(resolved genruntim
 
 	// Set property "AssignedUser":
 	if settings.AssignedUser != nil {
-		assignedUser_ARM, err := (*settings.AssignedUser).ConvertToARM(resolved)
+		assignedUser_ARM, err := settings.AssignedUser.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -18467,7 +18467,7 @@ func (scripts *SetupScripts) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Scripts":
 	if scripts.Scripts != nil {
-		scripts_ARM, err := (*scripts.Scripts).ConvertToARM(resolved)
+		scripts_ARM, err := scripts.Scripts.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -20269,7 +20269,7 @@ func (schedule *ComputeStartStopSchedule) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "Cron":
 	if schedule.Cron != nil {
-		cron_ARM, err := (*schedule.Cron).ConvertToARM(resolved)
+		cron_ARM, err := schedule.Cron.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -20279,7 +20279,7 @@ func (schedule *ComputeStartStopSchedule) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "Recurrence":
 	if schedule.Recurrence != nil {
-		recurrence_ARM, err := (*schedule.Recurrence).ConvertToARM(resolved)
+		recurrence_ARM, err := schedule.Recurrence.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -20289,7 +20289,7 @@ func (schedule *ComputeStartStopSchedule) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "Schedule":
 	if schedule.Schedule != nil {
-		schedule_ARM, err := (*schedule.Schedule).ConvertToARM(resolved)
+		schedule_ARM, err := schedule.Schedule.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -22261,7 +22261,7 @@ func (execute *ScriptsToExecute) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "CreationScript":
 	if execute.CreationScript != nil {
-		creationScript_ARM, err := (*execute.CreationScript).ConvertToARM(resolved)
+		creationScript_ARM, err := execute.CreationScript.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -22271,7 +22271,7 @@ func (execute *ScriptsToExecute) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "StartupScript":
 	if execute.StartupScript != nil {
-		startupScript_ARM, err := (*execute.StartupScript).ConvertToARM(resolved)
+		startupScript_ARM, err := execute.StartupScript.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -22610,7 +22610,7 @@ func (definition *VolumeDefinition) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Bind":
 	if definition.Bind != nil {
-		bind_ARM, err := (*definition.Bind).ConvertToARM(resolved)
+		bind_ARM, err := definition.Bind.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -22644,7 +22644,7 @@ func (definition *VolumeDefinition) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Tmpfs":
 	if definition.Tmpfs != nil {
-		tmpfs_ARM, err := (*definition.Tmpfs).ConvertToARM(resolved)
+		tmpfs_ARM, err := definition.Tmpfs.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -22662,7 +22662,7 @@ func (definition *VolumeDefinition) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Volume":
 	if definition.Volume != nil {
-		volume_ARM, err := (*definition.Volume).ConvertToARM(resolved)
+		volume_ARM, err := definition.Volume.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -23891,7 +23891,7 @@ func (recurrence *Recurrence) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "Schedule":
 	if recurrence.Schedule != nil {
-		schedule_ARM, err := (*recurrence.Schedule).ConvertToARM(resolved)
+		schedule_ARM, err := recurrence.Schedule.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/machinelearningservices/v1api20240401/workspaces_connection_types_gen.go
+++ b/v2/api/machinelearningservices/v1api20240401/workspaces_connection_types_gen.go
@@ -280,7 +280,7 @@ func (connection *WorkspacesConnection_Spec) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Properties":
 	if connection.Properties != nil {
-		properties_ARM, err := (*connection.Properties).ConvertToARM(resolved)
+		properties_ARM, err := connection.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -776,7 +776,7 @@ func (v2 *WorkspaceConnectionPropertiesV2) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "AAD":
 	if v2.AAD != nil {
-		aad_ARM, err := (*v2.AAD).ConvertToARM(resolved)
+		aad_ARM, err := v2.AAD.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -786,7 +786,7 @@ func (v2 *WorkspaceConnectionPropertiesV2) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "AccessKey":
 	if v2.AccessKey != nil {
-		accessKey_ARM, err := (*v2.AccessKey).ConvertToARM(resolved)
+		accessKey_ARM, err := v2.AccessKey.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -796,7 +796,7 @@ func (v2 *WorkspaceConnectionPropertiesV2) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "AccountKey":
 	if v2.AccountKey != nil {
-		accountKey_ARM, err := (*v2.AccountKey).ConvertToARM(resolved)
+		accountKey_ARM, err := v2.AccountKey.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -806,7 +806,7 @@ func (v2 *WorkspaceConnectionPropertiesV2) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "ApiKey":
 	if v2.ApiKey != nil {
-		apiKey_ARM, err := (*v2.ApiKey).ConvertToARM(resolved)
+		apiKey_ARM, err := v2.ApiKey.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -816,7 +816,7 @@ func (v2 *WorkspaceConnectionPropertiesV2) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "CustomKeys":
 	if v2.CustomKeys != nil {
-		customKeys_ARM, err := (*v2.CustomKeys).ConvertToARM(resolved)
+		customKeys_ARM, err := v2.CustomKeys.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -826,7 +826,7 @@ func (v2 *WorkspaceConnectionPropertiesV2) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "ManagedIdentity":
 	if v2.ManagedIdentity != nil {
-		managedIdentity_ARM, err := (*v2.ManagedIdentity).ConvertToARM(resolved)
+		managedIdentity_ARM, err := v2.ManagedIdentity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -836,7 +836,7 @@ func (v2 *WorkspaceConnectionPropertiesV2) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "None":
 	if v2.None != nil {
-		none_ARM, err := (*v2.None).ConvertToARM(resolved)
+		none_ARM, err := v2.None.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -846,7 +846,7 @@ func (v2 *WorkspaceConnectionPropertiesV2) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "OAuth2":
 	if v2.OAuth2 != nil {
-		oAuth2_ARM, err := (*v2.OAuth2).ConvertToARM(resolved)
+		oAuth2_ARM, err := v2.OAuth2.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -856,7 +856,7 @@ func (v2 *WorkspaceConnectionPropertiesV2) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "PAT":
 	if v2.PAT != nil {
-		pat_ARM, err := (*v2.PAT).ConvertToARM(resolved)
+		pat_ARM, err := v2.PAT.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -866,7 +866,7 @@ func (v2 *WorkspaceConnectionPropertiesV2) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "SAS":
 	if v2.SAS != nil {
-		sas_ARM, err := (*v2.SAS).ConvertToARM(resolved)
+		sas_ARM, err := v2.SAS.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -876,7 +876,7 @@ func (v2 *WorkspaceConnectionPropertiesV2) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "ServicePrincipal":
 	if v2.ServicePrincipal != nil {
-		servicePrincipal_ARM, err := (*v2.ServicePrincipal).ConvertToARM(resolved)
+		servicePrincipal_ARM, err := v2.ServicePrincipal.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -886,7 +886,7 @@ func (v2 *WorkspaceConnectionPropertiesV2) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "UsernamePassword":
 	if v2.UsernamePassword != nil {
-		usernamePassword_ARM, err := (*v2.UsernamePassword).ConvertToARM(resolved)
+		usernamePassword_ARM, err := v2.UsernamePassword.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2765,7 +2765,7 @@ func (properties *AccessKeyAuthTypeWorkspaceConnectionProperties) ConvertToARM(r
 
 	// Set property "Credentials":
 	if properties.Credentials != nil {
-		credentials_ARM, err := (*properties.Credentials).ConvertToARM(resolved)
+		credentials_ARM, err := properties.Credentials.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3464,7 +3464,7 @@ func (properties *AccountKeyAuthTypeWorkspaceConnectionProperties) ConvertToARM(
 
 	// Set property "Credentials":
 	if properties.Credentials != nil {
-		credentials_ARM, err := (*properties.Credentials).ConvertToARM(resolved)
+		credentials_ARM, err := properties.Credentials.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4165,7 +4165,7 @@ func (properties *ApiKeyAuthWorkspaceConnectionProperties) ConvertToARM(resolved
 
 	// Set property "Credentials":
 	if properties.Credentials != nil {
-		credentials_ARM, err := (*properties.Credentials).ConvertToARM(resolved)
+		credentials_ARM, err := properties.Credentials.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4868,7 +4868,7 @@ func (properties *CustomKeysWorkspaceConnectionProperties) ConvertToARM(resolved
 
 	// Set property "Credentials":
 	if properties.Credentials != nil {
-		credentials_ARM, err := (*properties.Credentials).ConvertToARM(resolved)
+		credentials_ARM, err := properties.Credentials.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5569,7 +5569,7 @@ func (properties *ManagedIdentityAuthTypeWorkspaceConnectionProperties) ConvertT
 
 	// Set property "Credentials":
 	if properties.Credentials != nil {
-		credentials_ARM, err := (*properties.Credentials).ConvertToARM(resolved)
+		credentials_ARM, err := properties.Credentials.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6876,7 +6876,7 @@ func (properties *OAuth2AuthTypeWorkspaceConnectionProperties) ConvertToARM(reso
 
 	// Set property "Credentials":
 	if properties.Credentials != nil {
-		credentials_ARM, err := (*properties.Credentials).ConvertToARM(resolved)
+		credentials_ARM, err := properties.Credentials.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7578,7 +7578,7 @@ func (properties *PATAuthTypeWorkspaceConnectionProperties) ConvertToARM(resolve
 
 	// Set property "Credentials":
 	if properties.Credentials != nil {
-		credentials_ARM, err := (*properties.Credentials).ConvertToARM(resolved)
+		credentials_ARM, err := properties.Credentials.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8277,7 +8277,7 @@ func (properties *SASAuthTypeWorkspaceConnectionProperties) ConvertToARM(resolve
 
 	// Set property "Credentials":
 	if properties.Credentials != nil {
-		credentials_ARM, err := (*properties.Credentials).ConvertToARM(resolved)
+		credentials_ARM, err := properties.Credentials.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8976,7 +8976,7 @@ func (properties *ServicePrincipalAuthTypeWorkspaceConnectionProperties) Convert
 
 	// Set property "Credentials":
 	if properties.Credentials != nil {
-		credentials_ARM, err := (*properties.Credentials).ConvertToARM(resolved)
+		credentials_ARM, err := properties.Credentials.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9675,7 +9675,7 @@ func (properties *UsernamePasswordAuthTypeWorkspaceConnectionProperties) Convert
 
 	// Set property "Credentials":
 	if properties.Credentials != nil {
-		credentials_ARM, err := (*properties.Credentials).ConvertToARM(resolved)
+		credentials_ARM, err := properties.Credentials.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network.frontdoor/v1api20220501/web_application_firewall_policy_types_gen.go
+++ b/v2/api/network.frontdoor/v1api20220501/web_application_firewall_policy_types_gen.go
@@ -320,7 +320,7 @@ func (policy *WebApplicationFirewallPolicy_Spec) ConvertToARM(resolved genruntim
 		result.Properties = &arm.WebApplicationFirewallPolicyProperties{}
 	}
 	if policy.CustomRules != nil {
-		customRules_ARM, err := (*policy.CustomRules).ConvertToARM(resolved)
+		customRules_ARM, err := policy.CustomRules.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -328,7 +328,7 @@ func (policy *WebApplicationFirewallPolicy_Spec) ConvertToARM(resolved genruntim
 		result.Properties.CustomRules = &customRules
 	}
 	if policy.ManagedRules != nil {
-		managedRules_ARM, err := (*policy.ManagedRules).ConvertToARM(resolved)
+		managedRules_ARM, err := policy.ManagedRules.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -336,7 +336,7 @@ func (policy *WebApplicationFirewallPolicy_Spec) ConvertToARM(resolved genruntim
 		result.Properties.ManagedRules = &managedRules
 	}
 	if policy.PolicySettings != nil {
-		policySettings_ARM, err := (*policy.PolicySettings).ConvertToARM(resolved)
+		policySettings_ARM, err := policy.PolicySettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -346,7 +346,7 @@ func (policy *WebApplicationFirewallPolicy_Spec) ConvertToARM(resolved genruntim
 
 	// Set property "Sku":
 	if policy.Sku != nil {
-		sku_ARM, err := (*policy.Sku).ConvertToARM(resolved)
+		sku_ARM, err := policy.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20180501/dns_zones_a_record_types_gen.go
+++ b/v2/api/network/v1api20180501/dns_zones_a_record_types_gen.go
@@ -353,7 +353,7 @@ func (record *DnsZonesARecord_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.ARecords = append(result.Properties.ARecords, *item_ARM.(*arm.ARecord))
 	}
 	if record.CNAMERecord != nil {
-		cnameRecord_ARM, err := (*record.CNAMERecord).ConvertToARM(resolved)
+		cnameRecord_ARM, err := record.CNAMERecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -395,7 +395,7 @@ func (record *DnsZonesARecord_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.PTRRecords = append(result.Properties.PTRRecords, *item_ARM.(*arm.PtrRecord))
 	}
 	if record.SOARecord != nil {
-		soaRecord_ARM, err := (*record.SOARecord).ConvertToARM(resolved)
+		soaRecord_ARM, err := record.SOARecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -421,7 +421,7 @@ func (record *DnsZonesARecord_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.TXTRecords = append(result.Properties.TXTRecords, *item_ARM.(*arm.TxtRecord))
 	}
 	if record.TargetResource != nil {
-		targetResource_ARM, err := (*record.TargetResource).ConvertToARM(resolved)
+		targetResource_ARM, err := record.TargetResource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20180501/dns_zones_aaaa_record_types_gen.go
+++ b/v2/api/network/v1api20180501/dns_zones_aaaa_record_types_gen.go
@@ -344,7 +344,7 @@ func (record *DnsZonesAAAARecord_Spec) ConvertToARM(resolved genruntime.ConvertT
 		result.Properties.ARecords = append(result.Properties.ARecords, *item_ARM.(*arm.ARecord))
 	}
 	if record.CNAMERecord != nil {
-		cnameRecord_ARM, err := (*record.CNAMERecord).ConvertToARM(resolved)
+		cnameRecord_ARM, err := record.CNAMERecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -386,7 +386,7 @@ func (record *DnsZonesAAAARecord_Spec) ConvertToARM(resolved genruntime.ConvertT
 		result.Properties.PTRRecords = append(result.Properties.PTRRecords, *item_ARM.(*arm.PtrRecord))
 	}
 	if record.SOARecord != nil {
-		soaRecord_ARM, err := (*record.SOARecord).ConvertToARM(resolved)
+		soaRecord_ARM, err := record.SOARecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -412,7 +412,7 @@ func (record *DnsZonesAAAARecord_Spec) ConvertToARM(resolved genruntime.ConvertT
 		result.Properties.TXTRecords = append(result.Properties.TXTRecords, *item_ARM.(*arm.TxtRecord))
 	}
 	if record.TargetResource != nil {
-		targetResource_ARM, err := (*record.TargetResource).ConvertToARM(resolved)
+		targetResource_ARM, err := record.TargetResource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20180501/dns_zones_caa_record_types_gen.go
+++ b/v2/api/network/v1api20180501/dns_zones_caa_record_types_gen.go
@@ -344,7 +344,7 @@ func (record *DnsZonesCAARecord_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties.ARecords = append(result.Properties.ARecords, *item_ARM.(*arm.ARecord))
 	}
 	if record.CNAMERecord != nil {
-		cnameRecord_ARM, err := (*record.CNAMERecord).ConvertToARM(resolved)
+		cnameRecord_ARM, err := record.CNAMERecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -386,7 +386,7 @@ func (record *DnsZonesCAARecord_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties.PTRRecords = append(result.Properties.PTRRecords, *item_ARM.(*arm.PtrRecord))
 	}
 	if record.SOARecord != nil {
-		soaRecord_ARM, err := (*record.SOARecord).ConvertToARM(resolved)
+		soaRecord_ARM, err := record.SOARecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -412,7 +412,7 @@ func (record *DnsZonesCAARecord_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties.TXTRecords = append(result.Properties.TXTRecords, *item_ARM.(*arm.TxtRecord))
 	}
 	if record.TargetResource != nil {
-		targetResource_ARM, err := (*record.TargetResource).ConvertToARM(resolved)
+		targetResource_ARM, err := record.TargetResource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20180501/dns_zones_cname_record_types_gen.go
+++ b/v2/api/network/v1api20180501/dns_zones_cname_record_types_gen.go
@@ -344,7 +344,7 @@ func (record *DnsZonesCNAMERecord_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Properties.ARecords = append(result.Properties.ARecords, *item_ARM.(*arm.ARecord))
 	}
 	if record.CNAMERecord != nil {
-		cnameRecord_ARM, err := (*record.CNAMERecord).ConvertToARM(resolved)
+		cnameRecord_ARM, err := record.CNAMERecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -386,7 +386,7 @@ func (record *DnsZonesCNAMERecord_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Properties.PTRRecords = append(result.Properties.PTRRecords, *item_ARM.(*arm.PtrRecord))
 	}
 	if record.SOARecord != nil {
-		soaRecord_ARM, err := (*record.SOARecord).ConvertToARM(resolved)
+		soaRecord_ARM, err := record.SOARecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -412,7 +412,7 @@ func (record *DnsZonesCNAMERecord_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Properties.TXTRecords = append(result.Properties.TXTRecords, *item_ARM.(*arm.TxtRecord))
 	}
 	if record.TargetResource != nil {
-		targetResource_ARM, err := (*record.TargetResource).ConvertToARM(resolved)
+		targetResource_ARM, err := record.TargetResource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20180501/dns_zones_mx_record_types_gen.go
+++ b/v2/api/network/v1api20180501/dns_zones_mx_record_types_gen.go
@@ -344,7 +344,7 @@ func (record *DnsZonesMXRecord_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.ARecords = append(result.Properties.ARecords, *item_ARM.(*arm.ARecord))
 	}
 	if record.CNAMERecord != nil {
-		cnameRecord_ARM, err := (*record.CNAMERecord).ConvertToARM(resolved)
+		cnameRecord_ARM, err := record.CNAMERecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -386,7 +386,7 @@ func (record *DnsZonesMXRecord_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.PTRRecords = append(result.Properties.PTRRecords, *item_ARM.(*arm.PtrRecord))
 	}
 	if record.SOARecord != nil {
-		soaRecord_ARM, err := (*record.SOARecord).ConvertToARM(resolved)
+		soaRecord_ARM, err := record.SOARecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -412,7 +412,7 @@ func (record *DnsZonesMXRecord_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.TXTRecords = append(result.Properties.TXTRecords, *item_ARM.(*arm.TxtRecord))
 	}
 	if record.TargetResource != nil {
-		targetResource_ARM, err := (*record.TargetResource).ConvertToARM(resolved)
+		targetResource_ARM, err := record.TargetResource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20180501/dns_zones_ns_record_types_gen.go
+++ b/v2/api/network/v1api20180501/dns_zones_ns_record_types_gen.go
@@ -344,7 +344,7 @@ func (record *DnsZonesNSRecord_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.ARecords = append(result.Properties.ARecords, *item_ARM.(*arm.ARecord))
 	}
 	if record.CNAMERecord != nil {
-		cnameRecord_ARM, err := (*record.CNAMERecord).ConvertToARM(resolved)
+		cnameRecord_ARM, err := record.CNAMERecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -386,7 +386,7 @@ func (record *DnsZonesNSRecord_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.PTRRecords = append(result.Properties.PTRRecords, *item_ARM.(*arm.PtrRecord))
 	}
 	if record.SOARecord != nil {
-		soaRecord_ARM, err := (*record.SOARecord).ConvertToARM(resolved)
+		soaRecord_ARM, err := record.SOARecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -412,7 +412,7 @@ func (record *DnsZonesNSRecord_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.TXTRecords = append(result.Properties.TXTRecords, *item_ARM.(*arm.TxtRecord))
 	}
 	if record.TargetResource != nil {
-		targetResource_ARM, err := (*record.TargetResource).ConvertToARM(resolved)
+		targetResource_ARM, err := record.TargetResource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20180501/dns_zones_ptr_record_types_gen.go
+++ b/v2/api/network/v1api20180501/dns_zones_ptr_record_types_gen.go
@@ -344,7 +344,7 @@ func (record *DnsZonesPTRRecord_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties.ARecords = append(result.Properties.ARecords, *item_ARM.(*arm.ARecord))
 	}
 	if record.CNAMERecord != nil {
-		cnameRecord_ARM, err := (*record.CNAMERecord).ConvertToARM(resolved)
+		cnameRecord_ARM, err := record.CNAMERecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -386,7 +386,7 @@ func (record *DnsZonesPTRRecord_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties.PTRRecords = append(result.Properties.PTRRecords, *item_ARM.(*arm.PtrRecord))
 	}
 	if record.SOARecord != nil {
-		soaRecord_ARM, err := (*record.SOARecord).ConvertToARM(resolved)
+		soaRecord_ARM, err := record.SOARecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -412,7 +412,7 @@ func (record *DnsZonesPTRRecord_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties.TXTRecords = append(result.Properties.TXTRecords, *item_ARM.(*arm.TxtRecord))
 	}
 	if record.TargetResource != nil {
-		targetResource_ARM, err := (*record.TargetResource).ConvertToARM(resolved)
+		targetResource_ARM, err := record.TargetResource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20180501/dns_zones_srv_record_types_gen.go
+++ b/v2/api/network/v1api20180501/dns_zones_srv_record_types_gen.go
@@ -344,7 +344,7 @@ func (record *DnsZonesSRVRecord_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties.ARecords = append(result.Properties.ARecords, *item_ARM.(*arm.ARecord))
 	}
 	if record.CNAMERecord != nil {
-		cnameRecord_ARM, err := (*record.CNAMERecord).ConvertToARM(resolved)
+		cnameRecord_ARM, err := record.CNAMERecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -386,7 +386,7 @@ func (record *DnsZonesSRVRecord_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties.PTRRecords = append(result.Properties.PTRRecords, *item_ARM.(*arm.PtrRecord))
 	}
 	if record.SOARecord != nil {
-		soaRecord_ARM, err := (*record.SOARecord).ConvertToARM(resolved)
+		soaRecord_ARM, err := record.SOARecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -412,7 +412,7 @@ func (record *DnsZonesSRVRecord_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties.TXTRecords = append(result.Properties.TXTRecords, *item_ARM.(*arm.TxtRecord))
 	}
 	if record.TargetResource != nil {
-		targetResource_ARM, err := (*record.TargetResource).ConvertToARM(resolved)
+		targetResource_ARM, err := record.TargetResource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20180501/dns_zones_txt_record_types_gen.go
+++ b/v2/api/network/v1api20180501/dns_zones_txt_record_types_gen.go
@@ -344,7 +344,7 @@ func (record *DnsZonesTXTRecord_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties.ARecords = append(result.Properties.ARecords, *item_ARM.(*arm.ARecord))
 	}
 	if record.CNAMERecord != nil {
-		cnameRecord_ARM, err := (*record.CNAMERecord).ConvertToARM(resolved)
+		cnameRecord_ARM, err := record.CNAMERecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -386,7 +386,7 @@ func (record *DnsZonesTXTRecord_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties.PTRRecords = append(result.Properties.PTRRecords, *item_ARM.(*arm.PtrRecord))
 	}
 	if record.SOARecord != nil {
-		soaRecord_ARM, err := (*record.SOARecord).ConvertToARM(resolved)
+		soaRecord_ARM, err := record.SOARecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -412,7 +412,7 @@ func (record *DnsZonesTXTRecord_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties.TXTRecords = append(result.Properties.TXTRecords, *item_ARM.(*arm.TxtRecord))
 	}
 	if record.TargetResource != nil {
-		targetResource_ARM, err := (*record.TargetResource).ConvertToARM(resolved)
+		targetResource_ARM, err := record.TargetResource.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20200601/private_dns_zones_a_record_types_gen.go
+++ b/v2/api/network/v1api20200601/private_dns_zones_a_record_types_gen.go
@@ -344,7 +344,7 @@ func (record *PrivateDnsZonesARecord_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.AaaaRecords = append(result.Properties.AaaaRecords, *item_ARM.(*arm.AaaaRecord))
 	}
 	if record.CnameRecord != nil {
-		cnameRecord_ARM, err := (*record.CnameRecord).ConvertToARM(resolved)
+		cnameRecord_ARM, err := record.CnameRecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -372,7 +372,7 @@ func (record *PrivateDnsZonesARecord_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.PtrRecords = append(result.Properties.PtrRecords, *item_ARM.(*arm.PtrRecord))
 	}
 	if record.SoaRecord != nil {
-		soaRecord_ARM, err := (*record.SoaRecord).ConvertToARM(resolved)
+		soaRecord_ARM, err := record.SoaRecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20200601/private_dns_zones_aaaa_record_types_gen.go
+++ b/v2/api/network/v1api20200601/private_dns_zones_aaaa_record_types_gen.go
@@ -349,7 +349,7 @@ func (record *PrivateDnsZonesAAAARecord_Spec) ConvertToARM(resolved genruntime.C
 		result.Properties.AaaaRecords = append(result.Properties.AaaaRecords, *item_ARM.(*arm.AaaaRecord))
 	}
 	if record.CnameRecord != nil {
-		cnameRecord_ARM, err := (*record.CnameRecord).ConvertToARM(resolved)
+		cnameRecord_ARM, err := record.CnameRecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -377,7 +377,7 @@ func (record *PrivateDnsZonesAAAARecord_Spec) ConvertToARM(resolved genruntime.C
 		result.Properties.PtrRecords = append(result.Properties.PtrRecords, *item_ARM.(*arm.PtrRecord))
 	}
 	if record.SoaRecord != nil {
-		soaRecord_ARM, err := (*record.SoaRecord).ConvertToARM(resolved)
+		soaRecord_ARM, err := record.SoaRecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20200601/private_dns_zones_cname_record_types_gen.go
+++ b/v2/api/network/v1api20200601/private_dns_zones_cname_record_types_gen.go
@@ -344,7 +344,7 @@ func (record *PrivateDnsZonesCNAMERecord_Spec) ConvertToARM(resolved genruntime.
 		result.Properties.AaaaRecords = append(result.Properties.AaaaRecords, *item_ARM.(*arm.AaaaRecord))
 	}
 	if record.CnameRecord != nil {
-		cnameRecord_ARM, err := (*record.CnameRecord).ConvertToARM(resolved)
+		cnameRecord_ARM, err := record.CnameRecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -372,7 +372,7 @@ func (record *PrivateDnsZonesCNAMERecord_Spec) ConvertToARM(resolved genruntime.
 		result.Properties.PtrRecords = append(result.Properties.PtrRecords, *item_ARM.(*arm.PtrRecord))
 	}
 	if record.SoaRecord != nil {
-		soaRecord_ARM, err := (*record.SoaRecord).ConvertToARM(resolved)
+		soaRecord_ARM, err := record.SoaRecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20200601/private_dns_zones_mx_record_types_gen.go
+++ b/v2/api/network/v1api20200601/private_dns_zones_mx_record_types_gen.go
@@ -344,7 +344,7 @@ func (record *PrivateDnsZonesMXRecord_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties.AaaaRecords = append(result.Properties.AaaaRecords, *item_ARM.(*arm.AaaaRecord))
 	}
 	if record.CnameRecord != nil {
-		cnameRecord_ARM, err := (*record.CnameRecord).ConvertToARM(resolved)
+		cnameRecord_ARM, err := record.CnameRecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -372,7 +372,7 @@ func (record *PrivateDnsZonesMXRecord_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties.PtrRecords = append(result.Properties.PtrRecords, *item_ARM.(*arm.PtrRecord))
 	}
 	if record.SoaRecord != nil {
-		soaRecord_ARM, err := (*record.SoaRecord).ConvertToARM(resolved)
+		soaRecord_ARM, err := record.SoaRecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20200601/private_dns_zones_ptr_record_types_gen.go
+++ b/v2/api/network/v1api20200601/private_dns_zones_ptr_record_types_gen.go
@@ -344,7 +344,7 @@ func (record *PrivateDnsZonesPTRRecord_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.AaaaRecords = append(result.Properties.AaaaRecords, *item_ARM.(*arm.AaaaRecord))
 	}
 	if record.CnameRecord != nil {
-		cnameRecord_ARM, err := (*record.CnameRecord).ConvertToARM(resolved)
+		cnameRecord_ARM, err := record.CnameRecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -372,7 +372,7 @@ func (record *PrivateDnsZonesPTRRecord_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.PtrRecords = append(result.Properties.PtrRecords, *item_ARM.(*arm.PtrRecord))
 	}
 	if record.SoaRecord != nil {
-		soaRecord_ARM, err := (*record.SoaRecord).ConvertToARM(resolved)
+		soaRecord_ARM, err := record.SoaRecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20200601/private_dns_zones_srv_record_types_gen.go
+++ b/v2/api/network/v1api20200601/private_dns_zones_srv_record_types_gen.go
@@ -344,7 +344,7 @@ func (record *PrivateDnsZonesSRVRecord_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.AaaaRecords = append(result.Properties.AaaaRecords, *item_ARM.(*arm.AaaaRecord))
 	}
 	if record.CnameRecord != nil {
-		cnameRecord_ARM, err := (*record.CnameRecord).ConvertToARM(resolved)
+		cnameRecord_ARM, err := record.CnameRecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -372,7 +372,7 @@ func (record *PrivateDnsZonesSRVRecord_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.PtrRecords = append(result.Properties.PtrRecords, *item_ARM.(*arm.PtrRecord))
 	}
 	if record.SoaRecord != nil {
-		soaRecord_ARM, err := (*record.SoaRecord).ConvertToARM(resolved)
+		soaRecord_ARM, err := record.SoaRecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20200601/private_dns_zones_txt_record_types_gen.go
+++ b/v2/api/network/v1api20200601/private_dns_zones_txt_record_types_gen.go
@@ -344,7 +344,7 @@ func (record *PrivateDnsZonesTXTRecord_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.AaaaRecords = append(result.Properties.AaaaRecords, *item_ARM.(*arm.AaaaRecord))
 	}
 	if record.CnameRecord != nil {
-		cnameRecord_ARM, err := (*record.CnameRecord).ConvertToARM(resolved)
+		cnameRecord_ARM, err := record.CnameRecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -372,7 +372,7 @@ func (record *PrivateDnsZonesTXTRecord_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.PtrRecords = append(result.Properties.PtrRecords, *item_ARM.(*arm.PtrRecord))
 	}
 	if record.SoaRecord != nil {
-		soaRecord_ARM, err := (*record.SoaRecord).ConvertToARM(resolved)
+		soaRecord_ARM, err := record.SoaRecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20200601/private_dns_zones_virtual_network_link_types_gen.go
+++ b/v2/api/network/v1api20200601/private_dns_zones_virtual_network_link_types_gen.go
@@ -314,7 +314,7 @@ func (link *PrivateDnsZonesVirtualNetworkLink_Spec) ConvertToARM(resolved genrun
 		result.Properties.RegistrationEnabled = &registrationEnabled
 	}
 	if link.VirtualNetwork != nil {
-		virtualNetwork_ARM, err := (*link.VirtualNetwork).ConvertToARM(resolved)
+		virtualNetwork_ARM, err := link.VirtualNetwork.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20201101/load_balancer_types_gen.go
+++ b/v2/api/network/v1api20201101/load_balancer_types_gen.go
@@ -321,7 +321,7 @@ func (balancer *LoadBalancer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "ExtendedLocation":
 	if balancer.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*balancer.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := balancer.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -400,7 +400,7 @@ func (balancer *LoadBalancer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Sku":
 	if balancer.Sku != nil {
-		sku_ARM, err := (*balancer.Sku).ConvertToARM(resolved)
+		sku_ARM, err := balancer.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2499,7 +2499,7 @@ func (embedded *FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded) Conver
 		result.Properties.PrivateIPAllocationMethod = &privateIPAllocationMethod
 	}
 	if embedded.PublicIPAddress != nil {
-		publicIPAddress_ARM, err := (*embedded.PublicIPAddress).ConvertToARM(resolved)
+		publicIPAddress_ARM, err := embedded.PublicIPAddress.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2507,7 +2507,7 @@ func (embedded *FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded) Conver
 		result.Properties.PublicIPAddress = &publicIPAddress
 	}
 	if embedded.PublicIPPrefix != nil {
-		publicIPPrefix_ARM, err := (*embedded.PublicIPPrefix).ConvertToARM(resolved)
+		publicIPPrefix_ARM, err := embedded.PublicIPPrefix.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2515,7 +2515,7 @@ func (embedded *FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded) Conver
 		result.Properties.PublicIPPrefix = &publicIPPrefix
 	}
 	if embedded.Subnet != nil {
-		subnet_ARM, err := (*embedded.Subnet).ConvertToARM(resolved)
+		subnet_ARM, err := embedded.Subnet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3418,7 +3418,7 @@ func (pool *InboundNatPool) ConvertToARM(resolved genruntime.ConvertToARMResolve
 		result.Properties.EnableTcpReset = &enableTcpReset
 	}
 	if pool.FrontendIPConfiguration != nil {
-		frontendIPConfiguration_ARM, err := (*pool.FrontendIPConfiguration).ConvertToARM(resolved)
+		frontendIPConfiguration_ARM, err := pool.FrontendIPConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4086,7 +4086,7 @@ func (embedded *InboundNatRule_LoadBalancer_SubResourceEmbedded) ConvertToARM(re
 		result.Properties.EnableTcpReset = &enableTcpReset
 	}
 	if embedded.FrontendIPConfiguration != nil {
-		frontendIPConfiguration_ARM, err := (*embedded.FrontendIPConfiguration).ConvertToARM(resolved)
+		frontendIPConfiguration_ARM, err := embedded.FrontendIPConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5096,7 +5096,7 @@ func (rule *LoadBalancingRule) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties = &arm.LoadBalancingRulePropertiesFormat{}
 	}
 	if rule.BackendAddressPool != nil {
-		backendAddressPool_ARM, err := (*rule.BackendAddressPool).ConvertToARM(resolved)
+		backendAddressPool_ARM, err := rule.BackendAddressPool.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5120,7 +5120,7 @@ func (rule *LoadBalancingRule) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.EnableTcpReset = &enableTcpReset
 	}
 	if rule.FrontendIPConfiguration != nil {
-		frontendIPConfiguration_ARM, err := (*rule.FrontendIPConfiguration).ConvertToARM(resolved)
+		frontendIPConfiguration_ARM, err := rule.FrontendIPConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5142,7 +5142,7 @@ func (rule *LoadBalancingRule) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.LoadDistribution = &loadDistribution
 	}
 	if rule.Probe != nil {
-		probe_ARM, err := (*rule.Probe).ConvertToARM(resolved)
+		probe_ARM, err := rule.Probe.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6025,7 +6025,7 @@ func (rule *OutboundRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.Properties.AllocatedOutboundPorts = &allocatedOutboundPorts
 	}
 	if rule.BackendAddressPool != nil {
-		backendAddressPool_ARM, err := (*rule.BackendAddressPool).ConvertToARM(resolved)
+		backendAddressPool_ARM, err := rule.BackendAddressPool.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7203,7 +7203,7 @@ func (address *LoadBalancerBackendAddress) ConvertToARM(resolved genruntime.Conv
 		result.Properties.IpAddress = &ipAddress
 	}
 	if address.LoadBalancerFrontendIPConfiguration != nil {
-		loadBalancerFrontendIPConfiguration_ARM, err := (*address.LoadBalancerFrontendIPConfiguration).ConvertToARM(resolved)
+		loadBalancerFrontendIPConfiguration_ARM, err := address.LoadBalancerFrontendIPConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7211,7 +7211,7 @@ func (address *LoadBalancerBackendAddress) ConvertToARM(resolved genruntime.Conv
 		result.Properties.LoadBalancerFrontendIPConfiguration = &loadBalancerFrontendIPConfiguration
 	}
 	if address.Subnet != nil {
-		subnet_ARM, err := (*address.Subnet).ConvertToARM(resolved)
+		subnet_ARM, err := address.Subnet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7219,7 +7219,7 @@ func (address *LoadBalancerBackendAddress) ConvertToARM(resolved genruntime.Conv
 		result.Properties.Subnet = &subnet
 	}
 	if address.VirtualNetwork != nil {
-		virtualNetwork_ARM, err := (*address.VirtualNetwork).ConvertToARM(resolved)
+		virtualNetwork_ARM, err := address.VirtualNetwork.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20201101/load_balancers_inbound_nat_rule_types_gen.go
+++ b/v2/api/network/v1api20201101/load_balancers_inbound_nat_rule_types_gen.go
@@ -326,7 +326,7 @@ func (rule *LoadBalancersInboundNatRule_Spec) ConvertToARM(resolved genruntime.C
 		result.Properties.EnableTcpReset = &enableTcpReset
 	}
 	if rule.FrontendIPConfiguration != nil {
-		frontendIPConfiguration_ARM, err := (*rule.FrontendIPConfiguration).ConvertToARM(resolved)
+		frontendIPConfiguration_ARM, err := rule.FrontendIPConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20201101/network_interface_types_gen.go
+++ b/v2/api/network/v1api20201101/network_interface_types_gen.go
@@ -306,7 +306,7 @@ func (networkInterface *NetworkInterface_Spec) ConvertToARM(resolved genruntime.
 
 	// Set property "ExtendedLocation":
 	if networkInterface.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*networkInterface.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := networkInterface.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -334,7 +334,7 @@ func (networkInterface *NetworkInterface_Spec) ConvertToARM(resolved genruntime.
 		result.Properties = &arm.NetworkInterfacePropertiesFormat{}
 	}
 	if networkInterface.DnsSettings != nil {
-		dnsSettings_ARM, err := (*networkInterface.DnsSettings).ConvertToARM(resolved)
+		dnsSettings_ARM, err := networkInterface.DnsSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -357,7 +357,7 @@ func (networkInterface *NetworkInterface_Spec) ConvertToARM(resolved genruntime.
 		result.Properties.IpConfigurations = append(result.Properties.IpConfigurations, *item_ARM.(*arm.NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded))
 	}
 	if networkInterface.NetworkSecurityGroup != nil {
-		networkSecurityGroup_ARM, err := (*networkInterface.NetworkSecurityGroup).ConvertToARM(resolved)
+		networkSecurityGroup_ARM, err := networkInterface.NetworkSecurityGroup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -371,7 +371,7 @@ func (networkInterface *NetworkInterface_Spec) ConvertToARM(resolved genruntime.
 		result.Properties.NicType = &nicType
 	}
 	if networkInterface.PrivateLinkService != nil {
-		privateLinkService_ARM, err := (*networkInterface.PrivateLinkService).ConvertToARM(resolved)
+		privateLinkService_ARM, err := networkInterface.PrivateLinkService.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1999,7 +1999,7 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 		result.Properties.PrivateIPAllocationMethod = &privateIPAllocationMethod
 	}
 	if embedded.PublicIPAddress != nil {
-		publicIPAddress_ARM, err := (*embedded.PublicIPAddress).ConvertToARM(resolved)
+		publicIPAddress_ARM, err := embedded.PublicIPAddress.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2007,7 +2007,7 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 		result.Properties.PublicIPAddress = &publicIPAddress
 	}
 	if embedded.Subnet != nil {
-		subnet_ARM, err := (*embedded.Subnet).ConvertToARM(resolved)
+		subnet_ARM, err := embedded.Subnet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20201101/public_ip_address_types_gen.go
+++ b/v2/api/network/v1api20201101/public_ip_address_types_gen.go
@@ -324,7 +324,7 @@ func (address *PublicIPAddress_Spec) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "ExtendedLocation":
 	if address.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*address.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := address.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -356,7 +356,7 @@ func (address *PublicIPAddress_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties = &arm.PublicIPAddressPropertiesFormat{}
 	}
 	if address.DdosSettings != nil {
-		ddosSettings_ARM, err := (*address.DdosSettings).ConvertToARM(resolved)
+		ddosSettings_ARM, err := address.DdosSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -364,7 +364,7 @@ func (address *PublicIPAddress_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.DdosSettings = &ddosSettings
 	}
 	if address.DnsSettings != nil {
-		dnsSettings_ARM, err := (*address.DnsSettings).ConvertToARM(resolved)
+		dnsSettings_ARM, err := address.DnsSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -387,7 +387,7 @@ func (address *PublicIPAddress_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.IpTags = append(result.Properties.IpTags, *item_ARM.(*arm.IpTag))
 	}
 	if address.LinkedPublicIPAddress != nil {
-		linkedPublicIPAddress_ARM, err := (*address.LinkedPublicIPAddress).ConvertToARM(resolved)
+		linkedPublicIPAddress_ARM, err := address.LinkedPublicIPAddress.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -395,7 +395,7 @@ func (address *PublicIPAddress_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.LinkedPublicIPAddress = &linkedPublicIPAddress
 	}
 	if address.NatGateway != nil {
-		natGateway_ARM, err := (*address.NatGateway).ConvertToARM(resolved)
+		natGateway_ARM, err := address.NatGateway.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -415,7 +415,7 @@ func (address *PublicIPAddress_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.PublicIPAllocationMethod = &publicIPAllocationMethod
 	}
 	if address.PublicIPPrefix != nil {
-		publicIPPrefix_ARM, err := (*address.PublicIPPrefix).ConvertToARM(resolved)
+		publicIPPrefix_ARM, err := address.PublicIPPrefix.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -423,7 +423,7 @@ func (address *PublicIPAddress_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.PublicIPPrefix = &publicIPPrefix
 	}
 	if address.ServicePublicIPAddress != nil {
-		servicePublicIPAddress_ARM, err := (*address.ServicePublicIPAddress).ConvertToARM(resolved)
+		servicePublicIPAddress_ARM, err := address.ServicePublicIPAddress.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -433,7 +433,7 @@ func (address *PublicIPAddress_Spec) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "Sku":
 	if address.Sku != nil {
-		sku_ARM, err := (*address.Sku).ConvertToARM(resolved)
+		sku_ARM, err := address.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1829,7 +1829,7 @@ func (settings *DdosSettings) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "DdosCustomPolicy":
 	if settings.DdosCustomPolicy != nil {
-		ddosCustomPolicy_ARM, err := (*settings.DdosCustomPolicy).ConvertToARM(resolved)
+		ddosCustomPolicy_ARM, err := settings.DdosCustomPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20201101/virtual_network_gateway_types_gen.go
+++ b/v2/api/network/v1api20201101/virtual_network_gateway_types_gen.go
@@ -332,7 +332,7 @@ func (gateway *VirtualNetworkGateway_Spec) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "ExtendedLocation":
 	if gateway.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*gateway.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := gateway.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -371,7 +371,7 @@ func (gateway *VirtualNetworkGateway_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.ActiveActive = &activeActive
 	}
 	if gateway.BgpSettings != nil {
-		bgpSettings_ARM, err := (*gateway.BgpSettings).ConvertToARM(resolved)
+		bgpSettings_ARM, err := gateway.BgpSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -379,7 +379,7 @@ func (gateway *VirtualNetworkGateway_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.BgpSettings = &bgpSettings
 	}
 	if gateway.CustomRoutes != nil {
-		customRoutes_ARM, err := (*gateway.CustomRoutes).ConvertToARM(resolved)
+		customRoutes_ARM, err := gateway.CustomRoutes.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -399,7 +399,7 @@ func (gateway *VirtualNetworkGateway_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.EnablePrivateIpAddress = &enablePrivateIpAddress
 	}
 	if gateway.GatewayDefaultSite != nil {
-		gatewayDefaultSite_ARM, err := (*gateway.GatewayDefaultSite).ConvertToARM(resolved)
+		gatewayDefaultSite_ARM, err := gateway.GatewayDefaultSite.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -420,7 +420,7 @@ func (gateway *VirtualNetworkGateway_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.IpConfigurations = append(result.Properties.IpConfigurations, *item_ARM.(*arm.VirtualNetworkGatewayIPConfiguration))
 	}
 	if gateway.Sku != nil {
-		sku_ARM, err := (*gateway.Sku).ConvertToARM(resolved)
+		sku_ARM, err := gateway.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -436,7 +436,7 @@ func (gateway *VirtualNetworkGateway_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.VNetExtendedLocationResourceId = &vNetExtendedLocationResourceId
 	}
 	if gateway.VpnClientConfiguration != nil {
-		vpnClientConfiguration_ARM, err := (*gateway.VpnClientConfiguration).ConvertToARM(resolved)
+		vpnClientConfiguration_ARM, err := gateway.VpnClientConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2289,7 +2289,7 @@ func (configuration *VirtualNetworkGatewayIPConfiguration) ConvertToARM(resolved
 		result.Properties.PrivateIPAllocationMethod = &privateIPAllocationMethod
 	}
 	if configuration.PublicIPAddress != nil {
-		publicIPAddress_ARM, err := (*configuration.PublicIPAddress).ConvertToARM(resolved)
+		publicIPAddress_ARM, err := configuration.PublicIPAddress.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2297,7 +2297,7 @@ func (configuration *VirtualNetworkGatewayIPConfiguration) ConvertToARM(resolved
 		result.Properties.PublicIPAddress = &publicIPAddress
 	}
 	if configuration.Subnet != nil {
-		subnet_ARM, err := (*configuration.Subnet).ConvertToARM(resolved)
+		subnet_ARM, err := configuration.Subnet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3245,7 +3245,7 @@ func (configuration *VpnClientConfiguration) ConvertToARM(resolved genruntime.Co
 
 	// Set property "VpnClientAddressPool":
 	if configuration.VpnClientAddressPool != nil {
-		vpnClientAddressPool_ARM, err := (*configuration.VpnClientAddressPool).ConvertToARM(resolved)
+		vpnClientAddressPool_ARM, err := configuration.VpnClientAddressPool.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20201101/virtual_network_types_gen.go
+++ b/v2/api/network/v1api20201101/virtual_network_types_gen.go
@@ -307,7 +307,7 @@ func (network *VirtualNetwork_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "ExtendedLocation":
 	if network.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*network.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := network.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -335,7 +335,7 @@ func (network *VirtualNetwork_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties = &arm.VirtualNetworkPropertiesFormat{}
 	}
 	if network.AddressSpace != nil {
-		addressSpace_ARM, err := (*network.AddressSpace).ConvertToARM(resolved)
+		addressSpace_ARM, err := network.AddressSpace.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -343,7 +343,7 @@ func (network *VirtualNetwork_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AddressSpace = &addressSpace
 	}
 	if network.BgpCommunities != nil {
-		bgpCommunities_ARM, err := (*network.BgpCommunities).ConvertToARM(resolved)
+		bgpCommunities_ARM, err := network.BgpCommunities.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -351,7 +351,7 @@ func (network *VirtualNetwork_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.BgpCommunities = &bgpCommunities
 	}
 	if network.DdosProtectionPlan != nil {
-		ddosProtectionPlan_ARM, err := (*network.DdosProtectionPlan).ConvertToARM(resolved)
+		ddosProtectionPlan_ARM, err := network.DdosProtectionPlan.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -359,7 +359,7 @@ func (network *VirtualNetwork_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.DdosProtectionPlan = &ddosProtectionPlan
 	}
 	if network.DhcpOptions != nil {
-		dhcpOptions_ARM, err := (*network.DhcpOptions).ConvertToARM(resolved)
+		dhcpOptions_ARM, err := network.DhcpOptions.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20201101/virtual_networks_subnet_types_gen.go
+++ b/v2/api/network/v1api20201101/virtual_networks_subnet_types_gen.go
@@ -357,7 +357,7 @@ func (subnet *VirtualNetworksSubnet_Spec) ConvertToARM(resolved genruntime.Conve
 		result.Properties.IpAllocations = append(result.Properties.IpAllocations, *item_ARM.(*arm.SubResource))
 	}
 	if subnet.NatGateway != nil {
-		natGateway_ARM, err := (*subnet.NatGateway).ConvertToARM(resolved)
+		natGateway_ARM, err := subnet.NatGateway.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -365,7 +365,7 @@ func (subnet *VirtualNetworksSubnet_Spec) ConvertToARM(resolved genruntime.Conve
 		result.Properties.NatGateway = &natGateway
 	}
 	if subnet.NetworkSecurityGroup != nil {
-		networkSecurityGroup_ARM, err := (*subnet.NetworkSecurityGroup).ConvertToARM(resolved)
+		networkSecurityGroup_ARM, err := subnet.NetworkSecurityGroup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -385,7 +385,7 @@ func (subnet *VirtualNetworksSubnet_Spec) ConvertToARM(resolved genruntime.Conve
 		result.Properties.PrivateLinkServiceNetworkPolicies = &privateLinkServiceNetworkPolicies
 	}
 	if subnet.RouteTable != nil {
-		routeTable_ARM, err := (*subnet.RouteTable).ConvertToARM(resolved)
+		routeTable_ARM, err := subnet.RouteTable.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20201101/virtual_networks_virtual_network_peering_types_gen.go
+++ b/v2/api/network/v1api20201101/virtual_networks_virtual_network_peering_types_gen.go
@@ -346,7 +346,7 @@ func (peering *VirtualNetworksVirtualNetworkPeering_Spec) ConvertToARM(resolved 
 		result.Properties.PeeringState = &peeringState
 	}
 	if peering.RemoteAddressSpace != nil {
-		remoteAddressSpace_ARM, err := (*peering.RemoteAddressSpace).ConvertToARM(resolved)
+		remoteAddressSpace_ARM, err := peering.RemoteAddressSpace.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -354,7 +354,7 @@ func (peering *VirtualNetworksVirtualNetworkPeering_Spec) ConvertToARM(resolved 
 		result.Properties.RemoteAddressSpace = &remoteAddressSpace
 	}
 	if peering.RemoteBgpCommunities != nil {
-		remoteBgpCommunities_ARM, err := (*peering.RemoteBgpCommunities).ConvertToARM(resolved)
+		remoteBgpCommunities_ARM, err := peering.RemoteBgpCommunities.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -362,7 +362,7 @@ func (peering *VirtualNetworksVirtualNetworkPeering_Spec) ConvertToARM(resolved 
 		result.Properties.RemoteBgpCommunities = &remoteBgpCommunities
 	}
 	if peering.RemoteVirtualNetwork != nil {
-		remoteVirtualNetwork_ARM, err := (*peering.RemoteVirtualNetwork).ConvertToARM(resolved)
+		remoteVirtualNetwork_ARM, err := peering.RemoteVirtualNetwork.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20220401/traffic_manager_profile_types_gen.go
+++ b/v2/api/network/v1api20220401/traffic_manager_profile_types_gen.go
@@ -355,7 +355,7 @@ func (profile *TrafficManagerProfile_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.AllowedEndpointRecordTypes = append(result.Properties.AllowedEndpointRecordTypes, arm.AllowedEndpointRecordType(temp))
 	}
 	if profile.DnsConfig != nil {
-		dnsConfig_ARM, err := (*profile.DnsConfig).ConvertToARM(resolved)
+		dnsConfig_ARM, err := profile.DnsConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -367,7 +367,7 @@ func (profile *TrafficManagerProfile_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.MaxReturn = &maxReturn
 	}
 	if profile.MonitorConfig != nil {
-		monitorConfig_ARM, err := (*profile.MonitorConfig).ConvertToARM(resolved)
+		monitorConfig_ARM, err := profile.MonitorConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20220701/application_gateway_types_gen.go
+++ b/v2/api/network/v1api20220701/application_gateway_types_gen.go
@@ -405,7 +405,7 @@ func (gateway *ApplicationGateway_Spec) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "Identity":
 	if gateway.Identity != nil {
-		identity_ARM, err := (*gateway.Identity).ConvertToARM(resolved)
+		identity_ARM, err := gateway.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -464,7 +464,7 @@ func (gateway *ApplicationGateway_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Properties.AuthenticationCertificates = append(result.Properties.AuthenticationCertificates, *item_ARM.(*arm.ApplicationGatewayAuthenticationCertificate))
 	}
 	if gateway.AutoscaleConfiguration != nil {
-		autoscaleConfiguration_ARM, err := (*gateway.AutoscaleConfiguration).ConvertToARM(resolved)
+		autoscaleConfiguration_ARM, err := gateway.AutoscaleConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -508,7 +508,7 @@ func (gateway *ApplicationGateway_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Properties.EnableHttp2 = &enableHttp2
 	}
 	if gateway.FirewallPolicy != nil {
-		firewallPolicy_ARM, err := (*gateway.FirewallPolicy).ConvertToARM(resolved)
+		firewallPolicy_ARM, err := gateway.FirewallPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -541,7 +541,7 @@ func (gateway *ApplicationGateway_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Properties.GatewayIPConfigurations = append(result.Properties.GatewayIPConfigurations, *item_ARM.(*arm.ApplicationGatewayIPConfiguration_ApplicationGateway_SubResourceEmbedded))
 	}
 	if gateway.GlobalConfiguration != nil {
-		globalConfiguration_ARM, err := (*gateway.GlobalConfiguration).ConvertToARM(resolved)
+		globalConfiguration_ARM, err := gateway.GlobalConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -612,7 +612,7 @@ func (gateway *ApplicationGateway_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Properties.RoutingRules = append(result.Properties.RoutingRules, *item_ARM.(*arm.ApplicationGatewayRoutingRule))
 	}
 	if gateway.Sku != nil {
-		sku_ARM, err := (*gateway.Sku).ConvertToARM(resolved)
+		sku_ARM, err := gateway.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -627,7 +627,7 @@ func (gateway *ApplicationGateway_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Properties.SslCertificates = append(result.Properties.SslCertificates, *item_ARM.(*arm.ApplicationGatewaySslCertificate))
 	}
 	if gateway.SslPolicy != nil {
-		sslPolicy_ARM, err := (*gateway.SslPolicy).ConvertToARM(resolved)
+		sslPolicy_ARM, err := gateway.SslPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -663,7 +663,7 @@ func (gateway *ApplicationGateway_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Properties.UrlPathMaps = append(result.Properties.UrlPathMaps, *item_ARM.(*arm.ApplicationGatewayUrlPathMap))
 	}
 	if gateway.WebApplicationFirewallConfiguration != nil {
-		webApplicationFirewallConfiguration_ARM, err := (*gateway.WebApplicationFirewallConfiguration).ConvertToARM(resolved)
+		webApplicationFirewallConfiguration_ARM, err := gateway.WebApplicationFirewallConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5347,7 +5347,7 @@ func (settings *ApplicationGatewayBackendHttpSettings) ConvertToARM(resolved gen
 		result.Properties.AuthenticationCertificates = append(result.Properties.AuthenticationCertificates, *item_ARM.(*arm.SubResource))
 	}
 	if settings.ConnectionDraining != nil {
-		connectionDraining_ARM, err := (*settings.ConnectionDraining).ConvertToARM(resolved)
+		connectionDraining_ARM, err := settings.ConnectionDraining.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5377,7 +5377,7 @@ func (settings *ApplicationGatewayBackendHttpSettings) ConvertToARM(resolved gen
 		result.Properties.Port = &port
 	}
 	if settings.Probe != nil {
-		probe_ARM, err := (*settings.Probe).ConvertToARM(resolved)
+		probe_ARM, err := settings.Probe.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5947,7 +5947,7 @@ func (settings *ApplicationGatewayBackendSettings) ConvertToARM(resolved genrunt
 		result.Properties.Port = &port
 	}
 	if settings.Probe != nil {
-		probe_ARM, err := (*settings.Probe).ConvertToARM(resolved)
+		probe_ARM, err := settings.Probe.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6546,7 +6546,7 @@ func (configuration *ApplicationGatewayFrontendIPConfiguration) ConvertToARM(res
 		result.Properties.PrivateIPAllocationMethod = &privateIPAllocationMethod
 	}
 	if configuration.PrivateLinkConfiguration != nil {
-		privateLinkConfiguration_ARM, err := (*configuration.PrivateLinkConfiguration).ConvertToARM(resolved)
+		privateLinkConfiguration_ARM, err := configuration.PrivateLinkConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6554,7 +6554,7 @@ func (configuration *ApplicationGatewayFrontendIPConfiguration) ConvertToARM(res
 		result.Properties.PrivateLinkConfiguration = &privateLinkConfiguration
 	}
 	if configuration.PublicIPAddress != nil {
-		publicIPAddress_ARM, err := (*configuration.PublicIPAddress).ConvertToARM(resolved)
+		publicIPAddress_ARM, err := configuration.PublicIPAddress.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6562,7 +6562,7 @@ func (configuration *ApplicationGatewayFrontendIPConfiguration) ConvertToARM(res
 		result.Properties.PublicIPAddress = &publicIPAddress
 	}
 	if configuration.Subnet != nil {
-		subnet_ARM, err := (*configuration.Subnet).ConvertToARM(resolved)
+		subnet_ARM, err := configuration.Subnet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7317,7 +7317,7 @@ func (listener *ApplicationGatewayHttpListener) ConvertToARM(resolved genruntime
 		result.Properties.CustomErrorConfigurations = append(result.Properties.CustomErrorConfigurations, *item_ARM.(*arm.ApplicationGatewayCustomError))
 	}
 	if listener.FirewallPolicy != nil {
-		firewallPolicy_ARM, err := (*listener.FirewallPolicy).ConvertToARM(resolved)
+		firewallPolicy_ARM, err := listener.FirewallPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7325,7 +7325,7 @@ func (listener *ApplicationGatewayHttpListener) ConvertToARM(resolved genruntime
 		result.Properties.FirewallPolicy = &firewallPolicy
 	}
 	if listener.FrontendIPConfiguration != nil {
-		frontendIPConfiguration_ARM, err := (*listener.FrontendIPConfiguration).ConvertToARM(resolved)
+		frontendIPConfiguration_ARM, err := listener.FrontendIPConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7333,7 +7333,7 @@ func (listener *ApplicationGatewayHttpListener) ConvertToARM(resolved genruntime
 		result.Properties.FrontendIPConfiguration = &frontendIPConfiguration
 	}
 	if listener.FrontendPort != nil {
-		frontendPort_ARM, err := (*listener.FrontendPort).ConvertToARM(resolved)
+		frontendPort_ARM, err := listener.FrontendPort.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7358,7 +7358,7 @@ func (listener *ApplicationGatewayHttpListener) ConvertToARM(resolved genruntime
 		result.Properties.RequireServerNameIndication = &requireServerNameIndication
 	}
 	if listener.SslCertificate != nil {
-		sslCertificate_ARM, err := (*listener.SslCertificate).ConvertToARM(resolved)
+		sslCertificate_ARM, err := listener.SslCertificate.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7366,7 +7366,7 @@ func (listener *ApplicationGatewayHttpListener) ConvertToARM(resolved genruntime
 		result.Properties.SslCertificate = &sslCertificate
 	}
 	if listener.SslProfile != nil {
-		sslProfile_ARM, err := (*listener.SslProfile).ConvertToARM(resolved)
+		sslProfile_ARM, err := listener.SslProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7843,7 +7843,7 @@ func (embedded *ApplicationGatewayIPConfiguration_ApplicationGateway_SubResource
 		result.Properties = &arm.ApplicationGatewayIPConfigurationPropertiesFormat{}
 	}
 	if embedded.Subnet != nil {
-		subnet_ARM, err := (*embedded.Subnet).ConvertToARM(resolved)
+		subnet_ARM, err := embedded.Subnet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8053,7 +8053,7 @@ func (listener *ApplicationGatewayListener) ConvertToARM(resolved genruntime.Con
 		result.Properties = &arm.ApplicationGatewayListenerPropertiesFormat{}
 	}
 	if listener.FrontendIPConfiguration != nil {
-		frontendIPConfiguration_ARM, err := (*listener.FrontendIPConfiguration).ConvertToARM(resolved)
+		frontendIPConfiguration_ARM, err := listener.FrontendIPConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8061,7 +8061,7 @@ func (listener *ApplicationGatewayListener) ConvertToARM(resolved genruntime.Con
 		result.Properties.FrontendIPConfiguration = &frontendIPConfiguration
 	}
 	if listener.FrontendPort != nil {
-		frontendPort_ARM, err := (*listener.FrontendPort).ConvertToARM(resolved)
+		frontendPort_ARM, err := listener.FrontendPort.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8075,7 +8075,7 @@ func (listener *ApplicationGatewayListener) ConvertToARM(resolved genruntime.Con
 		result.Properties.Protocol = &protocol
 	}
 	if listener.SslCertificate != nil {
-		sslCertificate_ARM, err := (*listener.SslCertificate).ConvertToARM(resolved)
+		sslCertificate_ARM, err := listener.SslCertificate.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8083,7 +8083,7 @@ func (listener *ApplicationGatewayListener) ConvertToARM(resolved genruntime.Con
 		result.Properties.SslCertificate = &sslCertificate
 	}
 	if listener.SslProfile != nil {
-		sslProfile_ARM, err := (*listener.SslProfile).ConvertToARM(resolved)
+		sslProfile_ARM, err := listener.SslProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9083,7 +9083,7 @@ func (probe *ApplicationGatewayProbe) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties.Interval = &interval
 	}
 	if probe.Match != nil {
-		match_ARM, err := (*probe.Match).ConvertToARM(resolved)
+		match_ARM, err := probe.Match.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9585,7 +9585,7 @@ func (configuration *ApplicationGatewayRedirectConfiguration) ConvertToARM(resol
 		result.Properties.RequestRoutingRules = append(result.Properties.RequestRoutingRules, *item_ARM.(*arm.SubResource))
 	}
 	if configuration.TargetListener != nil {
-		targetListener_ARM, err := (*configuration.TargetListener).ConvertToARM(resolved)
+		targetListener_ARM, err := configuration.TargetListener.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10064,7 +10064,7 @@ func (rule *ApplicationGatewayRequestRoutingRule) ConvertToARM(resolved genrunti
 		result.Properties = &arm.ApplicationGatewayRequestRoutingRulePropertiesFormat{}
 	}
 	if rule.BackendAddressPool != nil {
-		backendAddressPool_ARM, err := (*rule.BackendAddressPool).ConvertToARM(resolved)
+		backendAddressPool_ARM, err := rule.BackendAddressPool.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10072,7 +10072,7 @@ func (rule *ApplicationGatewayRequestRoutingRule) ConvertToARM(resolved genrunti
 		result.Properties.BackendAddressPool = &backendAddressPool
 	}
 	if rule.BackendHttpSettings != nil {
-		backendHttpSettings_ARM, err := (*rule.BackendHttpSettings).ConvertToARM(resolved)
+		backendHttpSettings_ARM, err := rule.BackendHttpSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10080,7 +10080,7 @@ func (rule *ApplicationGatewayRequestRoutingRule) ConvertToARM(resolved genrunti
 		result.Properties.BackendHttpSettings = &backendHttpSettings
 	}
 	if rule.HttpListener != nil {
-		httpListener_ARM, err := (*rule.HttpListener).ConvertToARM(resolved)
+		httpListener_ARM, err := rule.HttpListener.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10088,7 +10088,7 @@ func (rule *ApplicationGatewayRequestRoutingRule) ConvertToARM(resolved genrunti
 		result.Properties.HttpListener = &httpListener
 	}
 	if rule.LoadDistributionPolicy != nil {
-		loadDistributionPolicy_ARM, err := (*rule.LoadDistributionPolicy).ConvertToARM(resolved)
+		loadDistributionPolicy_ARM, err := rule.LoadDistributionPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10100,7 +10100,7 @@ func (rule *ApplicationGatewayRequestRoutingRule) ConvertToARM(resolved genrunti
 		result.Properties.Priority = &priority
 	}
 	if rule.RedirectConfiguration != nil {
-		redirectConfiguration_ARM, err := (*rule.RedirectConfiguration).ConvertToARM(resolved)
+		redirectConfiguration_ARM, err := rule.RedirectConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10108,7 +10108,7 @@ func (rule *ApplicationGatewayRequestRoutingRule) ConvertToARM(resolved genrunti
 		result.Properties.RedirectConfiguration = &redirectConfiguration
 	}
 	if rule.RewriteRuleSet != nil {
-		rewriteRuleSet_ARM, err := (*rule.RewriteRuleSet).ConvertToARM(resolved)
+		rewriteRuleSet_ARM, err := rule.RewriteRuleSet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10122,7 +10122,7 @@ func (rule *ApplicationGatewayRequestRoutingRule) ConvertToARM(resolved genrunti
 		result.Properties.RuleType = &ruleType
 	}
 	if rule.UrlPathMap != nil {
-		urlPathMap_ARM, err := (*rule.UrlPathMap).ConvertToARM(resolved)
+		urlPathMap_ARM, err := rule.UrlPathMap.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10810,7 +10810,7 @@ func (rule *ApplicationGatewayRoutingRule) ConvertToARM(resolved genruntime.Conv
 		result.Properties = &arm.ApplicationGatewayRoutingRulePropertiesFormat{}
 	}
 	if rule.BackendAddressPool != nil {
-		backendAddressPool_ARM, err := (*rule.BackendAddressPool).ConvertToARM(resolved)
+		backendAddressPool_ARM, err := rule.BackendAddressPool.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10818,7 +10818,7 @@ func (rule *ApplicationGatewayRoutingRule) ConvertToARM(resolved genruntime.Conv
 		result.Properties.BackendAddressPool = &backendAddressPool
 	}
 	if rule.BackendSettings != nil {
-		backendSettings_ARM, err := (*rule.BackendSettings).ConvertToARM(resolved)
+		backendSettings_ARM, err := rule.BackendSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -10826,7 +10826,7 @@ func (rule *ApplicationGatewayRoutingRule) ConvertToARM(resolved genruntime.Conv
 		result.Properties.BackendSettings = &backendSettings
 	}
 	if rule.Listener != nil {
-		listener_ARM, err := (*rule.Listener).ConvertToARM(resolved)
+		listener_ARM, err := rule.Listener.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12177,7 +12177,7 @@ func (profile *ApplicationGatewaySslProfile) ConvertToARM(resolved genruntime.Co
 		result.Properties = &arm.ApplicationGatewaySslProfilePropertiesFormat{}
 	}
 	if profile.ClientAuthConfiguration != nil {
-		clientAuthConfiguration_ARM, err := (*profile.ClientAuthConfiguration).ConvertToARM(resolved)
+		clientAuthConfiguration_ARM, err := profile.ClientAuthConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12185,7 +12185,7 @@ func (profile *ApplicationGatewaySslProfile) ConvertToARM(resolved genruntime.Co
 		result.Properties.ClientAuthConfiguration = &clientAuthConfiguration
 	}
 	if profile.SslPolicy != nil {
-		sslPolicy_ARM, err := (*profile.SslPolicy).ConvertToARM(resolved)
+		sslPolicy_ARM, err := profile.SslPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12863,7 +12863,7 @@ func (pathMap *ApplicationGatewayUrlPathMap) ConvertToARM(resolved genruntime.Co
 		result.Properties = &arm.ApplicationGatewayUrlPathMapPropertiesFormat{}
 	}
 	if pathMap.DefaultBackendAddressPool != nil {
-		defaultBackendAddressPool_ARM, err := (*pathMap.DefaultBackendAddressPool).ConvertToARM(resolved)
+		defaultBackendAddressPool_ARM, err := pathMap.DefaultBackendAddressPool.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12871,7 +12871,7 @@ func (pathMap *ApplicationGatewayUrlPathMap) ConvertToARM(resolved genruntime.Co
 		result.Properties.DefaultBackendAddressPool = &defaultBackendAddressPool
 	}
 	if pathMap.DefaultBackendHttpSettings != nil {
-		defaultBackendHttpSettings_ARM, err := (*pathMap.DefaultBackendHttpSettings).ConvertToARM(resolved)
+		defaultBackendHttpSettings_ARM, err := pathMap.DefaultBackendHttpSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12879,7 +12879,7 @@ func (pathMap *ApplicationGatewayUrlPathMap) ConvertToARM(resolved genruntime.Co
 		result.Properties.DefaultBackendHttpSettings = &defaultBackendHttpSettings
 	}
 	if pathMap.DefaultLoadDistributionPolicy != nil {
-		defaultLoadDistributionPolicy_ARM, err := (*pathMap.DefaultLoadDistributionPolicy).ConvertToARM(resolved)
+		defaultLoadDistributionPolicy_ARM, err := pathMap.DefaultLoadDistributionPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12887,7 +12887,7 @@ func (pathMap *ApplicationGatewayUrlPathMap) ConvertToARM(resolved genruntime.Co
 		result.Properties.DefaultLoadDistributionPolicy = &defaultLoadDistributionPolicy
 	}
 	if pathMap.DefaultRedirectConfiguration != nil {
-		defaultRedirectConfiguration_ARM, err := (*pathMap.DefaultRedirectConfiguration).ConvertToARM(resolved)
+		defaultRedirectConfiguration_ARM, err := pathMap.DefaultRedirectConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -12895,7 +12895,7 @@ func (pathMap *ApplicationGatewayUrlPathMap) ConvertToARM(resolved genruntime.Co
 		result.Properties.DefaultRedirectConfiguration = &defaultRedirectConfiguration
 	}
 	if pathMap.DefaultRewriteRuleSet != nil {
-		defaultRewriteRuleSet_ARM, err := (*pathMap.DefaultRewriteRuleSet).ConvertToARM(resolved)
+		defaultRewriteRuleSet_ARM, err := pathMap.DefaultRewriteRuleSet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15495,7 +15495,7 @@ func (rule *ApplicationGatewayPathRule) ConvertToARM(resolved genruntime.Convert
 		result.Properties = &arm.ApplicationGatewayPathRulePropertiesFormat{}
 	}
 	if rule.BackendAddressPool != nil {
-		backendAddressPool_ARM, err := (*rule.BackendAddressPool).ConvertToARM(resolved)
+		backendAddressPool_ARM, err := rule.BackendAddressPool.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15503,7 +15503,7 @@ func (rule *ApplicationGatewayPathRule) ConvertToARM(resolved genruntime.Convert
 		result.Properties.BackendAddressPool = &backendAddressPool
 	}
 	if rule.BackendHttpSettings != nil {
-		backendHttpSettings_ARM, err := (*rule.BackendHttpSettings).ConvertToARM(resolved)
+		backendHttpSettings_ARM, err := rule.BackendHttpSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15511,7 +15511,7 @@ func (rule *ApplicationGatewayPathRule) ConvertToARM(resolved genruntime.Convert
 		result.Properties.BackendHttpSettings = &backendHttpSettings
 	}
 	if rule.FirewallPolicy != nil {
-		firewallPolicy_ARM, err := (*rule.FirewallPolicy).ConvertToARM(resolved)
+		firewallPolicy_ARM, err := rule.FirewallPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15519,7 +15519,7 @@ func (rule *ApplicationGatewayPathRule) ConvertToARM(resolved genruntime.Convert
 		result.Properties.FirewallPolicy = &firewallPolicy
 	}
 	if rule.LoadDistributionPolicy != nil {
-		loadDistributionPolicy_ARM, err := (*rule.LoadDistributionPolicy).ConvertToARM(resolved)
+		loadDistributionPolicy_ARM, err := rule.LoadDistributionPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15530,7 +15530,7 @@ func (rule *ApplicationGatewayPathRule) ConvertToARM(resolved genruntime.Convert
 		result.Properties.Paths = append(result.Properties.Paths, item)
 	}
 	if rule.RedirectConfiguration != nil {
-		redirectConfiguration_ARM, err := (*rule.RedirectConfiguration).ConvertToARM(resolved)
+		redirectConfiguration_ARM, err := rule.RedirectConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -15538,7 +15538,7 @@ func (rule *ApplicationGatewayPathRule) ConvertToARM(resolved genruntime.Convert
 		result.Properties.RedirectConfiguration = &redirectConfiguration
 	}
 	if rule.RewriteRuleSet != nil {
-		rewriteRuleSet_ARM, err := (*rule.RewriteRuleSet).ConvertToARM(resolved)
+		rewriteRuleSet_ARM, err := rule.RewriteRuleSet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -16078,7 +16078,7 @@ func (rule *ApplicationGatewayRewriteRule) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "ActionSet":
 	if rule.ActionSet != nil {
-		actionSet_ARM, err := (*rule.ActionSet).ConvertToARM(resolved)
+		actionSet_ARM, err := rule.ActionSet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -16849,7 +16849,7 @@ func (actionSet *ApplicationGatewayRewriteRuleActionSet) ConvertToARM(resolved g
 
 	// Set property "UrlConfiguration":
 	if actionSet.UrlConfiguration != nil {
-		urlConfiguration_ARM, err := (*actionSet.UrlConfiguration).ConvertToARM(resolved)
+		urlConfiguration_ARM, err := actionSet.UrlConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20220701/bastion_host_types_gen.go
+++ b/v2/api/network/v1api20220701/bastion_host_types_gen.go
@@ -367,7 +367,7 @@ func (host *BastionHost_Spec) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "Sku":
 	if host.Sku != nil {
-		sku_ARM, err := (*host.Sku).ConvertToARM(resolved)
+		sku_ARM, err := host.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1346,7 +1346,7 @@ func (configuration *BastionHostIPConfiguration) ConvertToARM(resolved genruntim
 		result.Properties.PrivateIPAllocationMethod = &privateIPAllocationMethod
 	}
 	if configuration.PublicIPAddress != nil {
-		publicIPAddress_ARM, err := (*configuration.PublicIPAddress).ConvertToARM(resolved)
+		publicIPAddress_ARM, err := configuration.PublicIPAddress.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1354,7 +1354,7 @@ func (configuration *BastionHostIPConfiguration) ConvertToARM(resolved genruntim
 		result.Properties.PublicIPAddress = &publicIPAddress
 	}
 	if configuration.Subnet != nil {
-		subnet_ARM, err := (*configuration.Subnet).ConvertToARM(resolved)
+		subnet_ARM, err := configuration.Subnet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20220701/dns_forwarding_rule_sets_virtual_network_link_types_gen.go
+++ b/v2/api/network/v1api20220701/dns_forwarding_rule_sets_virtual_network_link_types_gen.go
@@ -292,7 +292,7 @@ func (link *DnsForwardingRuleSetsVirtualNetworkLink_Spec) ConvertToARM(resolved 
 		}
 	}
 	if link.VirtualNetwork != nil {
-		virtualNetwork_ARM, err := (*link.VirtualNetwork).ConvertToARM(resolved)
+		virtualNetwork_ARM, err := link.VirtualNetwork.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20220701/dns_resolver_types_gen.go
+++ b/v2/api/network/v1api20220701/dns_resolver_types_gen.go
@@ -296,7 +296,7 @@ func (resolver *DnsResolver_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Properties = &arm.DnsResolverProperties{}
 	}
 	if resolver.VirtualNetwork != nil {
-		virtualNetwork_ARM, err := (*resolver.VirtualNetwork).ConvertToARM(resolved)
+		virtualNetwork_ARM, err := resolver.VirtualNetwork.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20220701/dns_resolvers_inbound_endpoint_types_gen.go
+++ b/v2/api/network/v1api20220701/dns_resolvers_inbound_endpoint_types_gen.go
@@ -1057,7 +1057,7 @@ func (configuration *IpConfiguration) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "Subnet":
 	if configuration.Subnet != nil {
-		subnet_ARM, err := (*configuration.Subnet).ConvertToARM(resolved)
+		subnet_ARM, err := configuration.Subnet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20220701/dns_resolvers_outbound_endpoint_types_gen.go
+++ b/v2/api/network/v1api20220701/dns_resolvers_outbound_endpoint_types_gen.go
@@ -296,7 +296,7 @@ func (endpoint *DnsResolversOutboundEndpoint_Spec) ConvertToARM(resolved genrunt
 		result.Properties = &arm.OutboundEndpointProperties{}
 	}
 	if endpoint.Subnet != nil {
-		subnet_ARM, err := (*endpoint.Subnet).ConvertToARM(resolved)
+		subnet_ARM, err := endpoint.Subnet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20220701/nat_gateway_types_gen.go
+++ b/v2/api/network/v1api20220701/nat_gateway_types_gen.go
@@ -331,7 +331,7 @@ func (gateway *NatGateway_Spec) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "Sku":
 	if gateway.Sku != nil {
-		sku_ARM, err := (*gateway.Sku).ConvertToARM(resolved)
+		sku_ARM, err := gateway.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20220701/private_endpoint_types_gen.go
+++ b/v2/api/network/v1api20220701/private_endpoint_types_gen.go
@@ -305,7 +305,7 @@ func (endpoint *PrivateEndpoint_Spec) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "ExtendedLocation":
 	if endpoint.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*endpoint.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := endpoint.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -364,7 +364,7 @@ func (endpoint *PrivateEndpoint_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties.PrivateLinkServiceConnections = append(result.Properties.PrivateLinkServiceConnections, *item_ARM.(*arm.PrivateLinkServiceConnection))
 	}
 	if endpoint.Subnet != nil {
-		subnet_ARM, err := (*endpoint.Subnet).ConvertToARM(resolved)
+		subnet_ARM, err := endpoint.Subnet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2427,7 +2427,7 @@ func (connection *PrivateLinkServiceConnection) ConvertToARM(resolved genruntime
 		result.Properties.GroupIds = append(result.Properties.GroupIds, item)
 	}
 	if connection.PrivateLinkServiceConnectionState != nil {
-		privateLinkServiceConnectionState_ARM, err := (*connection.PrivateLinkServiceConnectionState).ConvertToARM(resolved)
+		privateLinkServiceConnectionState_ARM, err := connection.PrivateLinkServiceConnectionState.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20220701/private_link_service_types_gen.go
+++ b/v2/api/network/v1api20220701/private_link_service_types_gen.go
@@ -324,7 +324,7 @@ func (service *PrivateLinkService_Spec) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "ExtendedLocation":
 	if service.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*service.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := service.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -351,7 +351,7 @@ func (service *PrivateLinkService_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Properties = &arm.PrivateLinkServiceProperties{}
 	}
 	if service.AutoApproval != nil {
-		autoApproval_ARM, err := (*service.AutoApproval).ConvertToARM(resolved)
+		autoApproval_ARM, err := service.AutoApproval.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -380,7 +380,7 @@ func (service *PrivateLinkService_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Properties.LoadBalancerFrontendIpConfigurations = append(result.Properties.LoadBalancerFrontendIpConfigurations, *item_ARM.(*arm.FrontendIPConfiguration_PrivateLinkService_SubResourceEmbedded))
 	}
 	if service.Visibility != nil {
-		visibility_ARM, err := (*service.Visibility).ConvertToARM(resolved)
+		visibility_ARM, err := service.Visibility.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1774,7 +1774,7 @@ func (configuration *PrivateLinkServiceIpConfiguration) ConvertToARM(resolved ge
 		result.Properties.PrivateIPAllocationMethod = &privateIPAllocationMethod
 	}
 	if configuration.Subnet != nil {
-		subnet_ARM, err := (*configuration.Subnet).ConvertToARM(resolved)
+		subnet_ARM, err := configuration.Subnet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20220701/public_ip_prefix_types_gen.go
+++ b/v2/api/network/v1api20220701/public_ip_prefix_types_gen.go
@@ -306,7 +306,7 @@ func (prefix *PublicIPPrefix_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "ExtendedLocation":
 	if prefix.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*prefix.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := prefix.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -332,7 +332,7 @@ func (prefix *PublicIPPrefix_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties = &arm.PublicIPPrefixPropertiesFormat{}
 	}
 	if prefix.CustomIPPrefix != nil {
-		customIPPrefix_ARM, err := (*prefix.CustomIPPrefix).ConvertToARM(resolved)
+		customIPPrefix_ARM, err := prefix.CustomIPPrefix.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -347,7 +347,7 @@ func (prefix *PublicIPPrefix_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.IpTags = append(result.Properties.IpTags, *item_ARM.(*arm.IpTag))
 	}
 	if prefix.NatGateway != nil {
-		natGateway_ARM, err := (*prefix.NatGateway).ConvertToARM(resolved)
+		natGateway_ARM, err := prefix.NatGateway.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -367,7 +367,7 @@ func (prefix *PublicIPPrefix_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Sku":
 	if prefix.Sku != nil {
-		sku_ARM, err := (*prefix.Sku).ConvertToARM(resolved)
+		sku_ARM, err := prefix.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20240101/web_application_firewall_policy_types_gen.go
+++ b/v2/api/network/v1api20240101/web_application_firewall_policy_types_gen.go
@@ -311,7 +311,7 @@ func (policy *WebApplicationFirewallPolicy_Spec) ConvertToARM(resolved genruntim
 		result.Properties.CustomRules = append(result.Properties.CustomRules, *item_ARM.(*arm.WebApplicationFirewallCustomRule))
 	}
 	if policy.ManagedRules != nil {
-		managedRules_ARM, err := (*policy.ManagedRules).ConvertToARM(resolved)
+		managedRules_ARM, err := policy.ManagedRules.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -319,7 +319,7 @@ func (policy *WebApplicationFirewallPolicy_Spec) ConvertToARM(resolved genruntim
 		result.Properties.ManagedRules = &managedRules
 	}
 	if policy.PolicySettings != nil {
-		policySettings_ARM, err := (*policy.PolicySettings).ConvertToARM(resolved)
+		policySettings_ARM, err := policy.PolicySettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1752,7 +1752,7 @@ func (settings *PolicySettings) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "LogScrubbing":
 	if settings.LogScrubbing != nil {
-		logScrubbing_ARM, err := (*settings.LogScrubbing).ConvertToARM(resolved)
+		logScrubbing_ARM, err := settings.LogScrubbing.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20240301/azure_firewall_types_gen.go
+++ b/v2/api/network/v1api20240301/azure_firewall_types_gen.go
@@ -361,7 +361,7 @@ func (firewall *AzureFirewall_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.ApplicationRuleCollections = append(result.Properties.ApplicationRuleCollections, *item_ARM.(*arm.AzureFirewallApplicationRuleCollection))
 	}
 	if firewall.AutoscaleConfiguration != nil {
-		autoscaleConfiguration_ARM, err := (*firewall.AutoscaleConfiguration).ConvertToARM(resolved)
+		autoscaleConfiguration_ARM, err := firewall.AutoscaleConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -369,7 +369,7 @@ func (firewall *AzureFirewall_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AutoscaleConfiguration = &autoscaleConfiguration
 	}
 	if firewall.FirewallPolicy != nil {
-		firewallPolicy_ARM, err := (*firewall.FirewallPolicy).ConvertToARM(resolved)
+		firewallPolicy_ARM, err := firewall.FirewallPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -377,7 +377,7 @@ func (firewall *AzureFirewall_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.FirewallPolicy = &firewallPolicy
 	}
 	if firewall.HubIPAddresses != nil {
-		hubIPAddresses_ARM, err := (*firewall.HubIPAddresses).ConvertToARM(resolved)
+		hubIPAddresses_ARM, err := firewall.HubIPAddresses.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -392,7 +392,7 @@ func (firewall *AzureFirewall_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.IpConfigurations = append(result.Properties.IpConfigurations, *item_ARM.(*arm.AzureFirewallIPConfiguration))
 	}
 	if firewall.ManagementIpConfiguration != nil {
-		managementIpConfiguration_ARM, err := (*firewall.ManagementIpConfiguration).ConvertToARM(resolved)
+		managementIpConfiguration_ARM, err := firewall.ManagementIpConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -414,7 +414,7 @@ func (firewall *AzureFirewall_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.NetworkRuleCollections = append(result.Properties.NetworkRuleCollections, *item_ARM.(*arm.AzureFirewallNetworkRuleCollection))
 	}
 	if firewall.Sku != nil {
-		sku_ARM, err := (*firewall.Sku).ConvertToARM(resolved)
+		sku_ARM, err := firewall.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -428,7 +428,7 @@ func (firewall *AzureFirewall_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.ThreatIntelMode = &threatIntelMode
 	}
 	if firewall.VirtualHub != nil {
-		virtualHub_ARM, err := (*firewall.VirtualHub).ConvertToARM(resolved)
+		virtualHub_ARM, err := firewall.VirtualHub.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2123,7 +2123,7 @@ func (collection *AzureFirewallApplicationRuleCollection) ConvertToARM(resolved 
 		result.Properties = &arm.AzureFirewallApplicationRuleCollectionPropertiesFormat{}
 	}
 	if collection.Action != nil {
-		action_ARM, err := (*collection.Action).ConvertToARM(resolved)
+		action_ARM, err := collection.Action.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2584,7 +2584,7 @@ func (configuration *AzureFirewallIPConfiguration) ConvertToARM(resolved genrunt
 		result.Properties = &arm.AzureFirewallIPConfigurationPropertiesFormat{}
 	}
 	if configuration.PublicIPAddress != nil {
-		publicIPAddress_ARM, err := (*configuration.PublicIPAddress).ConvertToARM(resolved)
+		publicIPAddress_ARM, err := configuration.PublicIPAddress.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2592,7 +2592,7 @@ func (configuration *AzureFirewallIPConfiguration) ConvertToARM(resolved genrunt
 		result.Properties.PublicIPAddress = &publicIPAddress
 	}
 	if configuration.Subnet != nil {
-		subnet_ARM, err := (*configuration.Subnet).ConvertToARM(resolved)
+		subnet_ARM, err := configuration.Subnet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2908,7 +2908,7 @@ func (collection *AzureFirewallNatRuleCollection) ConvertToARM(resolved genrunti
 		result.Properties = &arm.AzureFirewallNatRuleCollectionProperties{}
 	}
 	if collection.Action != nil {
-		action_ARM, err := (*collection.Action).ConvertToARM(resolved)
+		action_ARM, err := collection.Action.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3187,7 +3187,7 @@ func (collection *AzureFirewallNetworkRuleCollection) ConvertToARM(resolved genr
 		result.Properties = &arm.AzureFirewallNetworkRuleCollectionPropertiesFormat{}
 	}
 	if collection.Action != nil {
-		action_ARM, err := (*collection.Action).ConvertToARM(resolved)
+		action_ARM, err := collection.Action.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3838,7 +3838,7 @@ func (addresses *HubIPAddresses) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "PublicIPs":
 	if addresses.PublicIPs != nil {
-		publicIPs_ARM, err := (*addresses.PublicIPs).ConvertToARM(resolved)
+		publicIPs_ARM, err := addresses.PublicIPs.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20240301/bastion_host_types_gen.go
+++ b/v2/api/network/v1api20240301/bastion_host_types_gen.go
@@ -383,7 +383,7 @@ func (host *BastionHost_Spec) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.Properties.IpConfigurations = append(result.Properties.IpConfigurations, *item_ARM.(*arm.BastionHostIPConfiguration))
 	}
 	if host.NetworkAcls != nil {
-		networkAcls_ARM, err := (*host.NetworkAcls).ConvertToARM(resolved)
+		networkAcls_ARM, err := host.NetworkAcls.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -395,7 +395,7 @@ func (host *BastionHost_Spec) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.Properties.ScaleUnits = &scaleUnits
 	}
 	if host.VirtualNetwork != nil {
-		virtualNetwork_ARM, err := (*host.VirtualNetwork).ConvertToARM(resolved)
+		virtualNetwork_ARM, err := host.VirtualNetwork.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -405,7 +405,7 @@ func (host *BastionHost_Spec) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "Sku":
 	if host.Sku != nil {
-		sku_ARM, err := (*host.Sku).ConvertToARM(resolved)
+		sku_ARM, err := host.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1808,7 +1808,7 @@ func (configuration *BastionHostIPConfiguration) ConvertToARM(resolved genruntim
 		result.Properties.PrivateIPAllocationMethod = &privateIPAllocationMethod
 	}
 	if configuration.PublicIPAddress != nil {
-		publicIPAddress_ARM, err := (*configuration.PublicIPAddress).ConvertToARM(resolved)
+		publicIPAddress_ARM, err := configuration.PublicIPAddress.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1816,7 +1816,7 @@ func (configuration *BastionHostIPConfiguration) ConvertToARM(resolved genruntim
 		result.Properties.PublicIPAddress = &publicIPAddress
 	}
 	if configuration.Subnet != nil {
-		subnet_ARM, err := (*configuration.Subnet).ConvertToARM(resolved)
+		subnet_ARM, err := configuration.Subnet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20240301/firewall_policies_rule_collection_group_types_gen.go
+++ b/v2/api/network/v1api20240301/firewall_policies_rule_collection_group_types_gen.go
@@ -957,7 +957,7 @@ func (collection *FirewallPolicyRuleCollection) ConvertToARM(resolved genruntime
 
 	// Set property "FirewallPolicyFilter":
 	if collection.FirewallPolicyFilter != nil {
-		firewallPolicyFilter_ARM, err := (*collection.FirewallPolicyFilter).ConvertToARM(resolved)
+		firewallPolicyFilter_ARM, err := collection.FirewallPolicyFilter.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -967,7 +967,7 @@ func (collection *FirewallPolicyRuleCollection) ConvertToARM(resolved genruntime
 
 	// Set property "FirewallPolicyNat":
 	if collection.FirewallPolicyNat != nil {
-		firewallPolicyNat_ARM, err := (*collection.FirewallPolicyNat).ConvertToARM(resolved)
+		firewallPolicyNat_ARM, err := collection.FirewallPolicyNat.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1267,7 +1267,7 @@ func (collection *FirewallPolicyFilterRuleCollection) ConvertToARM(resolved genr
 
 	// Set property "Action":
 	if collection.Action != nil {
-		action_ARM, err := (*collection.Action).ConvertToARM(resolved)
+		action_ARM, err := collection.Action.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1744,7 +1744,7 @@ func (collection *FirewallPolicyNatRuleCollection) ConvertToARM(resolved genrunt
 
 	// Set property "Action":
 	if collection.Action != nil {
-		action_ARM, err := (*collection.Action).ConvertToARM(resolved)
+		action_ARM, err := collection.Action.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2602,7 +2602,7 @@ func (rule *FirewallPolicyRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "Application":
 	if rule.Application != nil {
-		application_ARM, err := (*rule.Application).ConvertToARM(resolved)
+		application_ARM, err := rule.Application.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2612,7 +2612,7 @@ func (rule *FirewallPolicyRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "Nat":
 	if rule.Nat != nil {
-		nat_ARM, err := (*rule.Nat).ConvertToARM(resolved)
+		nat_ARM, err := rule.Nat.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2622,7 +2622,7 @@ func (rule *FirewallPolicyRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "Network":
 	if rule.Network != nil {
-		network_ARM, err := (*rule.Network).ConvertToARM(resolved)
+		network_ARM, err := rule.Network.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20240301/firewall_policy_types_gen.go
+++ b/v2/api/network/v1api20240301/firewall_policy_types_gen.go
@@ -315,7 +315,7 @@ func (policy *FirewallPolicy_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Identity":
 	if policy.Identity != nil {
-		identity_ARM, err := (*policy.Identity).ConvertToARM(resolved)
+		identity_ARM, err := policy.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -347,7 +347,7 @@ func (policy *FirewallPolicy_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties = &arm.FirewallPolicyPropertiesFormat{}
 	}
 	if policy.BasePolicy != nil {
-		basePolicy_ARM, err := (*policy.BasePolicy).ConvertToARM(resolved)
+		basePolicy_ARM, err := policy.BasePolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -355,7 +355,7 @@ func (policy *FirewallPolicy_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.BasePolicy = &basePolicy
 	}
 	if policy.DnsSettings != nil {
-		dnsSettings_ARM, err := (*policy.DnsSettings).ConvertToARM(resolved)
+		dnsSettings_ARM, err := policy.DnsSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -363,7 +363,7 @@ func (policy *FirewallPolicy_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.DnsSettings = &dnsSettings
 	}
 	if policy.ExplicitProxy != nil {
-		explicitProxy_ARM, err := (*policy.ExplicitProxy).ConvertToARM(resolved)
+		explicitProxy_ARM, err := policy.ExplicitProxy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -371,7 +371,7 @@ func (policy *FirewallPolicy_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.ExplicitProxy = &explicitProxy
 	}
 	if policy.Insights != nil {
-		insights_ARM, err := (*policy.Insights).ConvertToARM(resolved)
+		insights_ARM, err := policy.Insights.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -379,7 +379,7 @@ func (policy *FirewallPolicy_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.Insights = &insights
 	}
 	if policy.IntrusionDetection != nil {
-		intrusionDetection_ARM, err := (*policy.IntrusionDetection).ConvertToARM(resolved)
+		intrusionDetection_ARM, err := policy.IntrusionDetection.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -387,7 +387,7 @@ func (policy *FirewallPolicy_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.IntrusionDetection = &intrusionDetection
 	}
 	if policy.Sku != nil {
-		sku_ARM, err := (*policy.Sku).ConvertToARM(resolved)
+		sku_ARM, err := policy.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -395,7 +395,7 @@ func (policy *FirewallPolicy_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.Sku = &sku
 	}
 	if policy.Snat != nil {
-		snat_ARM, err := (*policy.Snat).ConvertToARM(resolved)
+		snat_ARM, err := policy.Snat.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -403,7 +403,7 @@ func (policy *FirewallPolicy_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.Snat = &snat
 	}
 	if policy.Sql != nil {
-		sql_ARM, err := (*policy.Sql).ConvertToARM(resolved)
+		sql_ARM, err := policy.Sql.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -417,7 +417,7 @@ func (policy *FirewallPolicy_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.ThreatIntelMode = &threatIntelMode
 	}
 	if policy.ThreatIntelWhitelist != nil {
-		threatIntelWhitelist_ARM, err := (*policy.ThreatIntelWhitelist).ConvertToARM(resolved)
+		threatIntelWhitelist_ARM, err := policy.ThreatIntelWhitelist.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -425,7 +425,7 @@ func (policy *FirewallPolicy_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.ThreatIntelWhitelist = &threatIntelWhitelist
 	}
 	if policy.TransportSecurity != nil {
-		transportSecurity_ARM, err := (*policy.TransportSecurity).ConvertToARM(resolved)
+		transportSecurity_ARM, err := policy.TransportSecurity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2794,7 +2794,7 @@ func (insights *FirewallPolicyInsights) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "LogAnalyticsResources":
 	if insights.LogAnalyticsResources != nil {
-		logAnalyticsResources_ARM, err := (*insights.LogAnalyticsResources).ConvertToARM(resolved)
+		logAnalyticsResources_ARM, err := insights.LogAnalyticsResources.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3095,7 +3095,7 @@ func (detection *FirewallPolicyIntrusionDetection) ConvertToARM(resolved genrunt
 
 	// Set property "Configuration":
 	if detection.Configuration != nil {
-		configuration_ARM, err := (*detection.Configuration).ConvertToARM(resolved)
+		configuration_ARM, err := detection.Configuration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4275,7 +4275,7 @@ func (security *FirewallPolicyTransportSecurity) ConvertToARM(resolved genruntim
 
 	// Set property "CertificateAuthority":
 	if security.CertificateAuthority != nil {
-		certificateAuthority_ARM, err := (*security.CertificateAuthority).ConvertToARM(resolved)
+		certificateAuthority_ARM, err := security.CertificateAuthority.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5458,7 +5458,7 @@ func (resources *FirewallPolicyLogAnalyticsResources) ConvertToARM(resolved genr
 
 	// Set property "DefaultWorkspaceId":
 	if resources.DefaultWorkspaceId != nil {
-		defaultWorkspaceId_ARM, err := (*resources.DefaultWorkspaceId).ConvertToARM(resolved)
+		defaultWorkspaceId_ARM, err := resources.DefaultWorkspaceId.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6640,7 +6640,7 @@ func (workspace *FirewallPolicyLogAnalyticsWorkspace) ConvertToARM(resolved genr
 
 	// Set property "WorkspaceId":
 	if workspace.WorkspaceId != nil {
-		workspaceId_ARM, err := (*workspace.WorkspaceId).ConvertToARM(resolved)
+		workspaceId_ARM, err := workspace.WorkspaceId.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20240301/load_balancer_types_gen.go
+++ b/v2/api/network/v1api20240301/load_balancer_types_gen.go
@@ -313,7 +313,7 @@ func (balancer *LoadBalancer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "ExtendedLocation":
 	if balancer.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*balancer.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := balancer.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -392,7 +392,7 @@ func (balancer *LoadBalancer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Sku":
 	if balancer.Sku != nil {
-		sku_ARM, err := (*balancer.Sku).ConvertToARM(resolved)
+		sku_ARM, err := balancer.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1940,7 +1940,7 @@ func (embedded *BackendAddressPool_LoadBalancer_SubResourceEmbedded) ConvertToAR
 		result.Properties.TunnelInterfaces = append(result.Properties.TunnelInterfaces, *item_ARM.(*arm.GatewayLoadBalancerTunnelInterface))
 	}
 	if embedded.VirtualNetwork != nil {
-		virtualNetwork_ARM, err := (*embedded.VirtualNetwork).ConvertToARM(resolved)
+		virtualNetwork_ARM, err := embedded.VirtualNetwork.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3136,7 +3136,7 @@ func (embedded *FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded) Conver
 		result.Properties = &arm.FrontendIPConfigurationPropertiesFormat{}
 	}
 	if embedded.GatewayLoadBalancer != nil {
-		gatewayLoadBalancer_ARM, err := (*embedded.GatewayLoadBalancer).ConvertToARM(resolved)
+		gatewayLoadBalancer_ARM, err := embedded.GatewayLoadBalancer.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3160,7 +3160,7 @@ func (embedded *FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded) Conver
 		result.Properties.PrivateIPAllocationMethod = &privateIPAllocationMethod
 	}
 	if embedded.PublicIPAddress != nil {
-		publicIPAddress_ARM, err := (*embedded.PublicIPAddress).ConvertToARM(resolved)
+		publicIPAddress_ARM, err := embedded.PublicIPAddress.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3168,7 +3168,7 @@ func (embedded *FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded) Conver
 		result.Properties.PublicIPAddress = &publicIPAddress
 	}
 	if embedded.PublicIPPrefix != nil {
-		publicIPPrefix_ARM, err := (*embedded.PublicIPPrefix).ConvertToARM(resolved)
+		publicIPPrefix_ARM, err := embedded.PublicIPPrefix.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3176,7 +3176,7 @@ func (embedded *FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded) Conver
 		result.Properties.PublicIPPrefix = &publicIPPrefix
 	}
 	if embedded.Subnet != nil {
-		subnet_ARM, err := (*embedded.Subnet).ConvertToARM(resolved)
+		subnet_ARM, err := embedded.Subnet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4238,7 +4238,7 @@ func (pool *InboundNatPool) ConvertToARM(resolved genruntime.ConvertToARMResolve
 		result.Properties.EnableTcpReset = &enableTcpReset
 	}
 	if pool.FrontendIPConfiguration != nil {
-		frontendIPConfiguration_ARM, err := (*pool.FrontendIPConfiguration).ConvertToARM(resolved)
+		frontendIPConfiguration_ARM, err := pool.FrontendIPConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4968,7 +4968,7 @@ func (embedded *InboundNatRule_LoadBalancer_SubResourceEmbedded) ConvertToARM(re
 		result.Properties = &arm.InboundNatRulePropertiesFormat{}
 	}
 	if embedded.BackendAddressPool != nil {
-		backendAddressPool_ARM, err := (*embedded.BackendAddressPool).ConvertToARM(resolved)
+		backendAddressPool_ARM, err := embedded.BackendAddressPool.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4988,7 +4988,7 @@ func (embedded *InboundNatRule_LoadBalancer_SubResourceEmbedded) ConvertToARM(re
 		result.Properties.EnableTcpReset = &enableTcpReset
 	}
 	if embedded.FrontendIPConfiguration != nil {
-		frontendIPConfiguration_ARM, err := (*embedded.FrontendIPConfiguration).ConvertToARM(resolved)
+		frontendIPConfiguration_ARM, err := embedded.FrontendIPConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6255,7 +6255,7 @@ func (rule *LoadBalancingRule) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties = &arm.LoadBalancingRulePropertiesFormat{}
 	}
 	if rule.BackendAddressPool != nil {
-		backendAddressPool_ARM, err := (*rule.BackendAddressPool).ConvertToARM(resolved)
+		backendAddressPool_ARM, err := rule.BackendAddressPool.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6286,7 +6286,7 @@ func (rule *LoadBalancingRule) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.EnableTcpReset = &enableTcpReset
 	}
 	if rule.FrontendIPConfiguration != nil {
-		frontendIPConfiguration_ARM, err := (*rule.FrontendIPConfiguration).ConvertToARM(resolved)
+		frontendIPConfiguration_ARM, err := rule.FrontendIPConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6308,7 +6308,7 @@ func (rule *LoadBalancingRule) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.LoadDistribution = &loadDistribution
 	}
 	if rule.Probe != nil {
-		probe_ARM, err := (*rule.Probe).ConvertToARM(resolved)
+		probe_ARM, err := rule.Probe.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7405,7 +7405,7 @@ func (rule *OutboundRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.Properties.AllocatedOutboundPorts = &allocatedOutboundPorts
 	}
 	if rule.BackendAddressPool != nil {
-		backendAddressPool_ARM, err := (*rule.BackendAddressPool).ConvertToARM(resolved)
+		backendAddressPool_ARM, err := rule.BackendAddressPool.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9148,7 +9148,7 @@ func (address *LoadBalancerBackendAddress) ConvertToARM(resolved genruntime.Conv
 		result.Properties.IpAddress = &ipAddress
 	}
 	if address.LoadBalancerFrontendIPConfiguration != nil {
-		loadBalancerFrontendIPConfiguration_ARM, err := (*address.LoadBalancerFrontendIPConfiguration).ConvertToARM(resolved)
+		loadBalancerFrontendIPConfiguration_ARM, err := address.LoadBalancerFrontendIPConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9156,7 +9156,7 @@ func (address *LoadBalancerBackendAddress) ConvertToARM(resolved genruntime.Conv
 		result.Properties.LoadBalancerFrontendIPConfiguration = &loadBalancerFrontendIPConfiguration
 	}
 	if address.Subnet != nil {
-		subnet_ARM, err := (*address.Subnet).ConvertToARM(resolved)
+		subnet_ARM, err := address.Subnet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9164,7 +9164,7 @@ func (address *LoadBalancerBackendAddress) ConvertToARM(resolved genruntime.Conv
 		result.Properties.Subnet = &subnet
 	}
 	if address.VirtualNetwork != nil {
-		virtualNetwork_ARM, err := (*address.VirtualNetwork).ConvertToARM(resolved)
+		virtualNetwork_ARM, err := address.VirtualNetwork.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20240301/load_balancers_inbound_nat_rule_types_gen.go
+++ b/v2/api/network/v1api20240301/load_balancers_inbound_nat_rule_types_gen.go
@@ -327,7 +327,7 @@ func (rule *LoadBalancersInboundNatRule_Spec) ConvertToARM(resolved genruntime.C
 		result.Properties = &arm.InboundNatRulePropertiesFormat{}
 	}
 	if rule.BackendAddressPool != nil {
-		backendAddressPool_ARM, err := (*rule.BackendAddressPool).ConvertToARM(resolved)
+		backendAddressPool_ARM, err := rule.BackendAddressPool.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -347,7 +347,7 @@ func (rule *LoadBalancersInboundNatRule_Spec) ConvertToARM(resolved genruntime.C
 		result.Properties.EnableTcpReset = &enableTcpReset
 	}
 	if rule.FrontendIPConfiguration != nil {
-		frontendIPConfiguration_ARM, err := (*rule.FrontendIPConfiguration).ConvertToARM(resolved)
+		frontendIPConfiguration_ARM, err := rule.FrontendIPConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20240301/nat_gateway_types_gen.go
+++ b/v2/api/network/v1api20240301/nat_gateway_types_gen.go
@@ -328,7 +328,7 @@ func (gateway *NatGateway_Spec) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "Sku":
 	if gateway.Sku != nil {
-		sku_ARM, err := (*gateway.Sku).ConvertToARM(resolved)
+		sku_ARM, err := gateway.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20240301/network_interface_types_gen.go
+++ b/v2/api/network/v1api20240301/network_interface_types_gen.go
@@ -316,7 +316,7 @@ func (networkInterface *NetworkInterface_Spec) ConvertToARM(resolved genruntime.
 
 	// Set property "ExtendedLocation":
 	if networkInterface.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*networkInterface.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := networkInterface.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -364,7 +364,7 @@ func (networkInterface *NetworkInterface_Spec) ConvertToARM(resolved genruntime.
 		result.Properties.DisableTcpStateTracking = &disableTcpStateTracking
 	}
 	if networkInterface.DnsSettings != nil {
-		dnsSettings_ARM, err := (*networkInterface.DnsSettings).ConvertToARM(resolved)
+		dnsSettings_ARM, err := networkInterface.DnsSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -387,7 +387,7 @@ func (networkInterface *NetworkInterface_Spec) ConvertToARM(resolved genruntime.
 		result.Properties.IpConfigurations = append(result.Properties.IpConfigurations, *item_ARM.(*arm.NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded))
 	}
 	if networkInterface.NetworkSecurityGroup != nil {
-		networkSecurityGroup_ARM, err := (*networkInterface.NetworkSecurityGroup).ConvertToARM(resolved)
+		networkSecurityGroup_ARM, err := networkInterface.NetworkSecurityGroup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -401,7 +401,7 @@ func (networkInterface *NetworkInterface_Spec) ConvertToARM(resolved genruntime.
 		result.Properties.NicType = &nicType
 	}
 	if networkInterface.PrivateLinkService != nil {
-		privateLinkService_ARM, err := (*networkInterface.PrivateLinkService).ConvertToARM(resolved)
+		privateLinkService_ARM, err := networkInterface.PrivateLinkService.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2387,7 +2387,7 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 		result.Properties.ApplicationSecurityGroups = append(result.Properties.ApplicationSecurityGroups, *item_ARM.(*arm.ApplicationSecurityGroupSpec_NetworkInterface_SubResourceEmbedded))
 	}
 	if embedded.GatewayLoadBalancer != nil {
-		gatewayLoadBalancer_ARM, err := (*embedded.GatewayLoadBalancer).ConvertToARM(resolved)
+		gatewayLoadBalancer_ARM, err := embedded.GatewayLoadBalancer.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2433,7 +2433,7 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 		result.Properties.PrivateIPAllocationMethod = &privateIPAllocationMethod
 	}
 	if embedded.PublicIPAddress != nil {
-		publicIPAddress_ARM, err := (*embedded.PublicIPAddress).ConvertToARM(resolved)
+		publicIPAddress_ARM, err := embedded.PublicIPAddress.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2441,7 +2441,7 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 		result.Properties.PublicIPAddress = &publicIPAddress
 	}
 	if embedded.Subnet != nil {
-		subnet_ARM, err := (*embedded.Subnet).ConvertToARM(resolved)
+		subnet_ARM, err := embedded.Subnet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20240301/private_endpoint_types_gen.go
+++ b/v2/api/network/v1api20240301/private_endpoint_types_gen.go
@@ -302,7 +302,7 @@ func (endpoint *PrivateEndpoint_Spec) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "ExtendedLocation":
 	if endpoint.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*endpoint.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := endpoint.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -361,7 +361,7 @@ func (endpoint *PrivateEndpoint_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties.PrivateLinkServiceConnections = append(result.Properties.PrivateLinkServiceConnections, *item_ARM.(*arm.PrivateLinkServiceConnection))
 	}
 	if endpoint.Subnet != nil {
-		subnet_ARM, err := (*endpoint.Subnet).ConvertToARM(resolved)
+		subnet_ARM, err := endpoint.Subnet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2373,7 +2373,7 @@ func (connection *PrivateLinkServiceConnection) ConvertToARM(resolved genruntime
 		result.Properties.GroupIds = append(result.Properties.GroupIds, item)
 	}
 	if connection.PrivateLinkServiceConnectionState != nil {
-		privateLinkServiceConnectionState_ARM, err := (*connection.PrivateLinkServiceConnectionState).ConvertToARM(resolved)
+		privateLinkServiceConnectionState_ARM, err := connection.PrivateLinkServiceConnectionState.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20240301/private_link_service_types_gen.go
+++ b/v2/api/network/v1api20240301/private_link_service_types_gen.go
@@ -324,7 +324,7 @@ func (service *PrivateLinkService_Spec) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "ExtendedLocation":
 	if service.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*service.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := service.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -352,7 +352,7 @@ func (service *PrivateLinkService_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Properties = &arm.PrivateLinkServiceProperties{}
 	}
 	if service.AutoApproval != nil {
-		autoApproval_ARM, err := (*service.AutoApproval).ConvertToARM(resolved)
+		autoApproval_ARM, err := service.AutoApproval.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -385,7 +385,7 @@ func (service *PrivateLinkService_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Properties.LoadBalancerFrontendIpConfigurations = append(result.Properties.LoadBalancerFrontendIpConfigurations, *item_ARM.(*arm.FrontendIPConfiguration_PrivateLinkService_SubResourceEmbedded))
 	}
 	if service.Visibility != nil {
-		visibility_ARM, err := (*service.Visibility).ConvertToARM(resolved)
+		visibility_ARM, err := service.Visibility.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1926,7 +1926,7 @@ func (configuration *PrivateLinkServiceIpConfiguration) ConvertToARM(resolved ge
 		result.Properties.PrivateIPAllocationMethod = &privateIPAllocationMethod
 	}
 	if configuration.Subnet != nil {
-		subnet_ARM, err := (*configuration.Subnet).ConvertToARM(resolved)
+		subnet_ARM, err := configuration.Subnet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20240301/public_ip_address_types_gen.go
+++ b/v2/api/network/v1api20240301/public_ip_address_types_gen.go
@@ -324,7 +324,7 @@ func (address *PublicIPAddress_Spec) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "ExtendedLocation":
 	if address.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*address.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := address.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -357,7 +357,7 @@ func (address *PublicIPAddress_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties = &arm.PublicIPAddressPropertiesFormat{}
 	}
 	if address.DdosSettings != nil {
-		ddosSettings_ARM, err := (*address.DdosSettings).ConvertToARM(resolved)
+		ddosSettings_ARM, err := address.DdosSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -371,7 +371,7 @@ func (address *PublicIPAddress_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.DeleteOption = &deleteOption
 	}
 	if address.DnsSettings != nil {
-		dnsSettings_ARM, err := (*address.DnsSettings).ConvertToARM(resolved)
+		dnsSettings_ARM, err := address.DnsSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -394,7 +394,7 @@ func (address *PublicIPAddress_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.IpTags = append(result.Properties.IpTags, *item_ARM.(*arm.IpTag))
 	}
 	if address.LinkedPublicIPAddress != nil {
-		linkedPublicIPAddress_ARM, err := (*address.LinkedPublicIPAddress).ConvertToARM(resolved)
+		linkedPublicIPAddress_ARM, err := address.LinkedPublicIPAddress.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -402,7 +402,7 @@ func (address *PublicIPAddress_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.LinkedPublicIPAddress = &linkedPublicIPAddress
 	}
 	if address.NatGateway != nil {
-		natGateway_ARM, err := (*address.NatGateway).ConvertToARM(resolved)
+		natGateway_ARM, err := address.NatGateway.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -422,7 +422,7 @@ func (address *PublicIPAddress_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.PublicIPAllocationMethod = &publicIPAllocationMethod
 	}
 	if address.PublicIPPrefix != nil {
-		publicIPPrefix_ARM, err := (*address.PublicIPPrefix).ConvertToARM(resolved)
+		publicIPPrefix_ARM, err := address.PublicIPPrefix.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -430,7 +430,7 @@ func (address *PublicIPAddress_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.PublicIPPrefix = &publicIPPrefix
 	}
 	if address.ServicePublicIPAddress != nil {
-		servicePublicIPAddress_ARM, err := (*address.ServicePublicIPAddress).ConvertToARM(resolved)
+		servicePublicIPAddress_ARM, err := address.ServicePublicIPAddress.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -440,7 +440,7 @@ func (address *PublicIPAddress_Spec) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "Sku":
 	if address.Sku != nil {
-		sku_ARM, err := (*address.Sku).ConvertToARM(resolved)
+		sku_ARM, err := address.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2027,7 +2027,7 @@ func (settings *DdosSettings) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "DdosProtectionPlan":
 	if settings.DdosProtectionPlan != nil {
-		ddosProtectionPlan_ARM, err := (*settings.DdosProtectionPlan).ConvertToARM(resolved)
+		ddosProtectionPlan_ARM, err := settings.DdosProtectionPlan.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20240301/public_ip_prefix_types_gen.go
+++ b/v2/api/network/v1api20240301/public_ip_prefix_types_gen.go
@@ -303,7 +303,7 @@ func (prefix *PublicIPPrefix_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "ExtendedLocation":
 	if prefix.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*prefix.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := prefix.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -329,7 +329,7 @@ func (prefix *PublicIPPrefix_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties = &arm.PublicIPPrefixPropertiesFormat{}
 	}
 	if prefix.CustomIPPrefix != nil {
-		customIPPrefix_ARM, err := (*prefix.CustomIPPrefix).ConvertToARM(resolved)
+		customIPPrefix_ARM, err := prefix.CustomIPPrefix.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -344,7 +344,7 @@ func (prefix *PublicIPPrefix_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.IpTags = append(result.Properties.IpTags, *item_ARM.(*arm.IpTag))
 	}
 	if prefix.NatGateway != nil {
-		natGateway_ARM, err := (*prefix.NatGateway).ConvertToARM(resolved)
+		natGateway_ARM, err := prefix.NatGateway.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -364,7 +364,7 @@ func (prefix *PublicIPPrefix_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Sku":
 	if prefix.Sku != nil {
-		sku_ARM, err := (*prefix.Sku).ConvertToARM(resolved)
+		sku_ARM, err := prefix.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20240301/virtual_network_gateway_types_gen.go
+++ b/v2/api/network/v1api20240301/virtual_network_gateway_types_gen.go
@@ -362,7 +362,7 @@ func (gateway *VirtualNetworkGateway_Spec) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "ExtendedLocation":
 	if gateway.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*gateway.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := gateway.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -372,7 +372,7 @@ func (gateway *VirtualNetworkGateway_Spec) ConvertToARM(resolved genruntime.Conv
 
 	// Set property "Identity":
 	if gateway.Identity != nil {
-		identity_ARM, err := (*gateway.Identity).ConvertToARM(resolved)
+		identity_ARM, err := gateway.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -434,7 +434,7 @@ func (gateway *VirtualNetworkGateway_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.AllowVirtualWanTraffic = &allowVirtualWanTraffic
 	}
 	if gateway.AutoScaleConfiguration != nil {
-		autoScaleConfiguration_ARM, err := (*gateway.AutoScaleConfiguration).ConvertToARM(resolved)
+		autoScaleConfiguration_ARM, err := gateway.AutoScaleConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -442,7 +442,7 @@ func (gateway *VirtualNetworkGateway_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.AutoScaleConfiguration = &autoScaleConfiguration
 	}
 	if gateway.BgpSettings != nil {
-		bgpSettings_ARM, err := (*gateway.BgpSettings).ConvertToARM(resolved)
+		bgpSettings_ARM, err := gateway.BgpSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -450,7 +450,7 @@ func (gateway *VirtualNetworkGateway_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.BgpSettings = &bgpSettings
 	}
 	if gateway.CustomRoutes != nil {
-		customRoutes_ARM, err := (*gateway.CustomRoutes).ConvertToARM(resolved)
+		customRoutes_ARM, err := gateway.CustomRoutes.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -478,7 +478,7 @@ func (gateway *VirtualNetworkGateway_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.EnablePrivateIpAddress = &enablePrivateIpAddress
 	}
 	if gateway.GatewayDefaultSite != nil {
-		gatewayDefaultSite_ARM, err := (*gateway.GatewayDefaultSite).ConvertToARM(resolved)
+		gatewayDefaultSite_ARM, err := gateway.GatewayDefaultSite.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -512,7 +512,7 @@ func (gateway *VirtualNetworkGateway_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.ResiliencyModel = &resiliencyModel
 	}
 	if gateway.Sku != nil {
-		sku_ARM, err := (*gateway.Sku).ConvertToARM(resolved)
+		sku_ARM, err := gateway.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -535,7 +535,7 @@ func (gateway *VirtualNetworkGateway_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.VirtualNetworkGatewayPolicyGroups = append(result.Properties.VirtualNetworkGatewayPolicyGroups, *item_ARM.(*arm.VirtualNetworkGatewayPolicyGroup))
 	}
 	if gateway.VpnClientConfiguration != nil {
-		vpnClientConfiguration_ARM, err := (*gateway.VpnClientConfiguration).ConvertToARM(resolved)
+		vpnClientConfiguration_ARM, err := gateway.VpnClientConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3363,7 +3363,7 @@ func (configuration *VirtualNetworkGatewayAutoScaleConfiguration) ConvertToARM(r
 
 	// Set property "Bounds":
 	if configuration.Bounds != nil {
-		bounds_ARM, err := (*configuration.Bounds).ConvertToARM(resolved)
+		bounds_ARM, err := configuration.Bounds.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3591,7 +3591,7 @@ func (configuration *VirtualNetworkGatewayIPConfiguration) ConvertToARM(resolved
 		result.Properties.PrivateIPAllocationMethod = &privateIPAllocationMethod
 	}
 	if configuration.PublicIPAddress != nil {
-		publicIPAddress_ARM, err := (*configuration.PublicIPAddress).ConvertToARM(resolved)
+		publicIPAddress_ARM, err := configuration.PublicIPAddress.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3599,7 +3599,7 @@ func (configuration *VirtualNetworkGatewayIPConfiguration) ConvertToARM(resolved
 		result.Properties.PublicIPAddress = &publicIPAddress
 	}
 	if configuration.Subnet != nil {
-		subnet_ARM, err := (*configuration.Subnet).ConvertToARM(resolved)
+		subnet_ARM, err := configuration.Subnet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5865,7 +5865,7 @@ func (configuration *VpnClientConfiguration) ConvertToARM(resolved genruntime.Co
 
 	// Set property "VpnClientAddressPool":
 	if configuration.VpnClientAddressPool != nil {
-		vpnClientAddressPool_ARM, err := (*configuration.VpnClientAddressPool).ConvertToARM(resolved)
+		vpnClientAddressPool_ARM, err := configuration.VpnClientAddressPool.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20240301/virtual_network_types_gen.go
+++ b/v2/api/network/v1api20240301/virtual_network_types_gen.go
@@ -314,7 +314,7 @@ func (network *VirtualNetwork_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "ExtendedLocation":
 	if network.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*network.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := network.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -345,7 +345,7 @@ func (network *VirtualNetwork_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties = &arm.VirtualNetworkPropertiesFormat{}
 	}
 	if network.AddressSpace != nil {
-		addressSpace_ARM, err := (*network.AddressSpace).ConvertToARM(resolved)
+		addressSpace_ARM, err := network.AddressSpace.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -353,7 +353,7 @@ func (network *VirtualNetwork_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AddressSpace = &addressSpace
 	}
 	if network.BgpCommunities != nil {
-		bgpCommunities_ARM, err := (*network.BgpCommunities).ConvertToARM(resolved)
+		bgpCommunities_ARM, err := network.BgpCommunities.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -361,7 +361,7 @@ func (network *VirtualNetwork_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.BgpCommunities = &bgpCommunities
 	}
 	if network.DdosProtectionPlan != nil {
-		ddosProtectionPlan_ARM, err := (*network.DdosProtectionPlan).ConvertToARM(resolved)
+		ddosProtectionPlan_ARM, err := network.DdosProtectionPlan.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -369,7 +369,7 @@ func (network *VirtualNetwork_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.DdosProtectionPlan = &ddosProtectionPlan
 	}
 	if network.DhcpOptions != nil {
-		dhcpOptions_ARM, err := (*network.DhcpOptions).ConvertToARM(resolved)
+		dhcpOptions_ARM, err := network.DhcpOptions.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -385,7 +385,7 @@ func (network *VirtualNetwork_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.EnableVmProtection = &enableVmProtection
 	}
 	if network.Encryption != nil {
-		encryption_ARM, err := (*network.Encryption).ConvertToARM(resolved)
+		encryption_ARM, err := network.Encryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20240301/virtual_networks_subnet_types_gen.go
+++ b/v2/api/network/v1api20240301/virtual_networks_subnet_types_gen.go
@@ -368,7 +368,7 @@ func (subnet *VirtualNetworksSubnet_Spec) ConvertToARM(resolved genruntime.Conve
 		result.Properties.IpAllocations = append(result.Properties.IpAllocations, *item_ARM.(*arm.SubResource))
 	}
 	if subnet.NatGateway != nil {
-		natGateway_ARM, err := (*subnet.NatGateway).ConvertToARM(resolved)
+		natGateway_ARM, err := subnet.NatGateway.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -376,7 +376,7 @@ func (subnet *VirtualNetworksSubnet_Spec) ConvertToARM(resolved genruntime.Conve
 		result.Properties.NatGateway = &natGateway
 	}
 	if subnet.NetworkSecurityGroup != nil {
-		networkSecurityGroup_ARM, err := (*subnet.NetworkSecurityGroup).ConvertToARM(resolved)
+		networkSecurityGroup_ARM, err := subnet.NetworkSecurityGroup.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -396,7 +396,7 @@ func (subnet *VirtualNetworksSubnet_Spec) ConvertToARM(resolved genruntime.Conve
 		result.Properties.PrivateLinkServiceNetworkPolicies = &privateLinkServiceNetworkPolicies
 	}
 	if subnet.RouteTable != nil {
-		routeTable_ARM, err := (*subnet.RouteTable).ConvertToARM(resolved)
+		routeTable_ARM, err := subnet.RouteTable.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3508,7 +3508,7 @@ func (format *ServiceEndpointPropertiesFormat) ConvertToARM(resolved genruntime.
 
 	// Set property "NetworkIdentifier":
 	if format.NetworkIdentifier != nil {
-		networkIdentifier_ARM, err := (*format.NetworkIdentifier).ConvertToARM(resolved)
+		networkIdentifier_ARM, err := format.NetworkIdentifier.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20240301/virtual_networks_virtual_network_peering_types_gen.go
+++ b/v2/api/network/v1api20240301/virtual_networks_virtual_network_peering_types_gen.go
@@ -373,7 +373,7 @@ func (peering *VirtualNetworksVirtualNetworkPeering_Spec) ConvertToARM(resolved 
 		result.Properties.EnableOnlyIPv6Peering = &enableOnlyIPv6Peering
 	}
 	if peering.LocalAddressSpace != nil {
-		localAddressSpace_ARM, err := (*peering.LocalAddressSpace).ConvertToARM(resolved)
+		localAddressSpace_ARM, err := peering.LocalAddressSpace.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -384,7 +384,7 @@ func (peering *VirtualNetworksVirtualNetworkPeering_Spec) ConvertToARM(resolved 
 		result.Properties.LocalSubnetNames = append(result.Properties.LocalSubnetNames, item)
 	}
 	if peering.LocalVirtualNetworkAddressSpace != nil {
-		localVirtualNetworkAddressSpace_ARM, err := (*peering.LocalVirtualNetworkAddressSpace).ConvertToARM(resolved)
+		localVirtualNetworkAddressSpace_ARM, err := peering.LocalVirtualNetworkAddressSpace.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -408,7 +408,7 @@ func (peering *VirtualNetworksVirtualNetworkPeering_Spec) ConvertToARM(resolved 
 		result.Properties.PeeringSyncLevel = &peeringSyncLevel
 	}
 	if peering.RemoteAddressSpace != nil {
-		remoteAddressSpace_ARM, err := (*peering.RemoteAddressSpace).ConvertToARM(resolved)
+		remoteAddressSpace_ARM, err := peering.RemoteAddressSpace.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -416,7 +416,7 @@ func (peering *VirtualNetworksVirtualNetworkPeering_Spec) ConvertToARM(resolved 
 		result.Properties.RemoteAddressSpace = &remoteAddressSpace
 	}
 	if peering.RemoteBgpCommunities != nil {
-		remoteBgpCommunities_ARM, err := (*peering.RemoteBgpCommunities).ConvertToARM(resolved)
+		remoteBgpCommunities_ARM, err := peering.RemoteBgpCommunities.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -427,7 +427,7 @@ func (peering *VirtualNetworksVirtualNetworkPeering_Spec) ConvertToARM(resolved 
 		result.Properties.RemoteSubnetNames = append(result.Properties.RemoteSubnetNames, item)
 	}
 	if peering.RemoteVirtualNetwork != nil {
-		remoteVirtualNetwork_ARM, err := (*peering.RemoteVirtualNetwork).ConvertToARM(resolved)
+		remoteVirtualNetwork_ARM, err := peering.RemoteVirtualNetwork.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -435,7 +435,7 @@ func (peering *VirtualNetworksVirtualNetworkPeering_Spec) ConvertToARM(resolved 
 		result.Properties.RemoteVirtualNetwork = &remoteVirtualNetwork
 	}
 	if peering.RemoteVirtualNetworkAddressSpace != nil {
-		remoteVirtualNetworkAddressSpace_ARM, err := (*peering.RemoteVirtualNetworkAddressSpace).ConvertToARM(resolved)
+		remoteVirtualNetworkAddressSpace_ARM, err := peering.RemoteVirtualNetworkAddressSpace.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20240601/private_dns_zones_a_record_types_gen.go
+++ b/v2/api/network/v1api20240601/private_dns_zones_a_record_types_gen.go
@@ -341,7 +341,7 @@ func (record *PrivateDnsZonesARecord_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.AaaaRecords = append(result.Properties.AaaaRecords, *item_ARM.(*arm.AaaaRecord))
 	}
 	if record.CnameRecord != nil {
-		cnameRecord_ARM, err := (*record.CnameRecord).ConvertToARM(resolved)
+		cnameRecord_ARM, err := record.CnameRecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -369,7 +369,7 @@ func (record *PrivateDnsZonesARecord_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.PtrRecords = append(result.Properties.PtrRecords, *item_ARM.(*arm.PtrRecord))
 	}
 	if record.SoaRecord != nil {
-		soaRecord_ARM, err := (*record.SoaRecord).ConvertToARM(resolved)
+		soaRecord_ARM, err := record.SoaRecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20240601/private_dns_zones_aaaa_record_types_gen.go
+++ b/v2/api/network/v1api20240601/private_dns_zones_aaaa_record_types_gen.go
@@ -341,7 +341,7 @@ func (record *PrivateDnsZonesAAAARecord_Spec) ConvertToARM(resolved genruntime.C
 		result.Properties.AaaaRecords = append(result.Properties.AaaaRecords, *item_ARM.(*arm.AaaaRecord))
 	}
 	if record.CnameRecord != nil {
-		cnameRecord_ARM, err := (*record.CnameRecord).ConvertToARM(resolved)
+		cnameRecord_ARM, err := record.CnameRecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -369,7 +369,7 @@ func (record *PrivateDnsZonesAAAARecord_Spec) ConvertToARM(resolved genruntime.C
 		result.Properties.PtrRecords = append(result.Properties.PtrRecords, *item_ARM.(*arm.PtrRecord))
 	}
 	if record.SoaRecord != nil {
-		soaRecord_ARM, err := (*record.SoaRecord).ConvertToARM(resolved)
+		soaRecord_ARM, err := record.SoaRecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20240601/private_dns_zones_cname_record_types_gen.go
+++ b/v2/api/network/v1api20240601/private_dns_zones_cname_record_types_gen.go
@@ -341,7 +341,7 @@ func (record *PrivateDnsZonesCNAMERecord_Spec) ConvertToARM(resolved genruntime.
 		result.Properties.AaaaRecords = append(result.Properties.AaaaRecords, *item_ARM.(*arm.AaaaRecord))
 	}
 	if record.CnameRecord != nil {
-		cnameRecord_ARM, err := (*record.CnameRecord).ConvertToARM(resolved)
+		cnameRecord_ARM, err := record.CnameRecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -369,7 +369,7 @@ func (record *PrivateDnsZonesCNAMERecord_Spec) ConvertToARM(resolved genruntime.
 		result.Properties.PtrRecords = append(result.Properties.PtrRecords, *item_ARM.(*arm.PtrRecord))
 	}
 	if record.SoaRecord != nil {
-		soaRecord_ARM, err := (*record.SoaRecord).ConvertToARM(resolved)
+		soaRecord_ARM, err := record.SoaRecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20240601/private_dns_zones_mx_record_types_gen.go
+++ b/v2/api/network/v1api20240601/private_dns_zones_mx_record_types_gen.go
@@ -341,7 +341,7 @@ func (record *PrivateDnsZonesMXRecord_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties.AaaaRecords = append(result.Properties.AaaaRecords, *item_ARM.(*arm.AaaaRecord))
 	}
 	if record.CnameRecord != nil {
-		cnameRecord_ARM, err := (*record.CnameRecord).ConvertToARM(resolved)
+		cnameRecord_ARM, err := record.CnameRecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -369,7 +369,7 @@ func (record *PrivateDnsZonesMXRecord_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties.PtrRecords = append(result.Properties.PtrRecords, *item_ARM.(*arm.PtrRecord))
 	}
 	if record.SoaRecord != nil {
-		soaRecord_ARM, err := (*record.SoaRecord).ConvertToARM(resolved)
+		soaRecord_ARM, err := record.SoaRecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20240601/private_dns_zones_ptr_record_types_gen.go
+++ b/v2/api/network/v1api20240601/private_dns_zones_ptr_record_types_gen.go
@@ -341,7 +341,7 @@ func (record *PrivateDnsZonesPTRRecord_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.AaaaRecords = append(result.Properties.AaaaRecords, *item_ARM.(*arm.AaaaRecord))
 	}
 	if record.CnameRecord != nil {
-		cnameRecord_ARM, err := (*record.CnameRecord).ConvertToARM(resolved)
+		cnameRecord_ARM, err := record.CnameRecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -369,7 +369,7 @@ func (record *PrivateDnsZonesPTRRecord_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.PtrRecords = append(result.Properties.PtrRecords, *item_ARM.(*arm.PtrRecord))
 	}
 	if record.SoaRecord != nil {
-		soaRecord_ARM, err := (*record.SoaRecord).ConvertToARM(resolved)
+		soaRecord_ARM, err := record.SoaRecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20240601/private_dns_zones_srv_record_types_gen.go
+++ b/v2/api/network/v1api20240601/private_dns_zones_srv_record_types_gen.go
@@ -341,7 +341,7 @@ func (record *PrivateDnsZonesSRVRecord_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.AaaaRecords = append(result.Properties.AaaaRecords, *item_ARM.(*arm.AaaaRecord))
 	}
 	if record.CnameRecord != nil {
-		cnameRecord_ARM, err := (*record.CnameRecord).ConvertToARM(resolved)
+		cnameRecord_ARM, err := record.CnameRecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -369,7 +369,7 @@ func (record *PrivateDnsZonesSRVRecord_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.PtrRecords = append(result.Properties.PtrRecords, *item_ARM.(*arm.PtrRecord))
 	}
 	if record.SoaRecord != nil {
-		soaRecord_ARM, err := (*record.SoaRecord).ConvertToARM(resolved)
+		soaRecord_ARM, err := record.SoaRecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20240601/private_dns_zones_txt_record_types_gen.go
+++ b/v2/api/network/v1api20240601/private_dns_zones_txt_record_types_gen.go
@@ -341,7 +341,7 @@ func (record *PrivateDnsZonesTXTRecord_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.AaaaRecords = append(result.Properties.AaaaRecords, *item_ARM.(*arm.AaaaRecord))
 	}
 	if record.CnameRecord != nil {
-		cnameRecord_ARM, err := (*record.CnameRecord).ConvertToARM(resolved)
+		cnameRecord_ARM, err := record.CnameRecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -369,7 +369,7 @@ func (record *PrivateDnsZonesTXTRecord_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.PtrRecords = append(result.Properties.PtrRecords, *item_ARM.(*arm.PtrRecord))
 	}
 	if record.SoaRecord != nil {
-		soaRecord_ARM, err := (*record.SoaRecord).ConvertToARM(resolved)
+		soaRecord_ARM, err := record.SoaRecord.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/network/v1api20240601/private_dns_zones_virtual_network_link_types_gen.go
+++ b/v2/api/network/v1api20240601/private_dns_zones_virtual_network_link_types_gen.go
@@ -324,7 +324,7 @@ func (link *PrivateDnsZonesVirtualNetworkLink_Spec) ConvertToARM(resolved genrun
 		result.Properties.ResolutionPolicy = &resolutionPolicy
 	}
 	if link.VirtualNetwork != nil {
-		virtualNetwork_ARM, err := (*link.VirtualNetwork).ConvertToARM(resolved)
+		virtualNetwork_ARM, err := link.VirtualNetwork.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/notificationhubs/v1api20230901/namespace_types_gen.go
+++ b/v2/api/notificationhubs/v1api20230901/namespace_types_gen.go
@@ -327,7 +327,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Properties":
 	if namespace.Properties != nil {
-		properties_ARM, err := (*namespace.Properties).ConvertToARM(resolved)
+		properties_ARM, err := namespace.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -337,7 +337,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Sku":
 	if namespace.Sku != nil {
-		sku_ARM, err := (*namespace.Sku).ConvertToARM(resolved)
+		sku_ARM, err := namespace.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1151,7 +1151,7 @@ func (properties *NamespaceProperties) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "NetworkAcls":
 	if properties.NetworkAcls != nil {
-		networkAcls_ARM, err := (*properties.NetworkAcls).ConvertToARM(resolved)
+		networkAcls_ARM, err := properties.NetworkAcls.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1161,7 +1161,7 @@ func (properties *NamespaceProperties) ConvertToARM(resolved genruntime.ConvertT
 
 	// Set property "PnsCredentials":
 	if properties.PnsCredentials != nil {
-		pnsCredentials_ARM, err := (*properties.PnsCredentials).ConvertToARM(resolved)
+		pnsCredentials_ARM, err := properties.PnsCredentials.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2748,7 +2748,7 @@ func (acls *NetworkAcls) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 
 	// Set property "PublicNetworkRule":
 	if acls.PublicNetworkRule != nil {
-		publicNetworkRule_ARM, err := (*acls.PublicNetworkRule).ConvertToARM(resolved)
+		publicNetworkRule_ARM, err := acls.PublicNetworkRule.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3109,7 +3109,7 @@ func (credentials *PnsCredentials) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "AdmCredential":
 	if credentials.AdmCredential != nil {
-		admCredential_ARM, err := (*credentials.AdmCredential).ConvertToARM(resolved)
+		admCredential_ARM, err := credentials.AdmCredential.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3119,7 +3119,7 @@ func (credentials *PnsCredentials) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "ApnsCredential":
 	if credentials.ApnsCredential != nil {
-		apnsCredential_ARM, err := (*credentials.ApnsCredential).ConvertToARM(resolved)
+		apnsCredential_ARM, err := credentials.ApnsCredential.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3129,7 +3129,7 @@ func (credentials *PnsCredentials) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "BaiduCredential":
 	if credentials.BaiduCredential != nil {
-		baiduCredential_ARM, err := (*credentials.BaiduCredential).ConvertToARM(resolved)
+		baiduCredential_ARM, err := credentials.BaiduCredential.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3139,7 +3139,7 @@ func (credentials *PnsCredentials) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "BrowserCredential":
 	if credentials.BrowserCredential != nil {
-		browserCredential_ARM, err := (*credentials.BrowserCredential).ConvertToARM(resolved)
+		browserCredential_ARM, err := credentials.BrowserCredential.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3149,7 +3149,7 @@ func (credentials *PnsCredentials) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "GcmCredential":
 	if credentials.GcmCredential != nil {
-		gcmCredential_ARM, err := (*credentials.GcmCredential).ConvertToARM(resolved)
+		gcmCredential_ARM, err := credentials.GcmCredential.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3159,7 +3159,7 @@ func (credentials *PnsCredentials) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "MpnsCredential":
 	if credentials.MpnsCredential != nil {
-		mpnsCredential_ARM, err := (*credentials.MpnsCredential).ConvertToARM(resolved)
+		mpnsCredential_ARM, err := credentials.MpnsCredential.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3169,7 +3169,7 @@ func (credentials *PnsCredentials) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "WnsCredential":
 	if credentials.WnsCredential != nil {
-		wnsCredential_ARM, err := (*credentials.WnsCredential).ConvertToARM(resolved)
+		wnsCredential_ARM, err := credentials.WnsCredential.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3179,7 +3179,7 @@ func (credentials *PnsCredentials) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "XiaomiCredential":
 	if credentials.XiaomiCredential != nil {
-		xiaomiCredential_ARM, err := (*credentials.XiaomiCredential).ConvertToARM(resolved)
+		xiaomiCredential_ARM, err := credentials.XiaomiCredential.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/notificationhubs/v1api20230901/namespaces_authorization_rule_types_gen.go
+++ b/v2/api/notificationhubs/v1api20230901/namespaces_authorization_rule_types_gen.go
@@ -294,7 +294,7 @@ func (rule *NamespacesAuthorizationRule_Spec) ConvertToARM(resolved genruntime.C
 
 	// Set property "Properties":
 	if rule.Properties != nil {
-		properties_ARM, err := (*rule.Properties).ConvertToARM(resolved)
+		properties_ARM, err := rule.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/notificationhubs/v1api20230901/notification_hub_types_gen.go
+++ b/v2/api/notificationhubs/v1api20230901/notification_hub_types_gen.go
@@ -298,7 +298,7 @@ func (notificationHub *NotificationHub_Spec) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Properties":
 	if notificationHub.Properties != nil {
-		properties_ARM, err := (*notificationHub.Properties).ConvertToARM(resolved)
+		properties_ARM, err := notificationHub.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -308,7 +308,7 @@ func (notificationHub *NotificationHub_Spec) ConvertToARM(resolved genruntime.Co
 
 	// Set property "Sku":
 	if notificationHub.Sku != nil {
-		sku_ARM, err := (*notificationHub.Sku).ConvertToARM(resolved)
+		sku_ARM, err := notificationHub.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1089,7 +1089,7 @@ func (properties *NotificationHubProperties) ConvertToARM(resolved genruntime.Co
 
 	// Set property "AdmCredential":
 	if properties.AdmCredential != nil {
-		admCredential_ARM, err := (*properties.AdmCredential).ConvertToARM(resolved)
+		admCredential_ARM, err := properties.AdmCredential.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1099,7 +1099,7 @@ func (properties *NotificationHubProperties) ConvertToARM(resolved genruntime.Co
 
 	// Set property "ApnsCredential":
 	if properties.ApnsCredential != nil {
-		apnsCredential_ARM, err := (*properties.ApnsCredential).ConvertToARM(resolved)
+		apnsCredential_ARM, err := properties.ApnsCredential.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1109,7 +1109,7 @@ func (properties *NotificationHubProperties) ConvertToARM(resolved genruntime.Co
 
 	// Set property "BaiduCredential":
 	if properties.BaiduCredential != nil {
-		baiduCredential_ARM, err := (*properties.BaiduCredential).ConvertToARM(resolved)
+		baiduCredential_ARM, err := properties.BaiduCredential.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1119,7 +1119,7 @@ func (properties *NotificationHubProperties) ConvertToARM(resolved genruntime.Co
 
 	// Set property "BrowserCredential":
 	if properties.BrowserCredential != nil {
-		browserCredential_ARM, err := (*properties.BrowserCredential).ConvertToARM(resolved)
+		browserCredential_ARM, err := properties.BrowserCredential.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1129,7 +1129,7 @@ func (properties *NotificationHubProperties) ConvertToARM(resolved genruntime.Co
 
 	// Set property "GcmCredential":
 	if properties.GcmCredential != nil {
-		gcmCredential_ARM, err := (*properties.GcmCredential).ConvertToARM(resolved)
+		gcmCredential_ARM, err := properties.GcmCredential.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1139,7 +1139,7 @@ func (properties *NotificationHubProperties) ConvertToARM(resolved genruntime.Co
 
 	// Set property "MpnsCredential":
 	if properties.MpnsCredential != nil {
-		mpnsCredential_ARM, err := (*properties.MpnsCredential).ConvertToARM(resolved)
+		mpnsCredential_ARM, err := properties.MpnsCredential.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1161,7 +1161,7 @@ func (properties *NotificationHubProperties) ConvertToARM(resolved genruntime.Co
 
 	// Set property "WnsCredential":
 	if properties.WnsCredential != nil {
-		wnsCredential_ARM, err := (*properties.WnsCredential).ConvertToARM(resolved)
+		wnsCredential_ARM, err := properties.WnsCredential.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1171,7 +1171,7 @@ func (properties *NotificationHubProperties) ConvertToARM(resolved genruntime.Co
 
 	// Set property "XiaomiCredential":
 	if properties.XiaomiCredential != nil {
-		xiaomiCredential_ARM, err := (*properties.XiaomiCredential).ConvertToARM(resolved)
+		xiaomiCredential_ARM, err := properties.XiaomiCredential.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2091,7 +2091,7 @@ func (credential *AdmCredential) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Properties":
 	if credential.Properties != nil {
-		properties_ARM, err := (*credential.Properties).ConvertToARM(resolved)
+		properties_ARM, err := credential.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2294,7 +2294,7 @@ func (credential *ApnsCredential) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "Properties":
 	if credential.Properties != nil {
-		properties_ARM, err := (*credential.Properties).ConvertToARM(resolved)
+		properties_ARM, err := credential.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2497,7 +2497,7 @@ func (credential *BaiduCredential) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Properties":
 	if credential.Properties != nil {
-		properties_ARM, err := (*credential.Properties).ConvertToARM(resolved)
+		properties_ARM, err := credential.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2700,7 +2700,7 @@ func (credential *BrowserCredential) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "Properties":
 	if credential.Properties != nil {
-		properties_ARM, err := (*credential.Properties).ConvertToARM(resolved)
+		properties_ARM, err := credential.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2903,7 +2903,7 @@ func (credential *GcmCredential) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Properties":
 	if credential.Properties != nil {
-		properties_ARM, err := (*credential.Properties).ConvertToARM(resolved)
+		properties_ARM, err := credential.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3106,7 +3106,7 @@ func (credential *MpnsCredential) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "Properties":
 	if credential.Properties != nil {
-		properties_ARM, err := (*credential.Properties).ConvertToARM(resolved)
+		properties_ARM, err := credential.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3414,7 +3414,7 @@ func (credential *WnsCredential) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Properties":
 	if credential.Properties != nil {
-		properties_ARM, err := (*credential.Properties).ConvertToARM(resolved)
+		properties_ARM, err := credential.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3617,7 +3617,7 @@ func (credential *XiaomiCredential) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Properties":
 	if credential.Properties != nil {
-		properties_ARM, err := (*credential.Properties).ConvertToARM(resolved)
+		properties_ARM, err := credential.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/notificationhubs/v1api20230901/notification_hubs_authorization_rule_types_gen.go
+++ b/v2/api/notificationhubs/v1api20230901/notification_hubs_authorization_rule_types_gen.go
@@ -294,7 +294,7 @@ func (rule *NotificationHubsAuthorizationRule_Spec) ConvertToARM(resolved genrun
 
 	// Set property "Properties":
 	if rule.Properties != nil {
-		properties_ARM, err := (*rule.Properties).ConvertToARM(resolved)
+		properties_ARM, err := rule.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/operationalinsights/v1api20210601/workspace_types_gen.go
+++ b/v2/api/operationalinsights/v1api20210601/workspace_types_gen.go
@@ -341,7 +341,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties = &arm.WorkspaceProperties{}
 	}
 	if workspace.Features != nil {
-		features_ARM, err := (*workspace.Features).ConvertToARM(resolved)
+		features_ARM, err := workspace.Features.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -375,7 +375,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.RetentionInDays = &retentionInDays
 	}
 	if workspace.Sku != nil {
-		sku_ARM, err := (*workspace.Sku).ConvertToARM(resolved)
+		sku_ARM, err := workspace.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -383,7 +383,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.Sku = &sku
 	}
 	if workspace.WorkspaceCapping != nil {
-		workspaceCapping_ARM, err := (*workspace.WorkspaceCapping).ConvertToARM(resolved)
+		workspaceCapping_ARM, err := workspace.WorkspaceCapping.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/redhatopenshift/v1api20231122/open_shift_cluster_types_gen.go
+++ b/v2/api/redhatopenshift/v1api20231122/open_shift_cluster_types_gen.go
@@ -324,7 +324,7 @@ func (cluster *OpenShiftCluster_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties = &arm.OpenShiftClusterProperties{}
 	}
 	if cluster.ApiserverProfile != nil {
-		apiserverProfile_ARM, err := (*cluster.ApiserverProfile).ConvertToARM(resolved)
+		apiserverProfile_ARM, err := cluster.ApiserverProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -332,7 +332,7 @@ func (cluster *OpenShiftCluster_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties.ApiserverProfile = &apiserverProfile
 	}
 	if cluster.ClusterProfile != nil {
-		clusterProfile_ARM, err := (*cluster.ClusterProfile).ConvertToARM(resolved)
+		clusterProfile_ARM, err := cluster.ClusterProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -347,7 +347,7 @@ func (cluster *OpenShiftCluster_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties.IngressProfiles = append(result.Properties.IngressProfiles, *item_ARM.(*arm.IngressProfile))
 	}
 	if cluster.MasterProfile != nil {
-		masterProfile_ARM, err := (*cluster.MasterProfile).ConvertToARM(resolved)
+		masterProfile_ARM, err := cluster.MasterProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -355,7 +355,7 @@ func (cluster *OpenShiftCluster_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties.MasterProfile = &masterProfile
 	}
 	if cluster.NetworkProfile != nil {
-		networkProfile_ARM, err := (*cluster.NetworkProfile).ConvertToARM(resolved)
+		networkProfile_ARM, err := cluster.NetworkProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -363,7 +363,7 @@ func (cluster *OpenShiftCluster_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties.NetworkProfile = &networkProfile
 	}
 	if cluster.ServicePrincipalProfile != nil {
-		servicePrincipalProfile_ARM, err := (*cluster.ServicePrincipalProfile).ConvertToARM(resolved)
+		servicePrincipalProfile_ARM, err := cluster.ServicePrincipalProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2793,7 +2793,7 @@ func (profile *NetworkProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "LoadBalancerProfile":
 	if profile.LoadBalancerProfile != nil {
-		loadBalancerProfile_ARM, err := (*profile.LoadBalancerProfile).ConvertToARM(resolved)
+		loadBalancerProfile_ARM, err := profile.LoadBalancerProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4221,7 +4221,7 @@ func (profile *LoadBalancerProfile) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "ManagedOutboundIps":
 	if profile.ManagedOutboundIps != nil {
-		managedOutboundIps_ARM, err := (*profile.ManagedOutboundIps).ConvertToARM(resolved)
+		managedOutboundIps_ARM, err := profile.ManagedOutboundIps.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/search/v1api20220901/search_service_types_gen.go
+++ b/v2/api/search/v1api20220901/search_service_types_gen.go
@@ -364,7 +364,7 @@ func (service *SearchService_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Identity":
 	if service.Identity != nil {
-		identity_ARM, err := (*service.Identity).ConvertToARM(resolved)
+		identity_ARM, err := service.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -393,7 +393,7 @@ func (service *SearchService_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties = &arm.SearchServiceProperties{}
 	}
 	if service.AuthOptions != nil {
-		authOptions_ARM, err := (*service.AuthOptions).ConvertToARM(resolved)
+		authOptions_ARM, err := service.AuthOptions.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -405,7 +405,7 @@ func (service *SearchService_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.DisableLocalAuth = &disableLocalAuth
 	}
 	if service.EncryptionWithCmk != nil {
-		encryptionWithCmk_ARM, err := (*service.EncryptionWithCmk).ConvertToARM(resolved)
+		encryptionWithCmk_ARM, err := service.EncryptionWithCmk.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -419,7 +419,7 @@ func (service *SearchService_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.HostingMode = &hostingMode
 	}
 	if service.NetworkRuleSet != nil {
-		networkRuleSet_ARM, err := (*service.NetworkRuleSet).ConvertToARM(resolved)
+		networkRuleSet_ARM, err := service.NetworkRuleSet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -443,7 +443,7 @@ func (service *SearchService_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Sku":
 	if service.Sku != nil {
-		sku_ARM, err := (*service.Sku).ConvertToARM(resolved)
+		sku_ARM, err := service.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1673,7 +1673,7 @@ func (options *DataPlaneAuthOptions) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "AadOrApiKey":
 	if options.AadOrApiKey != nil {
-		aadOrApiKey_ARM, err := (*options.AadOrApiKey).ConvertToARM(resolved)
+		aadOrApiKey_ARM, err := options.AadOrApiKey.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/search/v1api20231101/search_service_types_gen.go
+++ b/v2/api/search/v1api20231101/search_service_types_gen.go
@@ -365,7 +365,7 @@ func (service *SearchService_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Identity":
 	if service.Identity != nil {
-		identity_ARM, err := (*service.Identity).ConvertToARM(resolved)
+		identity_ARM, err := service.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -395,7 +395,7 @@ func (service *SearchService_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties = &arm.SearchServiceProperties{}
 	}
 	if service.AuthOptions != nil {
-		authOptions_ARM, err := (*service.AuthOptions).ConvertToARM(resolved)
+		authOptions_ARM, err := service.AuthOptions.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -407,7 +407,7 @@ func (service *SearchService_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.DisableLocalAuth = &disableLocalAuth
 	}
 	if service.EncryptionWithCmk != nil {
-		encryptionWithCmk_ARM, err := (*service.EncryptionWithCmk).ConvertToARM(resolved)
+		encryptionWithCmk_ARM, err := service.EncryptionWithCmk.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -421,7 +421,7 @@ func (service *SearchService_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.HostingMode = &hostingMode
 	}
 	if service.NetworkRuleSet != nil {
-		networkRuleSet_ARM, err := (*service.NetworkRuleSet).ConvertToARM(resolved)
+		networkRuleSet_ARM, err := service.NetworkRuleSet.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -451,7 +451,7 @@ func (service *SearchService_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Sku":
 	if service.Sku != nil {
-		sku_ARM, err := (*service.Sku).ConvertToARM(resolved)
+		sku_ARM, err := service.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1852,7 +1852,7 @@ func (options *DataPlaneAuthOptions) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "AadOrApiKey":
 	if options.AadOrApiKey != nil {
-		aadOrApiKey_ARM, err := (*options.AadOrApiKey).ConvertToARM(resolved)
+		aadOrApiKey_ARM, err := options.AadOrApiKey.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/servicebus/v1api20210101preview/namespace_types_gen.go
+++ b/v2/api/servicebus/v1api20210101preview/namespace_types_gen.go
@@ -300,7 +300,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Identity":
 	if namespace.Identity != nil {
-		identity_ARM, err := (*namespace.Identity).ConvertToARM(resolved)
+		identity_ARM, err := namespace.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -322,7 +322,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties = &arm.SBNamespaceProperties{}
 	}
 	if namespace.Encryption != nil {
-		encryption_ARM, err := (*namespace.Encryption).ConvertToARM(resolved)
+		encryption_ARM, err := namespace.Encryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -336,7 +336,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Sku":
 	if namespace.Sku != nil {
-		sku_ARM, err := (*namespace.Sku).ConvertToARM(resolved)
+		sku_ARM, err := namespace.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2578,7 +2578,7 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "Identity":
 	if properties.Identity != nil {
-		identity_ARM, err := (*properties.Identity).ConvertToARM(resolved)
+		identity_ARM, err := properties.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/servicebus/v1api20210101preview/namespaces_topics_subscriptions_rule_types_gen.go
+++ b/v2/api/servicebus/v1api20210101preview/namespaces_topics_subscriptions_rule_types_gen.go
@@ -300,7 +300,7 @@ func (rule *NamespacesTopicsSubscriptionsRule_Spec) ConvertToARM(resolved genrun
 		result.Properties = &arm.Ruleproperties{}
 	}
 	if rule.Action != nil {
-		action_ARM, err := (*rule.Action).ConvertToARM(resolved)
+		action_ARM, err := rule.Action.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -308,7 +308,7 @@ func (rule *NamespacesTopicsSubscriptionsRule_Spec) ConvertToARM(resolved genrun
 		result.Properties.Action = &action
 	}
 	if rule.CorrelationFilter != nil {
-		correlationFilter_ARM, err := (*rule.CorrelationFilter).ConvertToARM(resolved)
+		correlationFilter_ARM, err := rule.CorrelationFilter.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -322,7 +322,7 @@ func (rule *NamespacesTopicsSubscriptionsRule_Spec) ConvertToARM(resolved genrun
 		result.Properties.FilterType = &filterType
 	}
 	if rule.SqlFilter != nil {
-		sqlFilter_ARM, err := (*rule.SqlFilter).ConvertToARM(resolved)
+		sqlFilter_ARM, err := rule.SqlFilter.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/servicebus/v1api20211101/namespace_types_gen.go
+++ b/v2/api/servicebus/v1api20211101/namespace_types_gen.go
@@ -306,7 +306,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Identity":
 	if namespace.Identity != nil {
-		identity_ARM, err := (*namespace.Identity).ConvertToARM(resolved)
+		identity_ARM, err := namespace.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -339,7 +339,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.DisableLocalAuth = &disableLocalAuth
 	}
 	if namespace.Encryption != nil {
-		encryption_ARM, err := (*namespace.Encryption).ConvertToARM(resolved)
+		encryption_ARM, err := namespace.Encryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -353,7 +353,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Sku":
 	if namespace.Sku != nil {
-		sku_ARM, err := (*namespace.Sku).ConvertToARM(resolved)
+		sku_ARM, err := namespace.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2608,7 +2608,7 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "Identity":
 	if properties.Identity != nil {
-		identity_ARM, err := (*properties.Identity).ConvertToARM(resolved)
+		identity_ARM, err := properties.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/servicebus/v1api20211101/namespaces_topics_subscription_types_gen.go
+++ b/v2/api/servicebus/v1api20211101/namespaces_topics_subscription_types_gen.go
@@ -345,7 +345,7 @@ func (subscription *NamespacesTopicsSubscription_Spec) ConvertToARM(resolved gen
 		result.Properties.AutoDeleteOnIdle = &autoDeleteOnIdle
 	}
 	if subscription.ClientAffineProperties != nil {
-		clientAffineProperties_ARM, err := (*subscription.ClientAffineProperties).ConvertToARM(resolved)
+		clientAffineProperties_ARM, err := subscription.ClientAffineProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/servicebus/v1api20211101/namespaces_topics_subscriptions_rule_types_gen.go
+++ b/v2/api/servicebus/v1api20211101/namespaces_topics_subscriptions_rule_types_gen.go
@@ -300,7 +300,7 @@ func (rule *NamespacesTopicsSubscriptionsRule_Spec) ConvertToARM(resolved genrun
 		result.Properties = &arm.Ruleproperties{}
 	}
 	if rule.Action != nil {
-		action_ARM, err := (*rule.Action).ConvertToARM(resolved)
+		action_ARM, err := rule.Action.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -308,7 +308,7 @@ func (rule *NamespacesTopicsSubscriptionsRule_Spec) ConvertToARM(resolved genrun
 		result.Properties.Action = &action
 	}
 	if rule.CorrelationFilter != nil {
-		correlationFilter_ARM, err := (*rule.CorrelationFilter).ConvertToARM(resolved)
+		correlationFilter_ARM, err := rule.CorrelationFilter.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -322,7 +322,7 @@ func (rule *NamespacesTopicsSubscriptionsRule_Spec) ConvertToARM(resolved genrun
 		result.Properties.FilterType = &filterType
 	}
 	if rule.SqlFilter != nil {
-		sqlFilter_ARM, err := (*rule.SqlFilter).ConvertToARM(resolved)
+		sqlFilter_ARM, err := rule.SqlFilter.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/servicebus/v1api20221001preview/namespace_types_gen.go
+++ b/v2/api/servicebus/v1api20221001preview/namespace_types_gen.go
@@ -316,7 +316,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Identity":
 	if namespace.Identity != nil {
-		identity_ARM, err := (*namespace.Identity).ConvertToARM(resolved)
+		identity_ARM, err := namespace.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -352,7 +352,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.DisableLocalAuth = &disableLocalAuth
 	}
 	if namespace.Encryption != nil {
-		encryption_ARM, err := (*namespace.Encryption).ConvertToARM(resolved)
+		encryption_ARM, err := namespace.Encryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -382,7 +382,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Sku":
 	if namespace.Sku != nil {
-		sku_ARM, err := (*namespace.Sku).ConvertToARM(resolved)
+		sku_ARM, err := namespace.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2857,7 +2857,7 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "Identity":
 	if properties.Identity != nil {
-		identity_ARM, err := (*properties.Identity).ConvertToARM(resolved)
+		identity_ARM, err := properties.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/servicebus/v1api20221001preview/namespaces_topics_subscription_types_gen.go
+++ b/v2/api/servicebus/v1api20221001preview/namespaces_topics_subscription_types_gen.go
@@ -345,7 +345,7 @@ func (subscription *NamespacesTopicsSubscription_Spec) ConvertToARM(resolved gen
 		result.Properties.AutoDeleteOnIdle = &autoDeleteOnIdle
 	}
 	if subscription.ClientAffineProperties != nil {
-		clientAffineProperties_ARM, err := (*subscription.ClientAffineProperties).ConvertToARM(resolved)
+		clientAffineProperties_ARM, err := subscription.ClientAffineProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/servicebus/v1api20221001preview/namespaces_topics_subscriptions_rule_types_gen.go
+++ b/v2/api/servicebus/v1api20221001preview/namespaces_topics_subscriptions_rule_types_gen.go
@@ -300,7 +300,7 @@ func (rule *NamespacesTopicsSubscriptionsRule_Spec) ConvertToARM(resolved genrun
 		result.Properties = &arm.Ruleproperties{}
 	}
 	if rule.Action != nil {
-		action_ARM, err := (*rule.Action).ConvertToARM(resolved)
+		action_ARM, err := rule.Action.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -308,7 +308,7 @@ func (rule *NamespacesTopicsSubscriptionsRule_Spec) ConvertToARM(resolved genrun
 		result.Properties.Action = &action
 	}
 	if rule.CorrelationFilter != nil {
-		correlationFilter_ARM, err := (*rule.CorrelationFilter).ConvertToARM(resolved)
+		correlationFilter_ARM, err := rule.CorrelationFilter.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -322,7 +322,7 @@ func (rule *NamespacesTopicsSubscriptionsRule_Spec) ConvertToARM(resolved genrun
 		result.Properties.FilterType = &filterType
 	}
 	if rule.SqlFilter != nil {
-		sqlFilter_ARM, err := (*rule.SqlFilter).ConvertToARM(resolved)
+		sqlFilter_ARM, err := rule.SqlFilter.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/servicebus/v1api20240101/namespace_types_gen.go
+++ b/v2/api/servicebus/v1api20240101/namespace_types_gen.go
@@ -313,7 +313,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Identity":
 	if namespace.Identity != nil {
-		identity_ARM, err := (*namespace.Identity).ConvertToARM(resolved)
+		identity_ARM, err := namespace.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -349,7 +349,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.DisableLocalAuth = &disableLocalAuth
 	}
 	if namespace.Encryption != nil {
-		encryption_ARM, err := (*namespace.Encryption).ConvertToARM(resolved)
+		encryption_ARM, err := namespace.Encryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -379,7 +379,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Sku":
 	if namespace.Sku != nil {
-		sku_ARM, err := (*namespace.Sku).ConvertToARM(resolved)
+		sku_ARM, err := namespace.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3035,7 +3035,7 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "Identity":
 	if properties.Identity != nil {
-		identity_ARM, err := (*properties.Identity).ConvertToARM(resolved)
+		identity_ARM, err := properties.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/servicebus/v1api20240101/namespaces_topics_subscription_types_gen.go
+++ b/v2/api/servicebus/v1api20240101/namespaces_topics_subscription_types_gen.go
@@ -342,7 +342,7 @@ func (subscription *NamespacesTopicsSubscription_Spec) ConvertToARM(resolved gen
 		result.Properties.AutoDeleteOnIdle = &autoDeleteOnIdle
 	}
 	if subscription.ClientAffineProperties != nil {
-		clientAffineProperties_ARM, err := (*subscription.ClientAffineProperties).ConvertToARM(resolved)
+		clientAffineProperties_ARM, err := subscription.ClientAffineProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/servicebus/v1api20240101/namespaces_topics_subscriptions_rule_types_gen.go
+++ b/v2/api/servicebus/v1api20240101/namespaces_topics_subscriptions_rule_types_gen.go
@@ -297,7 +297,7 @@ func (rule *NamespacesTopicsSubscriptionsRule_Spec) ConvertToARM(resolved genrun
 		result.Properties = &arm.Ruleproperties{}
 	}
 	if rule.Action != nil {
-		action_ARM, err := (*rule.Action).ConvertToARM(resolved)
+		action_ARM, err := rule.Action.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -305,7 +305,7 @@ func (rule *NamespacesTopicsSubscriptionsRule_Spec) ConvertToARM(resolved genrun
 		result.Properties.Action = &action
 	}
 	if rule.CorrelationFilter != nil {
-		correlationFilter_ARM, err := (*rule.CorrelationFilter).ConvertToARM(resolved)
+		correlationFilter_ARM, err := rule.CorrelationFilter.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -319,7 +319,7 @@ func (rule *NamespacesTopicsSubscriptionsRule_Spec) ConvertToARM(resolved genrun
 		result.Properties.FilterType = &filterType
 	}
 	if rule.SqlFilter != nil {
-		sqlFilter_ARM, err := (*rule.SqlFilter).ConvertToARM(resolved)
+		sqlFilter_ARM, err := rule.SqlFilter.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/signalrservice/v1api20211001/signal_r_types_gen.go
+++ b/v2/api/signalrservice/v1api20211001/signal_r_types_gen.go
@@ -333,7 +333,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Identity":
 	if signalR.Identity != nil {
-		identity_ARM, err := (*signalR.Identity).ConvertToARM(resolved)
+		identity_ARM, err := signalR.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -371,7 +371,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties = &arm.SignalRProperties{}
 	}
 	if signalR.Cors != nil {
-		cors_ARM, err := (*signalR.Cors).ConvertToARM(resolved)
+		cors_ARM, err := signalR.Cors.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -394,7 +394,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.Features = append(result.Properties.Features, *item_ARM.(*arm.SignalRFeature))
 	}
 	if signalR.NetworkACLs != nil {
-		networkACLs_ARM, err := (*signalR.NetworkACLs).ConvertToARM(resolved)
+		networkACLs_ARM, err := signalR.NetworkACLs.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -406,7 +406,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.PublicNetworkAccess = &publicNetworkAccess
 	}
 	if signalR.ResourceLogConfiguration != nil {
-		resourceLogConfiguration_ARM, err := (*signalR.ResourceLogConfiguration).ConvertToARM(resolved)
+		resourceLogConfiguration_ARM, err := signalR.ResourceLogConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -414,7 +414,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.ResourceLogConfiguration = &resourceLogConfiguration
 	}
 	if signalR.Tls != nil {
-		tls_ARM, err := (*signalR.Tls).ConvertToARM(resolved)
+		tls_ARM, err := signalR.Tls.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -422,7 +422,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.Tls = &tls
 	}
 	if signalR.Upstream != nil {
-		upstream_ARM, err := (*signalR.Upstream).ConvertToARM(resolved)
+		upstream_ARM, err := signalR.Upstream.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -432,7 +432,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Sku":
 	if signalR.Sku != nil {
-		sku_ARM, err := (*signalR.Sku).ConvertToARM(resolved)
+		sku_ARM, err := signalR.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3528,7 +3528,7 @@ func (acLs *SignalRNetworkACLs) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "PublicNetwork":
 	if acLs.PublicNetwork != nil {
-		publicNetwork_ARM, err := (*acLs.PublicNetwork).ConvertToARM(resolved)
+		publicNetwork_ARM, err := acLs.PublicNetwork.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5359,7 +5359,7 @@ func (template *UpstreamTemplate) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "Auth":
 	if template.Auth != nil {
-		auth_ARM, err := (*template.Auth).ConvertToARM(resolved)
+		auth_ARM, err := template.Auth.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5840,7 +5840,7 @@ func (settings *UpstreamAuthSettings) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "ManagedIdentity":
 	if settings.ManagedIdentity != nil {
-		managedIdentity_ARM, err := (*settings.ManagedIdentity).ConvertToARM(resolved)
+		managedIdentity_ARM, err := settings.ManagedIdentity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/signalrservice/v1api20240301/custom_domain_types_gen.go
+++ b/v2/api/signalrservice/v1api20240301/custom_domain_types_gen.go
@@ -287,7 +287,7 @@ func (domain *CustomDomain_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties = &arm.CustomDomainProperties{}
 	}
 	if domain.CustomCertificate != nil {
-		customCertificate_ARM, err := (*domain.CustomCertificate).ConvertToARM(resolved)
+		customCertificate_ARM, err := domain.CustomCertificate.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/signalrservice/v1api20240301/replica_types_gen.go
+++ b/v2/api/signalrservice/v1api20240301/replica_types_gen.go
@@ -319,7 +319,7 @@ func (replica *Replica_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Sku":
 	if replica.Sku != nil {
-		sku_ARM, err := (*replica.Sku).ConvertToARM(resolved)
+		sku_ARM, err := replica.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/signalrservice/v1api20240301/signal_r_types_gen.go
+++ b/v2/api/signalrservice/v1api20240301/signal_r_types_gen.go
@@ -346,7 +346,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Identity":
 	if signalR.Identity != nil {
-		identity_ARM, err := (*signalR.Identity).ConvertToARM(resolved)
+		identity_ARM, err := signalR.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -388,7 +388,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties = &arm.SignalRProperties{}
 	}
 	if signalR.Cors != nil {
-		cors_ARM, err := (*signalR.Cors).ConvertToARM(resolved)
+		cors_ARM, err := signalR.Cors.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -411,7 +411,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.Features = append(result.Properties.Features, *item_ARM.(*arm.SignalRFeature))
 	}
 	if signalR.LiveTraceConfiguration != nil {
-		liveTraceConfiguration_ARM, err := (*signalR.LiveTraceConfiguration).ConvertToARM(resolved)
+		liveTraceConfiguration_ARM, err := signalR.LiveTraceConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -419,7 +419,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.LiveTraceConfiguration = &liveTraceConfiguration
 	}
 	if signalR.NetworkACLs != nil {
-		networkACLs_ARM, err := (*signalR.NetworkACLs).ConvertToARM(resolved)
+		networkACLs_ARM, err := signalR.NetworkACLs.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -435,7 +435,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.RegionEndpointEnabled = &regionEndpointEnabled
 	}
 	if signalR.ResourceLogConfiguration != nil {
-		resourceLogConfiguration_ARM, err := (*signalR.ResourceLogConfiguration).ConvertToARM(resolved)
+		resourceLogConfiguration_ARM, err := signalR.ResourceLogConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -447,7 +447,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.ResourceStopped = &resourceStopped
 	}
 	if signalR.Serverless != nil {
-		serverless_ARM, err := (*signalR.Serverless).ConvertToARM(resolved)
+		serverless_ARM, err := signalR.Serverless.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -455,7 +455,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.Serverless = &serverless
 	}
 	if signalR.Tls != nil {
-		tls_ARM, err := (*signalR.Tls).ConvertToARM(resolved)
+		tls_ARM, err := signalR.Tls.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -463,7 +463,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.Tls = &tls
 	}
 	if signalR.Upstream != nil {
-		upstream_ARM, err := (*signalR.Upstream).ConvertToARM(resolved)
+		upstream_ARM, err := signalR.Upstream.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -473,7 +473,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Sku":
 	if signalR.Sku != nil {
-		sku_ARM, err := (*signalR.Sku).ConvertToARM(resolved)
+		sku_ARM, err := signalR.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4200,7 +4200,7 @@ func (acLs *SignalRNetworkACLs) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "PublicNetwork":
 	if acLs.PublicNetwork != nil {
-		publicNetwork_ARM, err := (*acLs.PublicNetwork).ConvertToARM(resolved)
+		publicNetwork_ARM, err := acLs.PublicNetwork.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -6493,7 +6493,7 @@ func (template *UpstreamTemplate) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "Auth":
 	if template.Auth != nil {
-		auth_ARM, err := (*template.Auth).ConvertToARM(resolved)
+		auth_ARM, err := template.Auth.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7005,7 +7005,7 @@ func (settings *UpstreamAuthSettings) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "ManagedIdentity":
 	if settings.ManagedIdentity != nil {
-		managedIdentity_ARM, err := (*settings.ManagedIdentity).ConvertToARM(resolved)
+		managedIdentity_ARM, err := settings.ManagedIdentity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/sql/v1api20211101/server_types_gen.go
+++ b/v2/api/sql/v1api20211101/server_types_gen.go
@@ -342,7 +342,7 @@ func (server *Server_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 
 	// Set property "Identity":
 	if server.Identity != nil {
-		identity_ARM, err := (*server.Identity).ConvertToARM(resolved)
+		identity_ARM, err := server.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -385,7 +385,7 @@ func (server *Server_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.Properties.AdministratorLoginPassword = &administratorLoginPassword
 	}
 	if server.Administrators != nil {
-		administrators_ARM, err := (*server.Administrators).ConvertToARM(resolved)
+		administrators_ARM, err := server.Administrators.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/sql/v1api20211101/servers_database_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_database_types_gen.go
@@ -413,7 +413,7 @@ func (database *ServersDatabase_Spec) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "Identity":
 	if database.Identity != nil {
-		identity_ARM, err := (*database.Identity).ConvertToARM(resolved)
+		identity_ARM, err := database.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -603,7 +603,7 @@ func (database *ServersDatabase_Spec) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "Sku":
 	if database.Sku != nil {
-		sku_ARM, err := (*database.Sku).ConvertToARM(resolved)
+		sku_ARM, err := database.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/sql/v1api20211101/servers_databases_vulnerability_assessment_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_databases_vulnerability_assessment_types_gen.go
@@ -302,7 +302,7 @@ func (assessment *ServersDatabasesVulnerabilityAssessment_Spec) ConvertToARM(res
 		result.Properties = &arm.DatabaseVulnerabilityAssessmentsDatabaseVulnerabilityAssessmentProperties{}
 	}
 	if assessment.RecurringScans != nil {
-		recurringScans_ARM, err := (*assessment.RecurringScans).ConvertToARM(resolved)
+		recurringScans_ARM, err := assessment.RecurringScans.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/sql/v1api20211101/servers_elastic_pool_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_elastic_pool_types_gen.go
@@ -353,7 +353,7 @@ func (pool *ServersElasticPool_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.MinCapacity = &minCapacity
 	}
 	if pool.PerDatabaseSettings != nil {
-		perDatabaseSettings_ARM, err := (*pool.PerDatabaseSettings).ConvertToARM(resolved)
+		perDatabaseSettings_ARM, err := pool.PerDatabaseSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -367,7 +367,7 @@ func (pool *ServersElasticPool_Spec) ConvertToARM(resolved genruntime.ConvertToA
 
 	// Set property "Sku":
 	if pool.Sku != nil {
-		sku_ARM, err := (*pool.Sku).ConvertToARM(resolved)
+		sku_ARM, err := pool.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/sql/v1api20211101/servers_failover_group_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_failover_group_types_gen.go
@@ -313,7 +313,7 @@ func (group *ServersFailoverGroup_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Properties.PartnerServers = append(result.Properties.PartnerServers, *item_ARM.(*arm.PartnerInfo))
 	}
 	if group.ReadOnlyEndpoint != nil {
-		readOnlyEndpoint_ARM, err := (*group.ReadOnlyEndpoint).ConvertToARM(resolved)
+		readOnlyEndpoint_ARM, err := group.ReadOnlyEndpoint.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -321,7 +321,7 @@ func (group *ServersFailoverGroup_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Properties.ReadOnlyEndpoint = &readOnlyEndpoint
 	}
 	if group.ReadWriteEndpoint != nil {
-		readWriteEndpoint_ARM, err := (*group.ReadWriteEndpoint).ConvertToARM(resolved)
+		readWriteEndpoint_ARM, err := group.ReadWriteEndpoint.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/sql/v1api20211101/servers_vulnerability_assessment_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_vulnerability_assessment_types_gen.go
@@ -300,7 +300,7 @@ func (assessment *ServersVulnerabilityAssessment_Spec) ConvertToARM(resolved gen
 		result.Properties = &arm.ServerVulnerabilityAssessmentProperties{}
 	}
 	if assessment.RecurringScans != nil {
-		recurringScans_ARM, err := (*assessment.RecurringScans).ConvertToARM(resolved)
+		recurringScans_ARM, err := assessment.RecurringScans.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/storage/v1api20210401/storage_account_types_gen.go
+++ b/v2/api/storage/v1api20210401/storage_account_types_gen.go
@@ -423,7 +423,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "ExtendedLocation":
 	if account.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*account.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := account.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -433,7 +433,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Identity":
 	if account.Identity != nil {
-		identity_ARM, err := (*account.Identity).ConvertToARM(resolved)
+		identity_ARM, err := account.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -496,7 +496,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AllowSharedKeyAccess = &allowSharedKeyAccess
 	}
 	if account.AzureFilesIdentityBasedAuthentication != nil {
-		azureFilesIdentityBasedAuthentication_ARM, err := (*account.AzureFilesIdentityBasedAuthentication).ConvertToARM(resolved)
+		azureFilesIdentityBasedAuthentication_ARM, err := account.AzureFilesIdentityBasedAuthentication.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -504,7 +504,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AzureFilesIdentityBasedAuthentication = &azureFilesIdentityBasedAuthentication
 	}
 	if account.CustomDomain != nil {
-		customDomain_ARM, err := (*account.CustomDomain).ConvertToARM(resolved)
+		customDomain_ARM, err := account.CustomDomain.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -512,7 +512,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.CustomDomain = &customDomain
 	}
 	if account.Encryption != nil {
-		encryption_ARM, err := (*account.Encryption).ConvertToARM(resolved)
+		encryption_ARM, err := account.Encryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -528,7 +528,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.IsNfsV3Enabled = &isNfsV3Enabled
 	}
 	if account.KeyPolicy != nil {
-		keyPolicy_ARM, err := (*account.KeyPolicy).ConvertToARM(resolved)
+		keyPolicy_ARM, err := account.KeyPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -548,7 +548,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.MinimumTlsVersion = &minimumTlsVersion
 	}
 	if account.NetworkAcls != nil {
-		networkAcls_ARM, err := (*account.NetworkAcls).ConvertToARM(resolved)
+		networkAcls_ARM, err := account.NetworkAcls.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -556,7 +556,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.NetworkAcls = &networkAcls
 	}
 	if account.RoutingPreference != nil {
-		routingPreference_ARM, err := (*account.RoutingPreference).ConvertToARM(resolved)
+		routingPreference_ARM, err := account.RoutingPreference.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -564,7 +564,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.RoutingPreference = &routingPreference
 	}
 	if account.SasPolicy != nil {
-		sasPolicy_ARM, err := (*account.SasPolicy).ConvertToARM(resolved)
+		sasPolicy_ARM, err := account.SasPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -578,7 +578,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Sku":
 	if account.Sku != nil {
-		sku_ARM, err := (*account.Sku).ConvertToARM(resolved)
+		sku_ARM, err := account.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2768,7 +2768,7 @@ func (authentication *AzureFilesIdentityBasedAuthentication) ConvertToARM(resolv
 
 	// Set property "ActiveDirectoryProperties":
 	if authentication.ActiveDirectoryProperties != nil {
-		activeDirectoryProperties_ARM, err := (*authentication.ActiveDirectoryProperties).ConvertToARM(resolved)
+		activeDirectoryProperties_ARM, err := authentication.ActiveDirectoryProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3421,7 +3421,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "Identity":
 	if encryption.Identity != nil {
-		identity_ARM, err := (*encryption.Identity).ConvertToARM(resolved)
+		identity_ARM, err := encryption.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3439,7 +3439,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "Keyvaultproperties":
 	if encryption.Keyvaultproperties != nil {
-		keyvaultproperties_ARM, err := (*encryption.Keyvaultproperties).ConvertToARM(resolved)
+		keyvaultproperties_ARM, err := encryption.Keyvaultproperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3455,7 +3455,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "Services":
 	if encryption.Services != nil {
-		services_ARM, err := (*encryption.Services).ConvertToARM(resolved)
+		services_ARM, err := encryption.Services.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7228,7 +7228,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Blob":
 	if services.Blob != nil {
-		blob_ARM, err := (*services.Blob).ConvertToARM(resolved)
+		blob_ARM, err := services.Blob.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7238,7 +7238,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "File":
 	if services.File != nil {
-		file_ARM, err := (*services.File).ConvertToARM(resolved)
+		file_ARM, err := services.File.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7248,7 +7248,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Queue":
 	if services.Queue != nil {
-		queue_ARM, err := (*services.Queue).ConvertToARM(resolved)
+		queue_ARM, err := services.Queue.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -7258,7 +7258,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Table":
 	if services.Table != nil {
-		table_ARM, err := (*services.Table).ConvertToARM(resolved)
+		table_ARM, err := services.Table.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/storage/v1api20210401/storage_accounts_blob_service_types_gen.go
+++ b/v2/api/storage/v1api20210401/storage_accounts_blob_service_types_gen.go
@@ -319,7 +319,7 @@ func (service *StorageAccountsBlobService_Spec) ConvertToARM(resolved genruntime
 		result.Properties.AutomaticSnapshotPolicyEnabled = &automaticSnapshotPolicyEnabled
 	}
 	if service.ChangeFeed != nil {
-		changeFeed_ARM, err := (*service.ChangeFeed).ConvertToARM(resolved)
+		changeFeed_ARM, err := service.ChangeFeed.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -327,7 +327,7 @@ func (service *StorageAccountsBlobService_Spec) ConvertToARM(resolved genruntime
 		result.Properties.ChangeFeed = &changeFeed
 	}
 	if service.ContainerDeleteRetentionPolicy != nil {
-		containerDeleteRetentionPolicy_ARM, err := (*service.ContainerDeleteRetentionPolicy).ConvertToARM(resolved)
+		containerDeleteRetentionPolicy_ARM, err := service.ContainerDeleteRetentionPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -335,7 +335,7 @@ func (service *StorageAccountsBlobService_Spec) ConvertToARM(resolved genruntime
 		result.Properties.ContainerDeleteRetentionPolicy = &containerDeleteRetentionPolicy
 	}
 	if service.Cors != nil {
-		cors_ARM, err := (*service.Cors).ConvertToARM(resolved)
+		cors_ARM, err := service.Cors.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -347,7 +347,7 @@ func (service *StorageAccountsBlobService_Spec) ConvertToARM(resolved genruntime
 		result.Properties.DefaultServiceVersion = &defaultServiceVersion
 	}
 	if service.DeleteRetentionPolicy != nil {
-		deleteRetentionPolicy_ARM, err := (*service.DeleteRetentionPolicy).ConvertToARM(resolved)
+		deleteRetentionPolicy_ARM, err := service.DeleteRetentionPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -359,7 +359,7 @@ func (service *StorageAccountsBlobService_Spec) ConvertToARM(resolved genruntime
 		result.Properties.IsVersioningEnabled = &isVersioningEnabled
 	}
 	if service.LastAccessTimeTrackingPolicy != nil {
-		lastAccessTimeTrackingPolicy_ARM, err := (*service.LastAccessTimeTrackingPolicy).ConvertToARM(resolved)
+		lastAccessTimeTrackingPolicy_ARM, err := service.LastAccessTimeTrackingPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -367,7 +367,7 @@ func (service *StorageAccountsBlobService_Spec) ConvertToARM(resolved genruntime
 		result.Properties.LastAccessTimeTrackingPolicy = &lastAccessTimeTrackingPolicy
 	}
 	if service.RestorePolicy != nil {
-		restorePolicy_ARM, err := (*service.RestorePolicy).ConvertToARM(resolved)
+		restorePolicy_ARM, err := service.RestorePolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/storage/v1api20210401/storage_accounts_blob_services_container_types_gen.go
+++ b/v2/api/storage/v1api20210401/storage_accounts_blob_services_container_types_gen.go
@@ -312,7 +312,7 @@ func (container *StorageAccountsBlobServicesContainer_Spec) ConvertToARM(resolve
 		result.Properties.DenyEncryptionScopeOverride = &denyEncryptionScopeOverride
 	}
 	if container.ImmutableStorageWithVersioning != nil {
-		immutableStorageWithVersioning_ARM, err := (*container.ImmutableStorageWithVersioning).ConvertToARM(resolved)
+		immutableStorageWithVersioning_ARM, err := container.ImmutableStorageWithVersioning.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/storage/v1api20210401/storage_accounts_management_policy_types_gen.go
+++ b/v2/api/storage/v1api20210401/storage_accounts_management_policy_types_gen.go
@@ -283,7 +283,7 @@ func (policy *StorageAccountsManagementPolicy_Spec) ConvertToARM(resolved genrun
 		result.Properties = &arm.ManagementPolicyProperties{}
 	}
 	if policy.Policy != nil {
-		policy_ARM, err := (*policy.Policy).ConvertToARM(resolved)
+		policy_ARM, err := policy.Policy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1029,7 +1029,7 @@ func (rule *ManagementPolicyRule) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "Definition":
 	if rule.Definition != nil {
-		definition_ARM, err := (*rule.Definition).ConvertToARM(resolved)
+		definition_ARM, err := rule.Definition.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1364,7 +1364,7 @@ func (definition *ManagementPolicyDefinition) ConvertToARM(resolved genruntime.C
 
 	// Set property "Actions":
 	if definition.Actions != nil {
-		actions_ARM, err := (*definition.Actions).ConvertToARM(resolved)
+		actions_ARM, err := definition.Actions.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1374,7 +1374,7 @@ func (definition *ManagementPolicyDefinition) ConvertToARM(resolved genruntime.C
 
 	// Set property "Filters":
 	if definition.Filters != nil {
-		filters_ARM, err := (*definition.Filters).ConvertToARM(resolved)
+		filters_ARM, err := definition.Filters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1655,7 +1655,7 @@ func (action *ManagementPolicyAction) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "BaseBlob":
 	if action.BaseBlob != nil {
-		baseBlob_ARM, err := (*action.BaseBlob).ConvertToARM(resolved)
+		baseBlob_ARM, err := action.BaseBlob.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1665,7 +1665,7 @@ func (action *ManagementPolicyAction) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "Snapshot":
 	if action.Snapshot != nil {
-		snapshot_ARM, err := (*action.Snapshot).ConvertToARM(resolved)
+		snapshot_ARM, err := action.Snapshot.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1675,7 +1675,7 @@ func (action *ManagementPolicyAction) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "Version":
 	if action.Version != nil {
-		version_ARM, err := (*action.Version).ConvertToARM(resolved)
+		version_ARM, err := action.Version.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2289,7 +2289,7 @@ func (blob *ManagementPolicyBaseBlob) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "Delete":
 	if blob.Delete != nil {
-		delete_ARM, err := (*blob.Delete).ConvertToARM(resolved)
+		delete_ARM, err := blob.Delete.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2305,7 +2305,7 @@ func (blob *ManagementPolicyBaseBlob) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "TierToArchive":
 	if blob.TierToArchive != nil {
-		tierToArchive_ARM, err := (*blob.TierToArchive).ConvertToARM(resolved)
+		tierToArchive_ARM, err := blob.TierToArchive.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2315,7 +2315,7 @@ func (blob *ManagementPolicyBaseBlob) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "TierToCool":
 	if blob.TierToCool != nil {
-		tierToCool_ARM, err := (*blob.TierToCool).ConvertToARM(resolved)
+		tierToCool_ARM, err := blob.TierToCool.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2698,7 +2698,7 @@ func (shot *ManagementPolicySnapShot) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "Delete":
 	if shot.Delete != nil {
-		delete_ARM, err := (*shot.Delete).ConvertToARM(resolved)
+		delete_ARM, err := shot.Delete.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2708,7 +2708,7 @@ func (shot *ManagementPolicySnapShot) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "TierToArchive":
 	if shot.TierToArchive != nil {
-		tierToArchive_ARM, err := (*shot.TierToArchive).ConvertToARM(resolved)
+		tierToArchive_ARM, err := shot.TierToArchive.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2718,7 +2718,7 @@ func (shot *ManagementPolicySnapShot) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "TierToCool":
 	if shot.TierToCool != nil {
-		tierToCool_ARM, err := (*shot.TierToCool).ConvertToARM(resolved)
+		tierToCool_ARM, err := shot.TierToCool.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3053,7 +3053,7 @@ func (version *ManagementPolicyVersion) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "Delete":
 	if version.Delete != nil {
-		delete_ARM, err := (*version.Delete).ConvertToARM(resolved)
+		delete_ARM, err := version.Delete.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3063,7 +3063,7 @@ func (version *ManagementPolicyVersion) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "TierToArchive":
 	if version.TierToArchive != nil {
-		tierToArchive_ARM, err := (*version.TierToArchive).ConvertToARM(resolved)
+		tierToArchive_ARM, err := version.TierToArchive.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3073,7 +3073,7 @@ func (version *ManagementPolicyVersion) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "TierToCool":
 	if version.TierToCool != nil {
-		tierToCool_ARM, err := (*version.TierToCool).ConvertToARM(resolved)
+		tierToCool_ARM, err := version.TierToCool.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/storage/v1api20210401/storage_accounts_queue_service_types_gen.go
+++ b/v2/api/storage/v1api20210401/storage_accounts_queue_service_types_gen.go
@@ -282,7 +282,7 @@ func (service *StorageAccountsQueueService_Spec) ConvertToARM(resolved genruntim
 		result.Properties = &arm.StorageAccounts_QueueService_Properties_Spec{}
 	}
 	if service.Cors != nil {
-		cors_ARM, err := (*service.Cors).ConvertToARM(resolved)
+		cors_ARM, err := service.Cors.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/storage/v1api20220901/storage_account_types_gen.go
+++ b/v2/api/storage/v1api20220901/storage_account_types_gen.go
@@ -451,7 +451,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "ExtendedLocation":
 	if account.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*account.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := account.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -461,7 +461,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Identity":
 	if account.Identity != nil {
-		identity_ARM, err := (*account.Identity).ConvertToARM(resolved)
+		identity_ARM, err := account.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -537,7 +537,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AllowedCopyScope = &allowedCopyScope
 	}
 	if account.AzureFilesIdentityBasedAuthentication != nil {
-		azureFilesIdentityBasedAuthentication_ARM, err := (*account.AzureFilesIdentityBasedAuthentication).ConvertToARM(resolved)
+		azureFilesIdentityBasedAuthentication_ARM, err := account.AzureFilesIdentityBasedAuthentication.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -545,7 +545,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AzureFilesIdentityBasedAuthentication = &azureFilesIdentityBasedAuthentication
 	}
 	if account.CustomDomain != nil {
-		customDomain_ARM, err := (*account.CustomDomain).ConvertToARM(resolved)
+		customDomain_ARM, err := account.CustomDomain.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -563,7 +563,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.DnsEndpointType = &dnsEndpointType
 	}
 	if account.Encryption != nil {
-		encryption_ARM, err := (*account.Encryption).ConvertToARM(resolved)
+		encryption_ARM, err := account.Encryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -571,7 +571,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.Encryption = &encryption
 	}
 	if account.ImmutableStorageWithVersioning != nil {
-		immutableStorageWithVersioning_ARM, err := (*account.ImmutableStorageWithVersioning).ConvertToARM(resolved)
+		immutableStorageWithVersioning_ARM, err := account.ImmutableStorageWithVersioning.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -595,7 +595,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.IsSftpEnabled = &isSftpEnabled
 	}
 	if account.KeyPolicy != nil {
-		keyPolicy_ARM, err := (*account.KeyPolicy).ConvertToARM(resolved)
+		keyPolicy_ARM, err := account.KeyPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -615,7 +615,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.MinimumTlsVersion = &minimumTlsVersion
 	}
 	if account.NetworkAcls != nil {
-		networkAcls_ARM, err := (*account.NetworkAcls).ConvertToARM(resolved)
+		networkAcls_ARM, err := account.NetworkAcls.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -629,7 +629,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.PublicNetworkAccess = &publicNetworkAccess
 	}
 	if account.RoutingPreference != nil {
-		routingPreference_ARM, err := (*account.RoutingPreference).ConvertToARM(resolved)
+		routingPreference_ARM, err := account.RoutingPreference.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -637,7 +637,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.RoutingPreference = &routingPreference
 	}
 	if account.SasPolicy != nil {
-		sasPolicy_ARM, err := (*account.SasPolicy).ConvertToARM(resolved)
+		sasPolicy_ARM, err := account.SasPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -651,7 +651,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Sku":
 	if account.Sku != nil {
-		sku_ARM, err := (*account.Sku).ConvertToARM(resolved)
+		sku_ARM, err := account.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3305,7 +3305,7 @@ func (authentication *AzureFilesIdentityBasedAuthentication) ConvertToARM(resolv
 
 	// Set property "ActiveDirectoryProperties":
 	if authentication.ActiveDirectoryProperties != nil {
-		activeDirectoryProperties_ARM, err := (*authentication.ActiveDirectoryProperties).ConvertToARM(resolved)
+		activeDirectoryProperties_ARM, err := authentication.ActiveDirectoryProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3957,7 +3957,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "Identity":
 	if encryption.Identity != nil {
-		identity_ARM, err := (*encryption.Identity).ConvertToARM(resolved)
+		identity_ARM, err := encryption.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3975,7 +3975,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "Keyvaultproperties":
 	if encryption.Keyvaultproperties != nil {
-		keyvaultproperties_ARM, err := (*encryption.Keyvaultproperties).ConvertToARM(resolved)
+		keyvaultproperties_ARM, err := encryption.Keyvaultproperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3991,7 +3991,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "Services":
 	if encryption.Services != nil {
-		services_ARM, err := (*encryption.Services).ConvertToARM(resolved)
+		services_ARM, err := encryption.Services.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5260,7 +5260,7 @@ func (account *ImmutableStorageAccount) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "ImmutabilityPolicy":
 	if account.ImmutabilityPolicy != nil {
-		immutabilityPolicy_ARM, err := (*account.ImmutabilityPolicy).ConvertToARM(resolved)
+		immutabilityPolicy_ARM, err := account.ImmutabilityPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8629,7 +8629,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Blob":
 	if services.Blob != nil {
-		blob_ARM, err := (*services.Blob).ConvertToARM(resolved)
+		blob_ARM, err := services.Blob.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8639,7 +8639,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "File":
 	if services.File != nil {
-		file_ARM, err := (*services.File).ConvertToARM(resolved)
+		file_ARM, err := services.File.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8649,7 +8649,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Queue":
 	if services.Queue != nil {
-		queue_ARM, err := (*services.Queue).ConvertToARM(resolved)
+		queue_ARM, err := services.Queue.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -8659,7 +8659,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Table":
 	if services.Table != nil {
-		table_ARM, err := (*services.Table).ConvertToARM(resolved)
+		table_ARM, err := services.Table.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/storage/v1api20220901/storage_accounts_blob_service_types_gen.go
+++ b/v2/api/storage/v1api20220901/storage_accounts_blob_service_types_gen.go
@@ -319,7 +319,7 @@ func (service *StorageAccountsBlobService_Spec) ConvertToARM(resolved genruntime
 		result.Properties.AutomaticSnapshotPolicyEnabled = &automaticSnapshotPolicyEnabled
 	}
 	if service.ChangeFeed != nil {
-		changeFeed_ARM, err := (*service.ChangeFeed).ConvertToARM(resolved)
+		changeFeed_ARM, err := service.ChangeFeed.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -327,7 +327,7 @@ func (service *StorageAccountsBlobService_Spec) ConvertToARM(resolved genruntime
 		result.Properties.ChangeFeed = &changeFeed
 	}
 	if service.ContainerDeleteRetentionPolicy != nil {
-		containerDeleteRetentionPolicy_ARM, err := (*service.ContainerDeleteRetentionPolicy).ConvertToARM(resolved)
+		containerDeleteRetentionPolicy_ARM, err := service.ContainerDeleteRetentionPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -335,7 +335,7 @@ func (service *StorageAccountsBlobService_Spec) ConvertToARM(resolved genruntime
 		result.Properties.ContainerDeleteRetentionPolicy = &containerDeleteRetentionPolicy
 	}
 	if service.Cors != nil {
-		cors_ARM, err := (*service.Cors).ConvertToARM(resolved)
+		cors_ARM, err := service.Cors.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -347,7 +347,7 @@ func (service *StorageAccountsBlobService_Spec) ConvertToARM(resolved genruntime
 		result.Properties.DefaultServiceVersion = &defaultServiceVersion
 	}
 	if service.DeleteRetentionPolicy != nil {
-		deleteRetentionPolicy_ARM, err := (*service.DeleteRetentionPolicy).ConvertToARM(resolved)
+		deleteRetentionPolicy_ARM, err := service.DeleteRetentionPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -359,7 +359,7 @@ func (service *StorageAccountsBlobService_Spec) ConvertToARM(resolved genruntime
 		result.Properties.IsVersioningEnabled = &isVersioningEnabled
 	}
 	if service.LastAccessTimeTrackingPolicy != nil {
-		lastAccessTimeTrackingPolicy_ARM, err := (*service.LastAccessTimeTrackingPolicy).ConvertToARM(resolved)
+		lastAccessTimeTrackingPolicy_ARM, err := service.LastAccessTimeTrackingPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -367,7 +367,7 @@ func (service *StorageAccountsBlobService_Spec) ConvertToARM(resolved genruntime
 		result.Properties.LastAccessTimeTrackingPolicy = &lastAccessTimeTrackingPolicy
 	}
 	if service.RestorePolicy != nil {
-		restorePolicy_ARM, err := (*service.RestorePolicy).ConvertToARM(resolved)
+		restorePolicy_ARM, err := service.RestorePolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/storage/v1api20220901/storage_accounts_blob_services_container_types_gen.go
+++ b/v2/api/storage/v1api20220901/storage_accounts_blob_services_container_types_gen.go
@@ -328,7 +328,7 @@ func (container *StorageAccountsBlobServicesContainer_Spec) ConvertToARM(resolve
 		result.Properties.EnableNfsV3RootSquash = &enableNfsV3RootSquash
 	}
 	if container.ImmutableStorageWithVersioning != nil {
-		immutableStorageWithVersioning_ARM, err := (*container.ImmutableStorageWithVersioning).ConvertToARM(resolved)
+		immutableStorageWithVersioning_ARM, err := container.ImmutableStorageWithVersioning.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/storage/v1api20220901/storage_accounts_file_service_types_gen.go
+++ b/v2/api/storage/v1api20220901/storage_accounts_file_service_types_gen.go
@@ -290,7 +290,7 @@ func (service *StorageAccountsFileService_Spec) ConvertToARM(resolved genruntime
 		result.Properties = &arm.StorageAccounts_FileService_Properties_Spec{}
 	}
 	if service.Cors != nil {
-		cors_ARM, err := (*service.Cors).ConvertToARM(resolved)
+		cors_ARM, err := service.Cors.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -298,7 +298,7 @@ func (service *StorageAccountsFileService_Spec) ConvertToARM(resolved genruntime
 		result.Properties.Cors = &cors
 	}
 	if service.ProtocolSettings != nil {
-		protocolSettings_ARM, err := (*service.ProtocolSettings).ConvertToARM(resolved)
+		protocolSettings_ARM, err := service.ProtocolSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -306,7 +306,7 @@ func (service *StorageAccountsFileService_Spec) ConvertToARM(resolved genruntime
 		result.Properties.ProtocolSettings = &protocolSettings
 	}
 	if service.ShareDeleteRetentionPolicy != nil {
-		shareDeleteRetentionPolicy_ARM, err := (*service.ShareDeleteRetentionPolicy).ConvertToARM(resolved)
+		shareDeleteRetentionPolicy_ARM, err := service.ShareDeleteRetentionPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -905,7 +905,7 @@ func (settings *ProtocolSettings) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "Smb":
 	if settings.Smb != nil {
-		smb_ARM, err := (*settings.Smb).ConvertToARM(resolved)
+		smb_ARM, err := settings.Smb.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1226,7 +1226,7 @@ func (setting *SmbSetting) ConvertToARM(resolved genruntime.ConvertToARMResolved
 
 	// Set property "Multichannel":
 	if setting.Multichannel != nil {
-		multichannel_ARM, err := (*setting.Multichannel).ConvertToARM(resolved)
+		multichannel_ARM, err := setting.Multichannel.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/storage/v1api20220901/storage_accounts_file_services_share_types_gen.go
+++ b/v2/api/storage/v1api20220901/storage_accounts_file_services_share_types_gen.go
@@ -1447,7 +1447,7 @@ func (identifier *SignedIdentifier) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "AccessPolicy":
 	if identifier.AccessPolicy != nil {
-		accessPolicy_ARM, err := (*identifier.AccessPolicy).ConvertToARM(resolved)
+		accessPolicy_ARM, err := identifier.AccessPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/storage/v1api20220901/storage_accounts_management_policy_types_gen.go
+++ b/v2/api/storage/v1api20220901/storage_accounts_management_policy_types_gen.go
@@ -283,7 +283,7 @@ func (policy *StorageAccountsManagementPolicy_Spec) ConvertToARM(resolved genrun
 		result.Properties = &arm.ManagementPolicyProperties{}
 	}
 	if policy.Policy != nil {
-		policy_ARM, err := (*policy.Policy).ConvertToARM(resolved)
+		policy_ARM, err := policy.Policy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1029,7 +1029,7 @@ func (rule *ManagementPolicyRule) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "Definition":
 	if rule.Definition != nil {
-		definition_ARM, err := (*rule.Definition).ConvertToARM(resolved)
+		definition_ARM, err := rule.Definition.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1364,7 +1364,7 @@ func (definition *ManagementPolicyDefinition) ConvertToARM(resolved genruntime.C
 
 	// Set property "Actions":
 	if definition.Actions != nil {
-		actions_ARM, err := (*definition.Actions).ConvertToARM(resolved)
+		actions_ARM, err := definition.Actions.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1374,7 +1374,7 @@ func (definition *ManagementPolicyDefinition) ConvertToARM(resolved genruntime.C
 
 	// Set property "Filters":
 	if definition.Filters != nil {
-		filters_ARM, err := (*definition.Filters).ConvertToARM(resolved)
+		filters_ARM, err := definition.Filters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1655,7 +1655,7 @@ func (action *ManagementPolicyAction) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "BaseBlob":
 	if action.BaseBlob != nil {
-		baseBlob_ARM, err := (*action.BaseBlob).ConvertToARM(resolved)
+		baseBlob_ARM, err := action.BaseBlob.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1665,7 +1665,7 @@ func (action *ManagementPolicyAction) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "Snapshot":
 	if action.Snapshot != nil {
-		snapshot_ARM, err := (*action.Snapshot).ConvertToARM(resolved)
+		snapshot_ARM, err := action.Snapshot.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1675,7 +1675,7 @@ func (action *ManagementPolicyAction) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "Version":
 	if action.Version != nil {
-		version_ARM, err := (*action.Version).ConvertToARM(resolved)
+		version_ARM, err := action.Version.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2296,7 +2296,7 @@ func (blob *ManagementPolicyBaseBlob) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "Delete":
 	if blob.Delete != nil {
-		delete_ARM, err := (*blob.Delete).ConvertToARM(resolved)
+		delete_ARM, err := blob.Delete.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2312,7 +2312,7 @@ func (blob *ManagementPolicyBaseBlob) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "TierToArchive":
 	if blob.TierToArchive != nil {
-		tierToArchive_ARM, err := (*blob.TierToArchive).ConvertToARM(resolved)
+		tierToArchive_ARM, err := blob.TierToArchive.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2322,7 +2322,7 @@ func (blob *ManagementPolicyBaseBlob) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "TierToCold":
 	if blob.TierToCold != nil {
-		tierToCold_ARM, err := (*blob.TierToCold).ConvertToARM(resolved)
+		tierToCold_ARM, err := blob.TierToCold.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2332,7 +2332,7 @@ func (blob *ManagementPolicyBaseBlob) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "TierToCool":
 	if blob.TierToCool != nil {
-		tierToCool_ARM, err := (*blob.TierToCool).ConvertToARM(resolved)
+		tierToCool_ARM, err := blob.TierToCool.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2342,7 +2342,7 @@ func (blob *ManagementPolicyBaseBlob) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "TierToHot":
 	if blob.TierToHot != nil {
-		tierToHot_ARM, err := (*blob.TierToHot).ConvertToARM(resolved)
+		tierToHot_ARM, err := blob.TierToHot.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2879,7 +2879,7 @@ func (shot *ManagementPolicySnapShot) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "Delete":
 	if shot.Delete != nil {
-		delete_ARM, err := (*shot.Delete).ConvertToARM(resolved)
+		delete_ARM, err := shot.Delete.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2889,7 +2889,7 @@ func (shot *ManagementPolicySnapShot) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "TierToArchive":
 	if shot.TierToArchive != nil {
-		tierToArchive_ARM, err := (*shot.TierToArchive).ConvertToARM(resolved)
+		tierToArchive_ARM, err := shot.TierToArchive.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2899,7 +2899,7 @@ func (shot *ManagementPolicySnapShot) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "TierToCold":
 	if shot.TierToCold != nil {
-		tierToCold_ARM, err := (*shot.TierToCold).ConvertToARM(resolved)
+		tierToCold_ARM, err := shot.TierToCold.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2909,7 +2909,7 @@ func (shot *ManagementPolicySnapShot) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "TierToCool":
 	if shot.TierToCool != nil {
-		tierToCool_ARM, err := (*shot.TierToCool).ConvertToARM(resolved)
+		tierToCool_ARM, err := shot.TierToCool.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2919,7 +2919,7 @@ func (shot *ManagementPolicySnapShot) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "TierToHot":
 	if shot.TierToHot != nil {
-		tierToHot_ARM, err := (*shot.TierToHot).ConvertToARM(resolved)
+		tierToHot_ARM, err := shot.TierToHot.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3408,7 +3408,7 @@ func (version *ManagementPolicyVersion) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "Delete":
 	if version.Delete != nil {
-		delete_ARM, err := (*version.Delete).ConvertToARM(resolved)
+		delete_ARM, err := version.Delete.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3418,7 +3418,7 @@ func (version *ManagementPolicyVersion) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "TierToArchive":
 	if version.TierToArchive != nil {
-		tierToArchive_ARM, err := (*version.TierToArchive).ConvertToARM(resolved)
+		tierToArchive_ARM, err := version.TierToArchive.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3428,7 +3428,7 @@ func (version *ManagementPolicyVersion) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "TierToCold":
 	if version.TierToCold != nil {
-		tierToCold_ARM, err := (*version.TierToCold).ConvertToARM(resolved)
+		tierToCold_ARM, err := version.TierToCold.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3438,7 +3438,7 @@ func (version *ManagementPolicyVersion) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "TierToCool":
 	if version.TierToCool != nil {
-		tierToCool_ARM, err := (*version.TierToCool).ConvertToARM(resolved)
+		tierToCool_ARM, err := version.TierToCool.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3448,7 +3448,7 @@ func (version *ManagementPolicyVersion) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "TierToHot":
 	if version.TierToHot != nil {
-		tierToHot_ARM, err := (*version.TierToHot).ConvertToARM(resolved)
+		tierToHot_ARM, err := version.TierToHot.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/storage/v1api20220901/storage_accounts_queue_service_types_gen.go
+++ b/v2/api/storage/v1api20220901/storage_accounts_queue_service_types_gen.go
@@ -282,7 +282,7 @@ func (service *StorageAccountsQueueService_Spec) ConvertToARM(resolved genruntim
 		result.Properties = &arm.StorageAccounts_QueueService_Properties_Spec{}
 	}
 	if service.Cors != nil {
-		cors_ARM, err := (*service.Cors).ConvertToARM(resolved)
+		cors_ARM, err := service.Cors.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/storage/v1api20220901/storage_accounts_table_service_types_gen.go
+++ b/v2/api/storage/v1api20220901/storage_accounts_table_service_types_gen.go
@@ -282,7 +282,7 @@ func (service *StorageAccountsTableService_Spec) ConvertToARM(resolved genruntim
 		result.Properties = &arm.StorageAccounts_TableService_Properties_Spec{}
 	}
 	if service.Cors != nil {
-		cors_ARM, err := (*service.Cors).ConvertToARM(resolved)
+		cors_ARM, err := service.Cors.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/storage/v1api20220901/storage_accounts_table_services_table_types_gen.go
+++ b/v2/api/storage/v1api20220901/storage_accounts_table_services_table_types_gen.go
@@ -850,7 +850,7 @@ func (identifier *TableSignedIdentifier) ConvertToARM(resolved genruntime.Conver
 
 	// Set property "AccessPolicy":
 	if identifier.AccessPolicy != nil {
-		accessPolicy_ARM, err := (*identifier.AccessPolicy).ConvertToARM(resolved)
+		accessPolicy_ARM, err := identifier.AccessPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/storage/v1api20230101/storage_account_types_gen.go
+++ b/v2/api/storage/v1api20230101/storage_account_types_gen.go
@@ -450,7 +450,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "ExtendedLocation":
 	if account.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*account.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := account.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -460,7 +460,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Identity":
 	if account.Identity != nil {
-		identity_ARM, err := (*account.Identity).ConvertToARM(resolved)
+		identity_ARM, err := account.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -536,7 +536,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AllowedCopyScope = &allowedCopyScope
 	}
 	if account.AzureFilesIdentityBasedAuthentication != nil {
-		azureFilesIdentityBasedAuthentication_ARM, err := (*account.AzureFilesIdentityBasedAuthentication).ConvertToARM(resolved)
+		azureFilesIdentityBasedAuthentication_ARM, err := account.AzureFilesIdentityBasedAuthentication.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -544,7 +544,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.AzureFilesIdentityBasedAuthentication = &azureFilesIdentityBasedAuthentication
 	}
 	if account.CustomDomain != nil {
-		customDomain_ARM, err := (*account.CustomDomain).ConvertToARM(resolved)
+		customDomain_ARM, err := account.CustomDomain.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -562,7 +562,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.DnsEndpointType = &dnsEndpointType
 	}
 	if account.Encryption != nil {
-		encryption_ARM, err := (*account.Encryption).ConvertToARM(resolved)
+		encryption_ARM, err := account.Encryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -570,7 +570,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.Encryption = &encryption
 	}
 	if account.ImmutableStorageWithVersioning != nil {
-		immutableStorageWithVersioning_ARM, err := (*account.ImmutableStorageWithVersioning).ConvertToARM(resolved)
+		immutableStorageWithVersioning_ARM, err := account.ImmutableStorageWithVersioning.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -594,7 +594,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.IsSftpEnabled = &isSftpEnabled
 	}
 	if account.KeyPolicy != nil {
-		keyPolicy_ARM, err := (*account.KeyPolicy).ConvertToARM(resolved)
+		keyPolicy_ARM, err := account.KeyPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -614,7 +614,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.MinimumTlsVersion = &minimumTlsVersion
 	}
 	if account.NetworkAcls != nil {
-		networkAcls_ARM, err := (*account.NetworkAcls).ConvertToARM(resolved)
+		networkAcls_ARM, err := account.NetworkAcls.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -628,7 +628,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.PublicNetworkAccess = &publicNetworkAccess
 	}
 	if account.RoutingPreference != nil {
-		routingPreference_ARM, err := (*account.RoutingPreference).ConvertToARM(resolved)
+		routingPreference_ARM, err := account.RoutingPreference.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -636,7 +636,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.RoutingPreference = &routingPreference
 	}
 	if account.SasPolicy != nil {
-		sasPolicy_ARM, err := (*account.SasPolicy).ConvertToARM(resolved)
+		sasPolicy_ARM, err := account.SasPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -650,7 +650,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Sku":
 	if account.Sku != nil {
-		sku_ARM, err := (*account.Sku).ConvertToARM(resolved)
+		sku_ARM, err := account.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3636,7 +3636,7 @@ func (authentication *AzureFilesIdentityBasedAuthentication) ConvertToARM(resolv
 
 	// Set property "ActiveDirectoryProperties":
 	if authentication.ActiveDirectoryProperties != nil {
-		activeDirectoryProperties_ARM, err := (*authentication.ActiveDirectoryProperties).ConvertToARM(resolved)
+		activeDirectoryProperties_ARM, err := authentication.ActiveDirectoryProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4341,7 +4341,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "Identity":
 	if encryption.Identity != nil {
-		identity_ARM, err := (*encryption.Identity).ConvertToARM(resolved)
+		identity_ARM, err := encryption.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4359,7 +4359,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "Keyvaultproperties":
 	if encryption.Keyvaultproperties != nil {
-		keyvaultproperties_ARM, err := (*encryption.Keyvaultproperties).ConvertToARM(resolved)
+		keyvaultproperties_ARM, err := encryption.Keyvaultproperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4375,7 +4375,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 
 	// Set property "Services":
 	if encryption.Services != nil {
-		services_ARM, err := (*encryption.Services).ConvertToARM(resolved)
+		services_ARM, err := encryption.Services.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5829,7 +5829,7 @@ func (account *ImmutableStorageAccount) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "ImmutabilityPolicy":
 	if account.ImmutabilityPolicy != nil {
-		immutabilityPolicy_ARM, err := (*account.ImmutabilityPolicy).ConvertToARM(resolved)
+		immutabilityPolicy_ARM, err := account.ImmutabilityPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9456,7 +9456,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Blob":
 	if services.Blob != nil {
-		blob_ARM, err := (*services.Blob).ConvertToARM(resolved)
+		blob_ARM, err := services.Blob.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9466,7 +9466,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "File":
 	if services.File != nil {
-		file_ARM, err := (*services.File).ConvertToARM(resolved)
+		file_ARM, err := services.File.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9476,7 +9476,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Queue":
 	if services.Queue != nil {
-		queue_ARM, err := (*services.Queue).ConvertToARM(resolved)
+		queue_ARM, err := services.Queue.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9486,7 +9486,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "Table":
 	if services.Table != nil {
-		table_ARM, err := (*services.Table).ConvertToARM(resolved)
+		table_ARM, err := services.Table.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/storage/v1api20230101/storage_accounts_blob_service_types_gen.go
+++ b/v2/api/storage/v1api20230101/storage_accounts_blob_service_types_gen.go
@@ -316,7 +316,7 @@ func (service *StorageAccountsBlobService_Spec) ConvertToARM(resolved genruntime
 		result.Properties.AutomaticSnapshotPolicyEnabled = &automaticSnapshotPolicyEnabled
 	}
 	if service.ChangeFeed != nil {
-		changeFeed_ARM, err := (*service.ChangeFeed).ConvertToARM(resolved)
+		changeFeed_ARM, err := service.ChangeFeed.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -324,7 +324,7 @@ func (service *StorageAccountsBlobService_Spec) ConvertToARM(resolved genruntime
 		result.Properties.ChangeFeed = &changeFeed
 	}
 	if service.ContainerDeleteRetentionPolicy != nil {
-		containerDeleteRetentionPolicy_ARM, err := (*service.ContainerDeleteRetentionPolicy).ConvertToARM(resolved)
+		containerDeleteRetentionPolicy_ARM, err := service.ContainerDeleteRetentionPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -332,7 +332,7 @@ func (service *StorageAccountsBlobService_Spec) ConvertToARM(resolved genruntime
 		result.Properties.ContainerDeleteRetentionPolicy = &containerDeleteRetentionPolicy
 	}
 	if service.Cors != nil {
-		cors_ARM, err := (*service.Cors).ConvertToARM(resolved)
+		cors_ARM, err := service.Cors.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -344,7 +344,7 @@ func (service *StorageAccountsBlobService_Spec) ConvertToARM(resolved genruntime
 		result.Properties.DefaultServiceVersion = &defaultServiceVersion
 	}
 	if service.DeleteRetentionPolicy != nil {
-		deleteRetentionPolicy_ARM, err := (*service.DeleteRetentionPolicy).ConvertToARM(resolved)
+		deleteRetentionPolicy_ARM, err := service.DeleteRetentionPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -356,7 +356,7 @@ func (service *StorageAccountsBlobService_Spec) ConvertToARM(resolved genruntime
 		result.Properties.IsVersioningEnabled = &isVersioningEnabled
 	}
 	if service.LastAccessTimeTrackingPolicy != nil {
-		lastAccessTimeTrackingPolicy_ARM, err := (*service.LastAccessTimeTrackingPolicy).ConvertToARM(resolved)
+		lastAccessTimeTrackingPolicy_ARM, err := service.LastAccessTimeTrackingPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -364,7 +364,7 @@ func (service *StorageAccountsBlobService_Spec) ConvertToARM(resolved genruntime
 		result.Properties.LastAccessTimeTrackingPolicy = &lastAccessTimeTrackingPolicy
 	}
 	if service.RestorePolicy != nil {
-		restorePolicy_ARM, err := (*service.RestorePolicy).ConvertToARM(resolved)
+		restorePolicy_ARM, err := service.RestorePolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/storage/v1api20230101/storage_accounts_blob_services_container_types_gen.go
+++ b/v2/api/storage/v1api20230101/storage_accounts_blob_services_container_types_gen.go
@@ -325,7 +325,7 @@ func (container *StorageAccountsBlobServicesContainer_Spec) ConvertToARM(resolve
 		result.Properties.EnableNfsV3RootSquash = &enableNfsV3RootSquash
 	}
 	if container.ImmutableStorageWithVersioning != nil {
-		immutableStorageWithVersioning_ARM, err := (*container.ImmutableStorageWithVersioning).ConvertToARM(resolved)
+		immutableStorageWithVersioning_ARM, err := container.ImmutableStorageWithVersioning.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/storage/v1api20230101/storage_accounts_file_service_types_gen.go
+++ b/v2/api/storage/v1api20230101/storage_accounts_file_service_types_gen.go
@@ -287,7 +287,7 @@ func (service *StorageAccountsFileService_Spec) ConvertToARM(resolved genruntime
 		result.Properties = &arm.StorageAccounts_FileService_Properties_Spec{}
 	}
 	if service.Cors != nil {
-		cors_ARM, err := (*service.Cors).ConvertToARM(resolved)
+		cors_ARM, err := service.Cors.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -295,7 +295,7 @@ func (service *StorageAccountsFileService_Spec) ConvertToARM(resolved genruntime
 		result.Properties.Cors = &cors
 	}
 	if service.ProtocolSettings != nil {
-		protocolSettings_ARM, err := (*service.ProtocolSettings).ConvertToARM(resolved)
+		protocolSettings_ARM, err := service.ProtocolSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -303,7 +303,7 @@ func (service *StorageAccountsFileService_Spec) ConvertToARM(resolved genruntime
 		result.Properties.ProtocolSettings = &protocolSettings
 	}
 	if service.ShareDeleteRetentionPolicy != nil {
-		shareDeleteRetentionPolicy_ARM, err := (*service.ShareDeleteRetentionPolicy).ConvertToARM(resolved)
+		shareDeleteRetentionPolicy_ARM, err := service.ShareDeleteRetentionPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -945,7 +945,7 @@ func (settings *ProtocolSettings) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "Smb":
 	if settings.Smb != nil {
-		smb_ARM, err := (*settings.Smb).ConvertToARM(resolved)
+		smb_ARM, err := settings.Smb.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1285,7 +1285,7 @@ func (setting *SmbSetting) ConvertToARM(resolved genruntime.ConvertToARMResolved
 
 	// Set property "Multichannel":
 	if setting.Multichannel != nil {
-		multichannel_ARM, err := (*setting.Multichannel).ConvertToARM(resolved)
+		multichannel_ARM, err := setting.Multichannel.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/storage/v1api20230101/storage_accounts_file_services_share_types_gen.go
+++ b/v2/api/storage/v1api20230101/storage_accounts_file_services_share_types_gen.go
@@ -1499,7 +1499,7 @@ func (identifier *SignedIdentifier) ConvertToARM(resolved genruntime.ConvertToAR
 
 	// Set property "AccessPolicy":
 	if identifier.AccessPolicy != nil {
-		accessPolicy_ARM, err := (*identifier.AccessPolicy).ConvertToARM(resolved)
+		accessPolicy_ARM, err := identifier.AccessPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/storage/v1api20230101/storage_accounts_management_policy_types_gen.go
+++ b/v2/api/storage/v1api20230101/storage_accounts_management_policy_types_gen.go
@@ -280,7 +280,7 @@ func (policy *StorageAccountsManagementPolicy_Spec) ConvertToARM(resolved genrun
 		result.Properties = &arm.ManagementPolicyProperties{}
 	}
 	if policy.Policy != nil {
-		policy_ARM, err := (*policy.Policy).ConvertToARM(resolved)
+		policy_ARM, err := policy.Policy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1070,7 +1070,7 @@ func (rule *ManagementPolicyRule) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "Definition":
 	if rule.Definition != nil {
-		definition_ARM, err := (*rule.Definition).ConvertToARM(resolved)
+		definition_ARM, err := rule.Definition.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1443,7 +1443,7 @@ func (definition *ManagementPolicyDefinition) ConvertToARM(resolved genruntime.C
 
 	// Set property "Actions":
 	if definition.Actions != nil {
-		actions_ARM, err := (*definition.Actions).ConvertToARM(resolved)
+		actions_ARM, err := definition.Actions.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1453,7 +1453,7 @@ func (definition *ManagementPolicyDefinition) ConvertToARM(resolved genruntime.C
 
 	// Set property "Filters":
 	if definition.Filters != nil {
-		filters_ARM, err := (*definition.Filters).ConvertToARM(resolved)
+		filters_ARM, err := definition.Filters.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1765,7 +1765,7 @@ func (action *ManagementPolicyAction) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "BaseBlob":
 	if action.BaseBlob != nil {
-		baseBlob_ARM, err := (*action.BaseBlob).ConvertToARM(resolved)
+		baseBlob_ARM, err := action.BaseBlob.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1775,7 +1775,7 @@ func (action *ManagementPolicyAction) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "Snapshot":
 	if action.Snapshot != nil {
-		snapshot_ARM, err := (*action.Snapshot).ConvertToARM(resolved)
+		snapshot_ARM, err := action.Snapshot.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1785,7 +1785,7 @@ func (action *ManagementPolicyAction) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "Version":
 	if action.Version != nil {
-		version_ARM, err := (*action.Version).ConvertToARM(resolved)
+		version_ARM, err := action.Version.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2480,7 +2480,7 @@ func (blob *ManagementPolicyBaseBlob) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "Delete":
 	if blob.Delete != nil {
-		delete_ARM, err := (*blob.Delete).ConvertToARM(resolved)
+		delete_ARM, err := blob.Delete.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2496,7 +2496,7 @@ func (blob *ManagementPolicyBaseBlob) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "TierToArchive":
 	if blob.TierToArchive != nil {
-		tierToArchive_ARM, err := (*blob.TierToArchive).ConvertToARM(resolved)
+		tierToArchive_ARM, err := blob.TierToArchive.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2506,7 +2506,7 @@ func (blob *ManagementPolicyBaseBlob) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "TierToCold":
 	if blob.TierToCold != nil {
-		tierToCold_ARM, err := (*blob.TierToCold).ConvertToARM(resolved)
+		tierToCold_ARM, err := blob.TierToCold.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2516,7 +2516,7 @@ func (blob *ManagementPolicyBaseBlob) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "TierToCool":
 	if blob.TierToCool != nil {
-		tierToCool_ARM, err := (*blob.TierToCool).ConvertToARM(resolved)
+		tierToCool_ARM, err := blob.TierToCool.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2526,7 +2526,7 @@ func (blob *ManagementPolicyBaseBlob) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "TierToHot":
 	if blob.TierToHot != nil {
-		tierToHot_ARM, err := (*blob.TierToHot).ConvertToARM(resolved)
+		tierToHot_ARM, err := blob.TierToHot.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3138,7 +3138,7 @@ func (shot *ManagementPolicySnapShot) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "Delete":
 	if shot.Delete != nil {
-		delete_ARM, err := (*shot.Delete).ConvertToARM(resolved)
+		delete_ARM, err := shot.Delete.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3148,7 +3148,7 @@ func (shot *ManagementPolicySnapShot) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "TierToArchive":
 	if shot.TierToArchive != nil {
-		tierToArchive_ARM, err := (*shot.TierToArchive).ConvertToARM(resolved)
+		tierToArchive_ARM, err := shot.TierToArchive.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3158,7 +3158,7 @@ func (shot *ManagementPolicySnapShot) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "TierToCold":
 	if shot.TierToCold != nil {
-		tierToCold_ARM, err := (*shot.TierToCold).ConvertToARM(resolved)
+		tierToCold_ARM, err := shot.TierToCold.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3168,7 +3168,7 @@ func (shot *ManagementPolicySnapShot) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "TierToCool":
 	if shot.TierToCool != nil {
-		tierToCool_ARM, err := (*shot.TierToCool).ConvertToARM(resolved)
+		tierToCool_ARM, err := shot.TierToCool.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3178,7 +3178,7 @@ func (shot *ManagementPolicySnapShot) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "TierToHot":
 	if shot.TierToHot != nil {
-		tierToHot_ARM, err := (*shot.TierToHot).ConvertToARM(resolved)
+		tierToHot_ARM, err := shot.TierToHot.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3734,7 +3734,7 @@ func (version *ManagementPolicyVersion) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "Delete":
 	if version.Delete != nil {
-		delete_ARM, err := (*version.Delete).ConvertToARM(resolved)
+		delete_ARM, err := version.Delete.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3744,7 +3744,7 @@ func (version *ManagementPolicyVersion) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "TierToArchive":
 	if version.TierToArchive != nil {
-		tierToArchive_ARM, err := (*version.TierToArchive).ConvertToARM(resolved)
+		tierToArchive_ARM, err := version.TierToArchive.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3754,7 +3754,7 @@ func (version *ManagementPolicyVersion) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "TierToCold":
 	if version.TierToCold != nil {
-		tierToCold_ARM, err := (*version.TierToCold).ConvertToARM(resolved)
+		tierToCold_ARM, err := version.TierToCold.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3764,7 +3764,7 @@ func (version *ManagementPolicyVersion) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "TierToCool":
 	if version.TierToCool != nil {
-		tierToCool_ARM, err := (*version.TierToCool).ConvertToARM(resolved)
+		tierToCool_ARM, err := version.TierToCool.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -3774,7 +3774,7 @@ func (version *ManagementPolicyVersion) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "TierToHot":
 	if version.TierToHot != nil {
-		tierToHot_ARM, err := (*version.TierToHot).ConvertToARM(resolved)
+		tierToHot_ARM, err := version.TierToHot.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/storage/v1api20230101/storage_accounts_queue_service_types_gen.go
+++ b/v2/api/storage/v1api20230101/storage_accounts_queue_service_types_gen.go
@@ -279,7 +279,7 @@ func (service *StorageAccountsQueueService_Spec) ConvertToARM(resolved genruntim
 		result.Properties = &arm.StorageAccounts_QueueService_Properties_Spec{}
 	}
 	if service.Cors != nil {
-		cors_ARM, err := (*service.Cors).ConvertToARM(resolved)
+		cors_ARM, err := service.Cors.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/storage/v1api20230101/storage_accounts_table_service_types_gen.go
+++ b/v2/api/storage/v1api20230101/storage_accounts_table_service_types_gen.go
@@ -279,7 +279,7 @@ func (service *StorageAccountsTableService_Spec) ConvertToARM(resolved genruntim
 		result.Properties = &arm.StorageAccounts_TableService_Properties_Spec{}
 	}
 	if service.Cors != nil {
-		cors_ARM, err := (*service.Cors).ConvertToARM(resolved)
+		cors_ARM, err := service.Cors.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/storage/v1api20230101/storage_accounts_table_services_table_types_gen.go
+++ b/v2/api/storage/v1api20230101/storage_accounts_table_services_table_types_gen.go
@@ -872,7 +872,7 @@ func (identifier *TableSignedIdentifier) ConvertToARM(resolved genruntime.Conver
 
 	// Set property "AccessPolicy":
 	if identifier.AccessPolicy != nil {
-		accessPolicy_ARM, err := (*identifier.AccessPolicy).ConvertToARM(resolved)
+		accessPolicy_ARM, err := identifier.AccessPolicy.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/subscription/v1api20211001/alias_types_gen.go
+++ b/v2/api/subscription/v1api20211001/alias_types_gen.go
@@ -268,7 +268,7 @@ func (alias *Alias_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 
 	// Set property "Properties":
 	if alias.Properties != nil {
-		properties_ARM, err := (*alias.Properties).ConvertToARM(resolved)
+		properties_ARM, err := alias.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -831,7 +831,7 @@ func (properties *PutAliasRequestProperties) ConvertToARM(resolved genruntime.Co
 
 	// Set property "AdditionalProperties":
 	if properties.AdditionalProperties != nil {
-		additionalProperties_ARM, err := (*properties.AdditionalProperties).ConvertToARM(resolved)
+		additionalProperties_ARM, err := properties.AdditionalProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/synapse/v1api20210601/workspace_types_gen.go
+++ b/v2/api/synapse/v1api20210601/workspace_types_gen.go
@@ -334,7 +334,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 
 	// Set property "Identity":
 	if workspace.Identity != nil {
-		identity_ARM, err := (*workspace.Identity).ConvertToARM(resolved)
+		identity_ARM, err := workspace.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -373,7 +373,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.AzureADOnlyAuthentication = &azureADOnlyAuthentication
 	}
 	if workspace.CspWorkspaceAdminProperties != nil {
-		cspWorkspaceAdminProperties_ARM, err := (*workspace.CspWorkspaceAdminProperties).ConvertToARM(resolved)
+		cspWorkspaceAdminProperties_ARM, err := workspace.CspWorkspaceAdminProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -381,7 +381,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.CspWorkspaceAdminProperties = &cspWorkspaceAdminProperties
 	}
 	if workspace.DefaultDataLakeStorage != nil {
-		defaultDataLakeStorage_ARM, err := (*workspace.DefaultDataLakeStorage).ConvertToARM(resolved)
+		defaultDataLakeStorage_ARM, err := workspace.DefaultDataLakeStorage.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -389,7 +389,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.DefaultDataLakeStorage = &defaultDataLakeStorage
 	}
 	if workspace.Encryption != nil {
-		encryption_ARM, err := (*workspace.Encryption).ConvertToARM(resolved)
+		encryption_ARM, err := workspace.Encryption.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -405,7 +405,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.ManagedVirtualNetwork = &managedVirtualNetwork
 	}
 	if workspace.ManagedVirtualNetworkSettings != nil {
-		managedVirtualNetworkSettings_ARM, err := (*workspace.ManagedVirtualNetworkSettings).ConvertToARM(resolved)
+		managedVirtualNetworkSettings_ARM, err := workspace.ManagedVirtualNetworkSettings.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -419,7 +419,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.PublicNetworkAccess = &publicNetworkAccess
 	}
 	if workspace.PurviewConfiguration != nil {
-		purviewConfiguration_ARM, err := (*workspace.PurviewConfiguration).ConvertToARM(resolved)
+		purviewConfiguration_ARM, err := workspace.PurviewConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -443,7 +443,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.TrustedServiceBypassEnabled = &trustedServiceBypassEnabled
 	}
 	if workspace.VirtualNetworkProfile != nil {
-		virtualNetworkProfile_ARM, err := (*workspace.VirtualNetworkProfile).ConvertToARM(resolved)
+		virtualNetworkProfile_ARM, err := workspace.VirtualNetworkProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -451,7 +451,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.VirtualNetworkProfile = &virtualNetworkProfile
 	}
 	if workspace.WorkspaceRepositoryConfiguration != nil {
-		workspaceRepositoryConfiguration_ARM, err := (*workspace.WorkspaceRepositoryConfiguration).ConvertToARM(resolved)
+		workspaceRepositoryConfiguration_ARM, err := workspace.WorkspaceRepositoryConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2583,7 +2583,7 @@ func (details *EncryptionDetails) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "Cmk":
 	if details.Cmk != nil {
-		cmk_ARM, err := (*details.Cmk).ConvertToARM(resolved)
+		cmk_ARM, err := details.Cmk.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4351,7 +4351,7 @@ func (details *CustomerManagedKeyDetails) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "KekIdentity":
 	if details.KekIdentity != nil {
-		kekIdentity_ARM, err := (*details.KekIdentity).ConvertToARM(resolved)
+		kekIdentity_ARM, err := details.KekIdentity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4361,7 +4361,7 @@ func (details *CustomerManagedKeyDetails) ConvertToARM(resolved genruntime.Conve
 
 	// Set property "Key":
 	if details.Key != nil {
-		key_ARM, err := (*details.Key).ConvertToARM(resolved)
+		key_ARM, err := details.Key.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4805,7 +4805,7 @@ func (properties *KekIdentityProperties) ConvertToARM(resolved genruntime.Conver
 
 	// Set property "UseSystemAssignedIdentity":
 	if properties.UseSystemAssignedIdentity != nil {
-		useSystemAssignedIdentity := *(*properties.UseSystemAssignedIdentity).DeepCopy()
+		useSystemAssignedIdentity := *properties.UseSystemAssignedIdentity.DeepCopy()
 		result.UseSystemAssignedIdentity = &useSystemAssignedIdentity
 	}
 
@@ -4835,7 +4835,7 @@ func (properties *KekIdentityProperties) PopulateFromARM(owner genruntime.Arbitr
 
 	// Set property "UseSystemAssignedIdentity":
 	if typedInput.UseSystemAssignedIdentity != nil {
-		useSystemAssignedIdentity := *(*typedInput.UseSystemAssignedIdentity).DeepCopy()
+		useSystemAssignedIdentity := *typedInput.UseSystemAssignedIdentity.DeepCopy()
 		properties.UseSystemAssignedIdentity = &useSystemAssignedIdentity
 	}
 
@@ -4940,7 +4940,7 @@ func (properties *KekIdentityProperties_STATUS) PopulateFromARM(owner genruntime
 
 	// Set property "UseSystemAssignedIdentity":
 	if typedInput.UseSystemAssignedIdentity != nil {
-		useSystemAssignedIdentity := *(*typedInput.UseSystemAssignedIdentity).DeepCopy()
+		useSystemAssignedIdentity := *typedInput.UseSystemAssignedIdentity.DeepCopy()
 		properties.UseSystemAssignedIdentity = &useSystemAssignedIdentity
 	}
 

--- a/v2/api/synapse/v1api20210601/workspaces_big_data_pool_types_gen.go
+++ b/v2/api/synapse/v1api20210601/workspaces_big_data_pool_types_gen.go
@@ -359,7 +359,7 @@ func (pool *WorkspacesBigDataPool_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Properties = &arm.BigDataPoolResourceProperties{}
 	}
 	if pool.AutoPause != nil {
-		autoPause_ARM, err := (*pool.AutoPause).ConvertToARM(resolved)
+		autoPause_ARM, err := pool.AutoPause.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -367,7 +367,7 @@ func (pool *WorkspacesBigDataPool_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Properties.AutoPause = &autoPause
 	}
 	if pool.AutoScale != nil {
-		autoScale_ARM, err := (*pool.AutoScale).ConvertToARM(resolved)
+		autoScale_ARM, err := pool.AutoScale.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -390,7 +390,7 @@ func (pool *WorkspacesBigDataPool_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Properties.DefaultSparkLogFolder = &defaultSparkLogFolder
 	}
 	if pool.DynamicExecutorAllocation != nil {
-		dynamicExecutorAllocation_ARM, err := (*pool.DynamicExecutorAllocation).ConvertToARM(resolved)
+		dynamicExecutorAllocation_ARM, err := pool.DynamicExecutorAllocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -406,7 +406,7 @@ func (pool *WorkspacesBigDataPool_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Properties.IsComputeIsolationEnabled = &isComputeIsolationEnabled
 	}
 	if pool.LibraryRequirements != nil {
-		libraryRequirements_ARM, err := (*pool.LibraryRequirements).ConvertToARM(resolved)
+		libraryRequirements_ARM, err := pool.LibraryRequirements.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -438,7 +438,7 @@ func (pool *WorkspacesBigDataPool_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Properties.SessionLevelPackagesEnabled = &sessionLevelPackagesEnabled
 	}
 	if pool.SparkConfigProperties != nil {
-		sparkConfigProperties_ARM, err := (*pool.SparkConfigProperties).ConvertToARM(resolved)
+		sparkConfigProperties_ARM, err := pool.SparkConfigProperties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/web/v1api20220301/server_farm_types_gen.go
+++ b/v2/api/web/v1api20220301/server_farm_types_gen.go
@@ -342,7 +342,7 @@ func (farm *ServerFarm_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "ExtendedLocation":
 	if farm.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*farm.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := farm.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -392,7 +392,7 @@ func (farm *ServerFarm_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.FreeOfferExpirationTime = &freeOfferExpirationTime
 	}
 	if farm.HostingEnvironmentProfile != nil {
-		hostingEnvironmentProfile_ARM, err := (*farm.HostingEnvironmentProfile).ConvertToARM(resolved)
+		hostingEnvironmentProfile_ARM, err := farm.HostingEnvironmentProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -412,7 +412,7 @@ func (farm *ServerFarm_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.IsXenon = &isXenon
 	}
 	if farm.KubeEnvironmentProfile != nil {
-		kubeEnvironmentProfile_ARM, err := (*farm.KubeEnvironmentProfile).ConvertToARM(resolved)
+		kubeEnvironmentProfile_ARM, err := farm.KubeEnvironmentProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -454,7 +454,7 @@ func (farm *ServerFarm_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Sku":
 	if farm.Sku != nil {
-		sku_ARM, err := (*farm.Sku).ConvertToARM(resolved)
+		sku_ARM, err := farm.Sku.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -2795,7 +2795,7 @@ func (description *SkuDescription) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "SkuCapacity":
 	if description.SkuCapacity != nil {
-		skuCapacity_ARM, err := (*description.SkuCapacity).ConvertToARM(resolved)
+		skuCapacity_ARM, err := description.SkuCapacity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/web/v1api20220301/site_types_gen.go
+++ b/v2/api/web/v1api20220301/site_types_gen.go
@@ -386,7 +386,7 @@ func (site *Site_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 
 	// Set property "ExtendedLocation":
 	if site.ExtendedLocation != nil {
-		extendedLocation_ARM, err := (*site.ExtendedLocation).ConvertToARM(resolved)
+		extendedLocation_ARM, err := site.ExtendedLocation.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -396,7 +396,7 @@ func (site *Site_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 
 	// Set property "Identity":
 	if site.Identity != nil {
-		identity_ARM, err := (*site.Identity).ConvertToARM(resolved)
+		identity_ARM, err := site.Identity.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -468,7 +468,7 @@ func (site *Site_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 		result.Properties.ClientCertMode = &clientCertMode
 	}
 	if site.CloningInfo != nil {
-		cloningInfo_ARM, err := (*site.CloningInfo).ConvertToARM(resolved)
+		cloningInfo_ARM, err := site.CloningInfo.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -503,7 +503,7 @@ func (site *Site_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 		result.Properties.HostNamesDisabled = &hostNamesDisabled
 	}
 	if site.HostingEnvironmentProfile != nil {
-		hostingEnvironmentProfile_ARM, err := (*site.HostingEnvironmentProfile).ConvertToARM(resolved)
+		hostingEnvironmentProfile_ARM, err := site.HostingEnvironmentProfile.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -553,7 +553,7 @@ func (site *Site_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 		result.Properties.ServerFarmId = &serverFarmId
 	}
 	if site.SiteConfig != nil {
-		siteConfig_ARM, err := (*site.SiteConfig).ConvertToARM(resolved)
+		siteConfig_ARM, err := site.SiteConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4986,7 +4986,7 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "ApiDefinition":
 	if config.ApiDefinition != nil {
-		apiDefinition_ARM, err := (*config.ApiDefinition).ConvertToARM(resolved)
+		apiDefinition_ARM, err := config.ApiDefinition.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -4996,7 +4996,7 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "ApiManagementConfig":
 	if config.ApiManagementConfig != nil {
-		apiManagementConfig_ARM, err := (*config.ApiManagementConfig).ConvertToARM(resolved)
+		apiManagementConfig_ARM, err := config.ApiManagementConfig.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5027,7 +5027,7 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "AutoHealRules":
 	if config.AutoHealRules != nil {
-		autoHealRules_ARM, err := (*config.AutoHealRules).ConvertToARM(resolved)
+		autoHealRules_ARM, err := config.AutoHealRules.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5064,7 +5064,7 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "Cors":
 	if config.Cors != nil {
-		cors_ARM, err := (*config.Cors).ConvertToARM(resolved)
+		cors_ARM, err := config.Cors.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5091,7 +5091,7 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "Experiments":
 	if config.Experiments != nil {
-		experiments_ARM, err := (*config.Experiments).ConvertToARM(resolved)
+		experiments_ARM, err := config.Experiments.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5181,7 +5181,7 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "Limits":
 	if config.Limits != nil {
-		limits_ARM, err := (*config.Limits).ConvertToARM(resolved)
+		limits_ARM, err := config.Limits.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -5293,7 +5293,7 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "Push":
 	if config.Push != nil {
-		push_ARM, err := (*config.Push).ConvertToARM(resolved)
+		push_ARM, err := config.Push.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9566,7 +9566,7 @@ func (rules *AutoHealRules) ConvertToARM(resolved genruntime.ConvertToARMResolve
 
 	// Set property "Actions":
 	if rules.Actions != nil {
-		actions_ARM, err := (*rules.Actions).ConvertToARM(resolved)
+		actions_ARM, err := rules.Actions.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -9576,7 +9576,7 @@ func (rules *AutoHealRules) ConvertToARM(resolved genruntime.ConvertToARMResolve
 
 	// Set property "Triggers":
 	if rules.Triggers != nil {
-		triggers_ARM, err := (*rules.Triggers).ConvertToARM(resolved)
+		triggers_ARM, err := rules.Triggers.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -13579,7 +13579,7 @@ func (actions *AutoHealActions) ConvertToARM(resolved genruntime.ConvertToARMRes
 
 	// Set property "CustomAction":
 	if actions.CustomAction != nil {
-		customAction_ARM, err := (*actions.CustomAction).ConvertToARM(resolved)
+		customAction_ARM, err := actions.CustomAction.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -13900,7 +13900,7 @@ func (triggers *AutoHealTriggers) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "Requests":
 	if triggers.Requests != nil {
-		requests_ARM, err := (*triggers.Requests).ConvertToARM(resolved)
+		requests_ARM, err := triggers.Requests.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -13910,7 +13910,7 @@ func (triggers *AutoHealTriggers) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "SlowRequests":
 	if triggers.SlowRequests != nil {
-		slowRequests_ARM, err := (*triggers.SlowRequests).ConvertToARM(resolved)
+		slowRequests_ARM, err := triggers.SlowRequests.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/api/web/v1api20220301/sites_sourcecontrol_types_gen.go
+++ b/v2/api/web/v1api20220301/sites_sourcecontrol_types_gen.go
@@ -320,7 +320,7 @@ func (sourcecontrol *SitesSourcecontrol_Spec) ConvertToARM(resolved genruntime.C
 		result.Properties.DeploymentRollbackEnabled = &deploymentRollbackEnabled
 	}
 	if sourcecontrol.GitHubActionConfiguration != nil {
-		gitHubActionConfiguration_ARM, err := (*sourcecontrol.GitHubActionConfiguration).ConvertToARM(resolved)
+		gitHubActionConfiguration_ARM, err := sourcecontrol.GitHubActionConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1112,7 +1112,7 @@ func (configuration *GitHubActionConfiguration) ConvertToARM(resolved genruntime
 
 	// Set property "CodeConfiguration":
 	if configuration.CodeConfiguration != nil {
-		codeConfiguration_ARM, err := (*configuration.CodeConfiguration).ConvertToARM(resolved)
+		codeConfiguration_ARM, err := configuration.CodeConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -1122,7 +1122,7 @@ func (configuration *GitHubActionConfiguration) ConvertToARM(resolved genruntime
 
 	// Set property "ContainerConfiguration":
 	if configuration.ContainerConfiguration != nil {
-		containerConfiguration_ARM, err := (*configuration.ContainerConfiguration).ConvertToARM(resolved)
+		containerConfiguration_ARM, err := configuration.ContainerConfiguration.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/tools/generator/internal/astbuilder/builder.go
+++ b/v2/tools/generator/internal/astbuilder/builder.go
@@ -377,7 +377,13 @@ func QualifiedTypeName(pkg string, name string) *dst.SelectorExpr {
 //
 // <expr>.<name0>.(<name1>.<name2>…)
 func Selector(expr dst.Expr, names ...string) *dst.SelectorExpr {
-	exprs := []dst.Expr{dst.Clone(expr).(dst.Expr)}
+	// Value fields are accessible via pointers, so we don't need to dereference expr if it's a StarExpr
+	root := dst.Clone(expr).(dst.Expr)
+	if st, ok := expr.(*dst.StarExpr); ok {
+		root = st.X
+	}
+
+	exprs := []dst.Expr{root}
 	for _, name := range names {
 		exprs = append(exprs, dst.NewIdent(name))
 	}

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestCreateARMTypeWithConfigMap_CreatesExpectedConversions/person-v20200101.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestCreateARMTypeWithConfigMap_CreatesExpectedConversions/person-v20200101.golden
@@ -54,7 +54,7 @@ func (person *Person_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 
 	// Set property "Properties":
 	if person.Properties != nil {
-		properties_ARM, err := (*person.Properties).ConvertToARM(resolved)
+		properties_ARM, err := person.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestCreateARMTypeWithSecret_CreatesExpectedConversions/person-v20200101.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestCreateARMTypeWithSecret_CreatesExpectedConversions/person-v20200101.golden
@@ -54,7 +54,7 @@ func (person *Person_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 
 	// Set property "Properties":
 	if person.Properties != nil {
-		properties_ARM, err := (*person.Properties).ConvertToARM(resolved)
+		properties_ARM, err := person.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestCreateARMTypes_WithTopLevelOneOf_GeneratesExpectedCode/person-v20220630.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestCreateARMTypes_WithTopLevelOneOf_GeneratesExpectedCode/person-v20220630.golden
@@ -49,7 +49,7 @@ func (database *ClusterDatabase_Spec) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "ReadOnlyFollowing":
 	if database.ReadOnlyFollowing != nil {
-		readOnlyFollowing_ARM, err := (*database.ReadOnlyFollowing).ConvertToARM(resolved)
+		readOnlyFollowing_ARM, err := database.ReadOnlyFollowing.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -60,7 +60,7 @@ func (database *ClusterDatabase_Spec) ConvertToARM(resolved genruntime.ConvertTo
 
 	// Set property "ReadWrite":
 	if database.ReadWrite != nil {
-		readWrite_ARM, err := (*database.ReadWrite).ConvertToARM(resolved)
+		readWrite_ARM, err := database.ReadWrite.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_id_resource_reference_azure_v1api20200101.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_id_resource_reference_azure_v1api20200101.golden
@@ -233,7 +233,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Properties":
 	if resource.Properties != nil {
-		properties_ARM, err := (*resource.Properties).ConvertToARM(resolved)
+		properties_ARM, err := resource.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_required_and_optional_resource_references_azure_v1api20200101.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_required_and_optional_resource_references_azure_v1api20200101.golden
@@ -233,7 +233,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Properties":
 	if resource.Properties != nil {
-		properties_ARM, err := (*resource.Properties).ConvertToARM(resolved)
+		properties_ARM, err := resource.Properties.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_complex_properties_azure_v1api20200101.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_complex_properties_azure_v1api20200101.golden
@@ -243,7 +243,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Foo":
 	if resource.Foo != nil {
-		foo_ARM, err := (*resource.Foo).ConvertToARM(resolved)
+		foo_ARM, err := resource.Foo.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -256,7 +256,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "OptionalFoo":
 	if resource.OptionalFoo != nil {
-		optionalFoo_ARM, err := (*resource.OptionalFoo).ConvertToARM(resolved)
+		optionalFoo_ARM, err := resource.OptionalFoo.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_json_fields_azure_v1api20200101.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_json_fields_azure_v1api20200101.golden
@@ -243,7 +243,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "MandatoryJson":
 	if resource.MandatoryJson != nil {
-		mandatoryJson := *(*resource.MandatoryJson).DeepCopy()
+		mandatoryJson := *resource.MandatoryJson.DeepCopy()
 		result.MandatoryJson = &mandatoryJson
 	}
 
@@ -252,7 +252,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "OptionalJson":
 	if resource.OptionalJson != nil {
-		optionalJson := *(*resource.OptionalJson).DeepCopy()
+		optionalJson := *resource.OptionalJson.DeepCopy()
 		result.OptionalJson = &optionalJson
 	}
 
@@ -293,7 +293,7 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 
 	// Set property "MandatoryJson":
 	if typedInput.MandatoryJson != nil {
-		mandatoryJson := *(*typedInput.MandatoryJson).DeepCopy()
+		mandatoryJson := *typedInput.MandatoryJson.DeepCopy()
 		resource.MandatoryJson = &mandatoryJson
 	}
 
@@ -301,7 +301,7 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 
 	// Set property "OptionalJson":
 	if typedInput.OptionalJson != nil {
-		optionalJson := *(*typedInput.OptionalJson).DeepCopy()
+		optionalJson := *typedInput.OptionalJson.DeepCopy()
 		resource.OptionalJson = &optionalJson
 	}
 

--- a/v2/tools/generator/internal/codegen/testdata/EmbeddedTypes/Embedded_type_simple_resource_v1api20200101.golden
+++ b/v2/tools/generator/internal/codegen/testdata/EmbeddedTypes/Embedded_type_simple_resource_v1api20200101.golden
@@ -245,7 +245,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "Foo":
 	if resource.Foo != nil {
-		foo_ARM, err := (*resource.Foo).ConvertToARM(resolved)
+		foo_ARM, err := resource.Foo.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
@@ -258,7 +258,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 
 	// Set property "OptionalFoo":
 	if resource.OptionalFoo != nil {
-		optionalFoo_ARM, err := (*resource.OptionalFoo).ConvertToARM(resolved)
+		optionalFoo_ARM, err := resource.OptionalFoo.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## What this PR does

We've been generating a pointer dereference that's not strictly required.

Instead of this:
``` go
	if rule.Detector != nil {
		detector_ARM, err := (*rule.Detector).ConvertToARM(resolved)
		if err != nil {
			return nil, err
		}
```

we will now generate
``` go
	if rule.Detector != nil {
		detector_ARM, err := rule.Detector.ConvertToARM(resolved)
		if err != nil {
			return nil, err
		}
```

The only manual change is to `builder.go` - everything else follows from that.
