### PR TITLE
Improve documentation comments in `arm` packages

### DIFF
--- a/v2/api/alertsmanagement/v1api20210401/arm/smart_detector_alert_rule_spec_types_gen.go
+++ b/v2/api/alertsmanagement/v1api20210401/arm/smart_detector_alert_rule_spec_types_gen.go
@@ -50,8 +50,10 @@ type AlertRuleProperties struct {
 
 	// Frequency: The alert rule frequency in ISO8601 format. The time granularity must be in minutes and minimum value is 1
 	// minute, depending on the detector.
-	Frequency *string  `json:"frequency,omitempty"`
-	Scope     []string `json:"scope,omitempty"`
+	Frequency *string `json:"frequency,omitempty"`
+
+	// Scope: The alert rule resources scope.
+	Scope []string `json:"scope,omitempty"`
 
 	// Severity: The alert rule severity.
 	Severity *AlertRuleProperties_Severity `json:"severity,omitempty"`
@@ -69,8 +71,10 @@ type ActionGroupsInformation struct {
 	CustomEmailSubject *string `json:"customEmailSubject,omitempty"`
 
 	// CustomWebhookPayload: An optional custom web-hook payload to use in web-hook notifications.
-	CustomWebhookPayload *string  `json:"customWebhookPayload,omitempty"`
-	GroupIds             []string `json:"groupIds,omitempty"`
+	CustomWebhookPayload *string `json:"customWebhookPayload,omitempty"`
+
+	// GroupIds: The Action Group resource IDs.
+	GroupIds []string `json:"groupIds,omitempty"`
 }
 
 // +kubebuilder:validation:Enum={"Sev0","Sev1","Sev2","Sev3","Sev4"}

--- a/v2/api/alertsmanagement/v1api20230301/arm/prometheus_rule_group_spec_types_gen.go
+++ b/v2/api/alertsmanagement/v1api20230301/arm/prometheus_rule_group_spec_types_gen.go
@@ -50,8 +50,11 @@ type PrometheusRuleGroupProperties struct {
 	Interval *string `json:"interval,omitempty"`
 
 	// Rules: Defines the rules in the Prometheus rule group.
-	Rules  []PrometheusRule `json:"rules,omitempty"`
-	Scopes []string         `json:"scopes,omitempty"`
+	Rules []PrometheusRule `json:"rules,omitempty"`
+
+	// Scopes: Target Azure Monitor workspaces resource ids. This api-version is currently limited to creating with one scope.
+	// This may change in future.
+	Scopes []string `json:"scopes,omitempty"`
 }
 
 // An Azure Prometheus alerting or recording rule.
@@ -92,6 +95,7 @@ type PrometheusRule struct {
 
 // An alert action. Only relevant for alerts.
 type PrometheusRuleGroupAction struct {
+	// ActionGroupId: The resource id of the action group to use.
 	ActionGroupId *string `json:"actionGroupId,omitempty"`
 
 	// ActionProperties: The properties of an action group object.

--- a/v2/api/apimanagement/v1api20220801/arm/api_spec_types_gen.go
+++ b/v2/api/apimanagement/v1api20220801/arm/api_spec_types_gen.go
@@ -51,8 +51,10 @@ type ApiCreateOrUpdateProperties struct {
 	ApiVersionDescription *string `json:"apiVersionDescription,omitempty"`
 
 	// ApiVersionSet: Version set details
-	ApiVersionSet   *ApiVersionSetContractDetails `json:"apiVersionSet,omitempty"`
-	ApiVersionSetId *string                       `json:"apiVersionSetId,omitempty"`
+	ApiVersionSet *ApiVersionSetContractDetails `json:"apiVersionSet,omitempty"`
+
+	// ApiVersionSetId: A resource identifier for the related ApiVersionSet.
+	ApiVersionSetId *string `json:"apiVersionSetId,omitempty"`
 
 	// AuthenticationSettings: Collection of authentication settings included into this API.
 	AuthenticationSettings *AuthenticationSettingsContract `json:"authenticationSettings,omitempty"`
@@ -84,7 +86,9 @@ type ApiCreateOrUpdateProperties struct {
 	Protocols []ApiCreateOrUpdateProperties_Protocols `json:"protocols,omitempty"`
 
 	// ServiceUrl: Absolute URL of the backend service implementing this API. Cannot be more than 2000 characters long.
-	ServiceUrl  *string `json:"serviceUrl,omitempty"`
+	ServiceUrl *string `json:"serviceUrl,omitempty"`
+
+	// SourceApiId: API identifier of the source API.
 	SourceApiId *string `json:"sourceApiId,omitempty"`
 
 	// SubscriptionKeyParameterNames: Protocols over which API is made available.
@@ -243,7 +247,9 @@ type ApiLicenseInformation struct {
 type ApiVersionSetContractDetails struct {
 	// Description: Description of API Version Set.
 	Description *string `json:"description,omitempty"`
-	Id          *string `json:"id,omitempty"`
+
+	// Id: Identifier for existing API Version Set. Omit this value to create a new Version Set.
+	Id *string `json:"id,omitempty"`
 
 	// Name: The display Name of the API Version Set.
 	Name *string `json:"name,omitempty"`

--- a/v2/api/apimanagement/v1api20220801/arm/backend_spec_types_gen.go
+++ b/v2/api/apimanagement/v1api20220801/arm/backend_spec_types_gen.go
@@ -44,8 +44,11 @@ type BackendContractProperties struct {
 	Protocol *BackendContractProperties_Protocol `json:"protocol,omitempty"`
 
 	// Proxy: Backend gateway Contract Properties
-	Proxy      *BackendProxyContract `json:"proxy,omitempty"`
-	ResourceId *string               `json:"resourceId,omitempty"`
+	Proxy *BackendProxyContract `json:"proxy,omitempty"`
+
+	// ResourceId: Management Uri of the Resource in External System. This URL can be the Arm Resource Id of Logic Apps,
+	// Function Apps or API Apps.
+	ResourceId *string `json:"resourceId,omitempty"`
 
 	// Title: Backend Title.
 	Title *string `json:"title,omitempty"`

--- a/v2/api/apimanagement/v1api20220801/arm/service_spec_types_gen.go
+++ b/v2/api/apimanagement/v1api20220801/arm/service_spec_types_gen.go
@@ -103,7 +103,10 @@ type ApiManagementServiceProperties struct {
 
 	// NotificationSenderEmail: Email address from which the notification will be sent.
 	NotificationSenderEmail *string `json:"notificationSenderEmail,omitempty"`
-	PublicIpAddressId       *string `json:"publicIpAddressId,omitempty"`
+
+	// PublicIpAddressId: Public Standard SKU IP V4 based IP address to be associated with Virtual Network deployed service in
+	// the region. Supported only for Developer and Premium SKU being deployed in Virtual Network.
+	PublicIpAddressId *string `json:"publicIpAddressId,omitempty"`
 
 	// PublicNetworkAccess: Whether or not public endpoint access is allowed for this API Management service.  Value is
 	// optional but if passed in, must be 'Enabled' or 'Disabled'. If 'Disabled', private endpoints are the exclusive access
@@ -149,8 +152,11 @@ type AdditionalLocation struct {
 	Location *string `json:"location,omitempty"`
 
 	// NatGatewayState: Property can be used to enable NAT Gateway for this API Management service.
-	NatGatewayState   *AdditionalLocation_NatGatewayState `json:"natGatewayState,omitempty"`
-	PublicIpAddressId *string                             `json:"publicIpAddressId,omitempty"`
+	NatGatewayState *AdditionalLocation_NatGatewayState `json:"natGatewayState,omitempty"`
+
+	// PublicIpAddressId: Public Standard SKU IP V4 based IP address to be associated with Virtual Network deployed service in
+	// the location. Supported only for Premium SKU being deployed in Virtual Network.
+	PublicIpAddressId *string `json:"publicIpAddressId,omitempty"`
 
 	// Sku: SKU properties of the API Management service.
 	Sku *ApiManagementServiceSkuProperties `json:"sku,omitempty"`
@@ -316,6 +322,7 @@ type UserAssignedIdentityDetails struct {
 
 // Configuration of a virtual network to which API Management service is deployed.
 type VirtualNetworkConfiguration struct {
+	// SubnetResourceId: The full resource ID of a subnet in a virtual network to deploy the API Management service in.
 	SubnetResourceId *string `json:"subnetResourceId,omitempty"`
 }
 

--- a/v2/api/apimanagement/v1api20220801/arm/subscription_spec_types_gen.go
+++ b/v2/api/apimanagement/v1api20220801/arm/subscription_spec_types_gen.go
@@ -36,7 +36,9 @@ type SubscriptionCreateParameterProperties struct {
 
 	// DisplayName: Subscription name.
 	DisplayName *string `json:"displayName,omitempty"`
-	OwnerId     *string `json:"ownerId,omitempty"`
+
+	// OwnerId: User (user id path) for whom subscription is being created in form /users/{userId}
+	OwnerId *string `json:"ownerId,omitempty"`
 
 	// PrimaryKey: Primary subscription key. If not specified during request key will be generated automatically.
 	PrimaryKey *string `json:"primaryKey,omitempty"`

--- a/v2/api/apimanagement/v1api20230501preview/arm/api_spec_types_gen.go
+++ b/v2/api/apimanagement/v1api20230501preview/arm/api_spec_types_gen.go
@@ -52,8 +52,10 @@ type ApiCreateOrUpdateProperties struct {
 	ApiVersionDescription *string `json:"apiVersionDescription,omitempty"`
 
 	// ApiVersionSet: Version set details
-	ApiVersionSet   *ApiVersionSetContractDetails `json:"apiVersionSet,omitempty"`
-	ApiVersionSetId *string                       `json:"apiVersionSetId,omitempty"`
+	ApiVersionSet *ApiVersionSetContractDetails `json:"apiVersionSet,omitempty"`
+
+	// ApiVersionSetId: A resource identifier for the related ApiVersionSet.
+	ApiVersionSetId *string `json:"apiVersionSetId,omitempty"`
 
 	// AuthenticationSettings: Collection of authentication settings included into this API.
 	AuthenticationSettings *AuthenticationSettingsContract `json:"authenticationSettings,omitempty"`
@@ -85,7 +87,9 @@ type ApiCreateOrUpdateProperties struct {
 	Protocols []ApiCreateOrUpdateProperties_Protocols `json:"protocols,omitempty"`
 
 	// ServiceUrl: Absolute URL of the backend service implementing this API. Cannot be more than 2000 characters long.
-	ServiceUrl  *string `json:"serviceUrl,omitempty"`
+	ServiceUrl *string `json:"serviceUrl,omitempty"`
+
+	// SourceApiId: API identifier of the source API.
 	SourceApiId *string `json:"sourceApiId,omitempty"`
 
 	// SubscriptionKeyParameterNames: Protocols over which API is made available.
@@ -260,7 +264,9 @@ type ApiLicenseInformation struct {
 type ApiVersionSetContractDetails struct {
 	// Description: Description of API Version Set.
 	Description *string `json:"description,omitempty"`
-	Id          *string `json:"id,omitempty"`
+
+	// Id: Identifier for existing API Version Set. Omit this value to create a new Version Set.
+	Id *string `json:"id,omitempty"`
 
 	// Name: The display Name of the API Version Set.
 	Name *string `json:"name,omitempty"`

--- a/v2/api/apimanagement/v1api20230501preview/arm/backend_spec_types_gen.go
+++ b/v2/api/apimanagement/v1api20230501preview/arm/backend_spec_types_gen.go
@@ -50,8 +50,11 @@ type BackendContractProperties struct {
 	Protocol *BackendContractProperties_Protocol `json:"protocol,omitempty"`
 
 	// Proxy: Backend gateway Contract Properties
-	Proxy      *BackendProxyContract `json:"proxy,omitempty"`
-	ResourceId *string               `json:"resourceId,omitempty"`
+	Proxy *BackendProxyContract `json:"proxy,omitempty"`
+
+	// ResourceId: Management Uri of the Resource in External System. This URL can be the Arm Resource Id of Logic Apps,
+	// Function Apps or API Apps.
+	ResourceId *string `json:"resourceId,omitempty"`
 
 	// Title: Backend Title.
 	Title *string `json:"title,omitempty"`
@@ -165,6 +168,7 @@ type BackendAuthorizationHeaderCredentials struct {
 
 // Backend pool service information
 type BackendPoolItem struct {
+	// Id: The unique ARM id of the backend entity. The ARM id should refer to an already existing backend entity.
 	Id *string `json:"id,omitempty"`
 }
 

--- a/v2/api/apimanagement/v1api20230501preview/arm/service_spec_types_gen.go
+++ b/v2/api/apimanagement/v1api20230501preview/arm/service_spec_types_gen.go
@@ -112,7 +112,10 @@ type ApiManagementServiceProperties struct {
 
 	// NotificationSenderEmail: Email address from which the notification will be sent.
 	NotificationSenderEmail *string `json:"notificationSenderEmail,omitempty"`
-	PublicIpAddressId       *string `json:"publicIpAddressId,omitempty"`
+
+	// PublicIpAddressId: Public Standard SKU IP V4 based IP address to be associated with Virtual Network deployed service in
+	// the region. Supported only for Developer and Premium SKU being deployed in Virtual Network.
+	PublicIpAddressId *string `json:"publicIpAddressId,omitempty"`
 
 	// PublicNetworkAccess: Whether or not public endpoint access is allowed for this API Management service.  Value is
 	// optional but if passed in, must be 'Enabled' or 'Disabled'. If 'Disabled', private endpoints are the exclusive access
@@ -158,8 +161,11 @@ type AdditionalLocation struct {
 	Location *string `json:"location,omitempty"`
 
 	// NatGatewayState: Property can be used to enable NAT Gateway for this API Management service.
-	NatGatewayState   *AdditionalLocation_NatGatewayState `json:"natGatewayState,omitempty"`
-	PublicIpAddressId *string                             `json:"publicIpAddressId,omitempty"`
+	NatGatewayState *AdditionalLocation_NatGatewayState `json:"natGatewayState,omitempty"`
+
+	// PublicIpAddressId: Public Standard SKU IP V4 based IP address to be associated with Virtual Network deployed service in
+	// the location. Supported only for Premium SKU being deployed in Virtual Network.
+	PublicIpAddressId *string `json:"publicIpAddressId,omitempty"`
 
 	// Sku: SKU properties of the API Management service.
 	Sku *ApiManagementServiceSkuProperties `json:"sku,omitempty"`
@@ -365,6 +371,7 @@ type UserAssignedIdentityDetails struct {
 
 // Configuration of a virtual network to which API Management service is deployed.
 type VirtualNetworkConfiguration struct {
+	// SubnetResourceId: The full resource ID of a subnet in a virtual network to deploy the API Management service in.
 	SubnetResourceId *string `json:"subnetResourceId,omitempty"`
 }
 

--- a/v2/api/apimanagement/v1api20230501preview/arm/subscription_spec_types_gen.go
+++ b/v2/api/apimanagement/v1api20230501preview/arm/subscription_spec_types_gen.go
@@ -36,7 +36,9 @@ type SubscriptionCreateParameterProperties struct {
 
 	// DisplayName: Subscription name.
 	DisplayName *string `json:"displayName,omitempty"`
-	OwnerId     *string `json:"ownerId,omitempty"`
+
+	// OwnerId: User (user id path) for whom subscription is being created in form /users/{userId}
+	OwnerId *string `json:"ownerId,omitempty"`
 
 	// PrimaryKey: Primary subscription key. If not specified during request key will be generated automatically.
 	PrimaryKey *string `json:"primaryKey,omitempty"`

--- a/v2/api/app/v1api20240301/arm/container_app_spec_types_gen.go
+++ b/v2/api/app/v1api20240301/arm/container_app_spec_types_gen.go
@@ -14,7 +14,11 @@ type ContainerApp_Spec struct {
 	Identity *ManagedServiceIdentity `json:"identity,omitempty"`
 
 	// Location: The geo-location where the resource lives
-	Location  *string `json:"location,omitempty"`
+	Location *string `json:"location,omitempty"`
+
+	// ManagedBy: The fully qualified resource ID of the resource that manages this resource. Indicates if this resource is
+	// managed by another Azure resource. If this is present, complete mode deployment will not delete the resource if it is
+	// removed from the template since it is managed by another resource.
 	ManagedBy *string `json:"managedBy,omitempty"`
 	Name      string  `json:"name,omitempty"`
 
@@ -44,9 +48,13 @@ func (containerApp *ContainerApp_Spec) GetType() string {
 
 type ContainerApp_Properties_Spec struct {
 	// Configuration: Non versioned Container App configuration properties.
-	Configuration        *Configuration `json:"configuration,omitempty"`
-	EnvironmentId        *string        `json:"environmentId,omitempty"`
-	ManagedEnvironmentId *string        `json:"managedEnvironmentId,omitempty"`
+	Configuration *Configuration `json:"configuration,omitempty"`
+
+	// EnvironmentId: Resource ID of environment.
+	EnvironmentId *string `json:"environmentId,omitempty"`
+
+	// ManagedEnvironmentId: Deprecated. Resource ID of the Container App's environment.
+	ManagedEnvironmentId *string `json:"managedEnvironmentId,omitempty"`
 
 	// Template: Container App versioned application definition.
 	Template *Template `json:"template,omitempty"`
@@ -299,6 +307,8 @@ type Ingress struct {
 
 // Container App Private Registry
 type RegistryCredentials struct {
+	// Identity: A Managed Identity to use to authenticate with Azure Container Registry. For user-assigned identities, use the
+	// full user-assigned identity Resource ID. For system-assigned identities, use 'system'
 	Identity *string `json:"identity,omitempty"`
 
 	// PasswordSecretRef: The name of the Secret that contains the registry login password
@@ -325,6 +335,8 @@ type Scale struct {
 
 // Secret definition.
 type Secret struct {
+	// Identity: Resource ID of a managed identity to authenticate with Azure Key Vault, or System to use a system-assigned
+	// identity.
 	Identity *string `json:"identity,omitempty"`
 
 	// KeyVaultUrl: Azure Key Vault URL pointing to the secret referenced by the container app.
@@ -346,7 +358,9 @@ type Service struct {
 // Configuration to bind a ContainerApp to a dev ContainerApp Service
 type ServiceBind struct {
 	// Name: Name of the service bind
-	Name      *string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
+
+	// ServiceId: Resource id of the target service
 	ServiceId *string `json:"serviceId,omitempty"`
 }
 
@@ -444,8 +458,10 @@ type CorsPolicy struct {
 // Custom Domain of a Container App
 type CustomDomain struct {
 	// BindingType: Custom Domain binding type.
-	BindingType   *CustomDomain_BindingType `json:"bindingType,omitempty"`
-	CertificateId *string                   `json:"certificateId,omitempty"`
+	BindingType *CustomDomain_BindingType `json:"bindingType,omitempty"`
+
+	// CertificateId: Resource Id of the Certificate to be bound to this hostname. Must exist in the Managed Environment.
+	CertificateId *string `json:"certificateId,omitempty"`
 
 	// Name: Hostname.
 	Name *string `json:"name,omitempty"`

--- a/v2/api/app/v1api20240301/arm/job_spec_types_gen.go
+++ b/v2/api/app/v1api20240301/arm/job_spec_types_gen.go
@@ -44,7 +44,9 @@ func (job *Job_Spec) GetType() string {
 type Job_Properties_Spec struct {
 	// Configuration: Container Apps Job configuration properties.
 	Configuration *JobConfiguration `json:"configuration,omitempty"`
-	EnvironmentId *string           `json:"environmentId,omitempty"`
+
+	// EnvironmentId: Resource ID of environment.
+	EnvironmentId *string `json:"environmentId,omitempty"`
 
 	// Template: Container Apps job definition.
 	Template *JobTemplate `json:"template,omitempty"`

--- a/v2/api/app/v1api20240301/arm/managed_environment_spec_types_gen.go
+++ b/v2/api/app/v1api20240301/arm/managed_environment_spec_types_gen.go
@@ -109,7 +109,10 @@ type ManagedEnvironment_Properties_PeerTrafficConfiguration_Spec struct {
 type VnetConfiguration struct {
 	// DockerBridgeCidr: CIDR notation IP range assigned to the Docker bridge, network. Must not overlap with any other
 	// provided IP ranges.
-	DockerBridgeCidr       *string `json:"dockerBridgeCidr,omitempty"`
+	DockerBridgeCidr *string `json:"dockerBridgeCidr,omitempty"`
+
+	// InfrastructureSubnetId: Resource ID of a subnet for infrastructure components. Must not overlap with any other provided
+	// IP ranges.
 	InfrastructureSubnetId *string `json:"infrastructureSubnetId,omitempty"`
 
 	// Internal: Boolean indicating the environment only has an internal load balancer. These environments do not have a public

--- a/v2/api/app/v1api20250101/arm/container_app_spec_types_gen.go
+++ b/v2/api/app/v1api20250101/arm/container_app_spec_types_gen.go
@@ -14,7 +14,11 @@ type ContainerApp_Spec struct {
 	Identity *ManagedServiceIdentity `json:"identity,omitempty"`
 
 	// Location: The geo-location where the resource lives
-	Location  *string `json:"location,omitempty"`
+	Location *string `json:"location,omitempty"`
+
+	// ManagedBy: The fully qualified resource ID of the resource that manages this resource. Indicates if this resource is
+	// managed by another Azure resource. If this is present, complete mode deployment will not delete the resource if it is
+	// removed from the template since it is managed by another resource.
 	ManagedBy *string `json:"managedBy,omitempty"`
 	Name      string  `json:"name,omitempty"`
 
@@ -44,9 +48,13 @@ func (containerApp *ContainerApp_Spec) GetType() string {
 
 type ContainerApp_Properties_Spec struct {
 	// Configuration: Non versioned Container App configuration properties.
-	Configuration        *Configuration `json:"configuration,omitempty"`
-	EnvironmentId        *string        `json:"environmentId,omitempty"`
-	ManagedEnvironmentId *string        `json:"managedEnvironmentId,omitempty"`
+	Configuration *Configuration `json:"configuration,omitempty"`
+
+	// EnvironmentId: Resource ID of environment.
+	EnvironmentId *string `json:"environmentId,omitempty"`
+
+	// ManagedEnvironmentId: Deprecated. Resource ID of the Container App's environment.
+	ManagedEnvironmentId *string `json:"managedEnvironmentId,omitempty"`
 
 	// Template: Container App versioned application definition.
 	Template *Template `json:"template,omitempty"`
@@ -264,6 +272,8 @@ type Dapr struct {
 
 // Optional settings for a Managed Identity that is assigned to the Container App.
 type IdentitySettings struct {
+	// Identity: The resource ID of a user-assigned managed identity that is assigned to the Container App, or 'system' for
+	// system-assigned identity.
 	Identity *string `json:"identity,omitempty"`
 
 	// Lifecycle: Use to select the lifecycle stages of a Container App during which the Managed Identity should be available.
@@ -314,6 +324,8 @@ type Ingress struct {
 
 // Container App Private Registry
 type RegistryCredentials struct {
+	// Identity: A Managed Identity to use to authenticate with Azure Container Registry. For user-assigned identities, use the
+	// full user-assigned identity Resource ID. For system-assigned identities, use 'system'
 	Identity *string `json:"identity,omitempty"`
 
 	// PasswordSecretRef: The name of the Secret that contains the registry login password
@@ -352,6 +364,8 @@ type Scale struct {
 
 // Secret definition.
 type Secret struct {
+	// Identity: Resource ID of a managed identity to authenticate with Azure Key Vault, or System to use a system-assigned
+	// identity.
 	Identity *string `json:"identity,omitempty"`
 
 	// KeyVaultUrl: Azure Key Vault URL pointing to the secret referenced by the container app.
@@ -373,7 +387,9 @@ type Service struct {
 // Configuration to bind a ContainerApp to a dev ContainerApp Service
 type ServiceBind struct {
 	// Name: Name of the service bind
-	Name      *string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
+
+	// ServiceId: Resource id of the target service
 	ServiceId *string `json:"serviceId,omitempty"`
 }
 
@@ -472,8 +488,10 @@ type CorsPolicy struct {
 // Custom Domain of a Container App
 type CustomDomain struct {
 	// BindingType: Custom Domain binding type.
-	BindingType   *CustomDomain_BindingType `json:"bindingType,omitempty"`
-	CertificateId *string                   `json:"certificateId,omitempty"`
+	BindingType *CustomDomain_BindingType `json:"bindingType,omitempty"`
+
+	// CertificateId: Resource Id of the Certificate to be bound to this hostname. Must exist in the Managed Environment.
+	CertificateId *string `json:"certificateId,omitempty"`
 
 	// Name: Hostname.
 	Name *string `json:"name,omitempty"`
@@ -744,8 +762,11 @@ var customDomain_BindingType_Values = map[string]CustomDomain_BindingType{
 // Container App container Custom scaling rule.
 type CustomScaleRule struct {
 	// Auth: Authentication secrets for the custom scale rule.
-	Auth     []ScaleRuleAuth `json:"auth,omitempty"`
-	Identity *string         `json:"identity,omitempty"`
+	Auth []ScaleRuleAuth `json:"auth,omitempty"`
+
+	// Identity: The resource ID of a user-assigned managed identity that is assigned to the Container App, or 'system' for
+	// system-assigned identity.
+	Identity *string `json:"identity,omitempty"`
 
 	// Metadata: Metadata properties to describe custom scale rule.
 	Metadata map[string]string `json:"metadata,omitempty"`
@@ -758,8 +779,11 @@ type CustomScaleRule struct {
 // Container App container Http scaling rule.
 type HttpScaleRule struct {
 	// Auth: Authentication secrets for the custom scale rule.
-	Auth     []ScaleRuleAuth `json:"auth,omitempty"`
-	Identity *string         `json:"identity,omitempty"`
+	Auth []ScaleRuleAuth `json:"auth,omitempty"`
+
+	// Identity: The resource ID of a user-assigned managed identity that is assigned to the Container App, or 'system' for
+	// system-assigned identity.
+	Identity *string `json:"identity,omitempty"`
 
 	// Metadata: Metadata properties to describe http scale rule.
 	Metadata map[string]string `json:"metadata,omitempty"`
@@ -799,8 +823,11 @@ type QueueScaleRule struct {
 	AccountName *string `json:"accountName,omitempty"`
 
 	// Auth: Authentication secrets for the queue scale rule.
-	Auth     []ScaleRuleAuth `json:"auth,omitempty"`
-	Identity *string         `json:"identity,omitempty"`
+	Auth []ScaleRuleAuth `json:"auth,omitempty"`
+
+	// Identity: The resource ID of a user-assigned managed identity that is assigned to the Container App, or 'system' for
+	// system-assigned identity.
+	Identity *string `json:"identity,omitempty"`
 
 	// QueueLength: Queue length.
 	QueueLength *int `json:"queueLength,omitempty"`
@@ -812,8 +839,11 @@ type QueueScaleRule struct {
 // Container App container Tcp scaling rule.
 type TcpScaleRule struct {
 	// Auth: Authentication secrets for the tcp scale rule.
-	Auth     []ScaleRuleAuth `json:"auth,omitempty"`
-	Identity *string         `json:"identity,omitempty"`
+	Auth []ScaleRuleAuth `json:"auth,omitempty"`
+
+	// Identity: The resource ID of a user-assigned managed identity that is assigned to the Container App, or 'system' for
+	// system-assigned identity.
+	Identity *string `json:"identity,omitempty"`
 
 	// Metadata: Metadata properties to describe tcp scale rule.
 	Metadata map[string]string `json:"metadata,omitempty"`

--- a/v2/api/app/v1api20250101/arm/job_spec_types_gen.go
+++ b/v2/api/app/v1api20250101/arm/job_spec_types_gen.go
@@ -44,7 +44,9 @@ func (job *Job_Spec) GetType() string {
 type Job_Properties_Spec struct {
 	// Configuration: Container Apps Job configuration properties.
 	Configuration *JobConfiguration `json:"configuration,omitempty"`
-	EnvironmentId *string           `json:"environmentId,omitempty"`
+
+	// EnvironmentId: Resource ID of environment.
+	EnvironmentId *string `json:"environmentId,omitempty"`
 
 	// Template: Container Apps job definition.
 	Template *JobTemplate `json:"template,omitempty"`
@@ -151,8 +153,11 @@ type JobScale struct {
 // Scaling rule.
 type JobScaleRule struct {
 	// Auth: Authentication secrets for the scale rule.
-	Auth     []ScaleRuleAuth `json:"auth,omitempty"`
-	Identity *string         `json:"identity,omitempty"`
+	Auth []ScaleRuleAuth `json:"auth,omitempty"`
+
+	// Identity: The resource ID of a user-assigned managed identity that is assigned to the Container App, or 'system' for
+	// system-assigned identity.
+	Identity *string `json:"identity,omitempty"`
 
 	// Metadata: Metadata properties to describe the scale rule.
 	Metadata map[string]v1.JSON `json:"metadata,omitempty"`

--- a/v2/api/app/v1api20250101/arm/managed_environment_spec_types_gen.go
+++ b/v2/api/app/v1api20250101/arm/managed_environment_spec_types_gen.go
@@ -116,7 +116,10 @@ type ManagedEnvironment_Properties_PeerTrafficConfiguration_Spec struct {
 type VnetConfiguration struct {
 	// DockerBridgeCidr: CIDR notation IP range assigned to the Docker bridge, network. Must not overlap with any other
 	// provided IP ranges.
-	DockerBridgeCidr       *string `json:"dockerBridgeCidr,omitempty"`
+	DockerBridgeCidr *string `json:"dockerBridgeCidr,omitempty"`
+
+	// InfrastructureSubnetId: Resource ID of a subnet for infrastructure components. Must not overlap with any other provided
+	// IP ranges.
 	InfrastructureSubnetId *string `json:"infrastructureSubnetId,omitempty"`
 
 	// Internal: Boolean indicating the environment only has an internal load balancer. These environments do not have a public
@@ -149,6 +152,8 @@ type WorkloadProfile struct {
 
 // Properties for a certificate stored in a Key Vault.
 type CertificateKeyVaultProperties struct {
+	// Identity: Resource ID of a managed identity to authenticate with Azure Key Vault, or System to use a system-assigned
+	// identity.
 	Identity *string `json:"identity,omitempty"`
 
 	// KeyVaultUrl: URL pointing to the Azure Key Vault secret that holds the certificate.

--- a/v2/api/authorization/v1api20200801preview/arm/role_assignment_spec_types_gen.go
+++ b/v2/api/authorization/v1api20200801preview/arm/role_assignment_spec_types_gen.go
@@ -37,7 +37,9 @@ type RoleAssignmentProperties struct {
 	Condition *string `json:"condition,omitempty"`
 
 	// ConditionVersion: Version of the condition. Currently accepted value is '2.0'
-	ConditionVersion                   *string `json:"conditionVersion,omitempty"`
+	ConditionVersion *string `json:"conditionVersion,omitempty"`
+
+	// DelegatedManagedIdentityResourceId: Id of the delegated managed identity resource
 	DelegatedManagedIdentityResourceId *string `json:"delegatedManagedIdentityResourceId,omitempty"`
 
 	// Description: Description of role assignment
@@ -47,8 +49,10 @@ type RoleAssignmentProperties struct {
 	PrincipalId *string `json:"principalId,omitempty" optionalConfigMapPair:"PrincipalId"`
 
 	// PrincipalType: The principal type of the assigned principal ID.
-	PrincipalType    *RoleAssignmentProperties_PrincipalType `json:"principalType,omitempty"`
-	RoleDefinitionId *string                                 `json:"roleDefinitionId,omitempty"`
+	PrincipalType *RoleAssignmentProperties_PrincipalType `json:"principalType,omitempty"`
+
+	// RoleDefinitionId: The role definition ID.
+	RoleDefinitionId *string `json:"roleDefinitionId,omitempty"`
 }
 
 // +kubebuilder:validation:Enum={"ForeignGroup","Group","ServicePrincipal","User"}

--- a/v2/api/authorization/v1api20220401/arm/role_assignment_spec_types_gen.go
+++ b/v2/api/authorization/v1api20220401/arm/role_assignment_spec_types_gen.go
@@ -37,7 +37,9 @@ type RoleAssignmentProperties struct {
 	Condition *string `json:"condition,omitempty"`
 
 	// ConditionVersion: Version of the condition. Currently the only accepted value is '2.0'
-	ConditionVersion                   *string `json:"conditionVersion,omitempty"`
+	ConditionVersion *string `json:"conditionVersion,omitempty"`
+
+	// DelegatedManagedIdentityResourceId: Id of the delegated managed identity resource
 	DelegatedManagedIdentityResourceId *string `json:"delegatedManagedIdentityResourceId,omitempty"`
 
 	// Description: Description of role assignment
@@ -47,8 +49,10 @@ type RoleAssignmentProperties struct {
 	PrincipalId *string `json:"principalId,omitempty" optionalConfigMapPair:"PrincipalId"`
 
 	// PrincipalType: The principal type of the assigned principal ID.
-	PrincipalType    *RoleAssignmentProperties_PrincipalType `json:"principalType,omitempty"`
-	RoleDefinitionId *string                                 `json:"roleDefinitionId,omitempty"`
+	PrincipalType *RoleAssignmentProperties_PrincipalType `json:"principalType,omitempty"`
+
+	// RoleDefinitionId: The role definition ID.
+	RoleDefinitionId *string `json:"roleDefinitionId,omitempty"`
 }
 
 // +kubebuilder:validation:Enum={"Device","ForeignGroup","Group","ServicePrincipal","User"}

--- a/v2/api/authorization/v1api20220401/arm/role_definition_spec_types_gen.go
+++ b/v2/api/authorization/v1api20220401/arm/role_definition_spec_types_gen.go
@@ -31,6 +31,7 @@ func (definition *RoleDefinition_Spec) GetType() string {
 
 // Role definition properties.
 type RoleDefinitionProperties struct {
+	// AssignableScopes: Role definition assignable scopes.
 	AssignableScopes []string `json:"assignableScopes,omitempty"`
 
 	// Description: The role definition description.

--- a/v2/api/batch/v1api20210101/arm/batch_account_spec_types_gen.go
+++ b/v2/api/batch/v1api20210101/arm/batch_account_spec_types_gen.go
@@ -68,6 +68,7 @@ type BatchAccountIdentity struct {
 
 // The properties related to the auto-storage account.
 type AutoStorageBaseProperties struct {
+	// StorageAccountId: The resource ID of the storage account to be used for auto-storage account.
 	StorageAccountId *string `json:"storageAccountId,omitempty"`
 }
 
@@ -99,6 +100,7 @@ type EncryptionProperties struct {
 
 // Identifies the Azure key vault associated with a Batch account.
 type KeyVaultReference struct {
+	// Id: The resource ID of the Azure key vault associated with the Batch account.
 	Id *string `json:"id,omitempty"`
 
 	// Url: The URL of the Azure key vault associated with the Batch account.

--- a/v2/api/cache/v1api20201201/arm/redis_linked_server_spec_types_gen.go
+++ b/v2/api/cache/v1api20201201/arm/redis_linked_server_spec_types_gen.go
@@ -31,6 +31,7 @@ func (server *RedisLinkedServer_Spec) GetType() string {
 
 // Create properties for a linked server
 type RedisLinkedServerCreateProperties struct {
+	// LinkedRedisCacheId: Fully qualified resourceId of the linked redis cache.
 	LinkedRedisCacheId *string `json:"linkedRedisCacheId,omitempty"`
 
 	// LinkedRedisCacheLocation: Location of the linked redis cache.

--- a/v2/api/cache/v1api20201201/arm/redis_spec_types_gen.go
+++ b/v2/api/cache/v1api20201201/arm/redis_spec_types_gen.go
@@ -76,6 +76,9 @@ type RedisCreateProperties struct {
 	// StaticIP: Static IP address. Optionally, may be specified when deploying a Redis cache inside an existing Azure Virtual
 	// Network; auto assigned by default.
 	StaticIP *string `json:"staticIP,omitempty"`
+
+	// SubnetId: The full resource ID of a subnet in a virtual network to deploy the Redis cache in. Example format:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/Microsoft.{Network|ClassicNetwork}/VirtualNetworks/vnet1/subnets/subnet1
 	SubnetId *string `json:"subnetId,omitempty"`
 
 	// TenantSettings: A dictionary of tenant settings

--- a/v2/api/cache/v1api20230401/arm/redis_linked_server_spec_types_gen.go
+++ b/v2/api/cache/v1api20230401/arm/redis_linked_server_spec_types_gen.go
@@ -31,6 +31,7 @@ func (server *RedisLinkedServer_Spec) GetType() string {
 
 // Create properties for a linked server
 type RedisLinkedServerCreateProperties struct {
+	// LinkedRedisCacheId: Fully qualified resourceId of the linked redis cache.
 	LinkedRedisCacheId *string `json:"linkedRedisCacheId,omitempty"`
 
 	// LinkedRedisCacheLocation: Location of the linked redis cache.

--- a/v2/api/cache/v1api20230401/arm/redis_spec_types_gen.go
+++ b/v2/api/cache/v1api20230401/arm/redis_spec_types_gen.go
@@ -87,6 +87,9 @@ type RedisCreateProperties struct {
 	// StaticIP: Static IP address. Optionally, may be specified when deploying a Redis cache inside an existing Azure Virtual
 	// Network; auto assigned by default.
 	StaticIP *string `json:"staticIP,omitempty"`
+
+	// SubnetId: The full resource ID of a subnet in a virtual network to deploy the Redis cache in. Example format:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/Microsoft.{Network|ClassicNetwork}/VirtualNetworks/vnet1/subnets/subnet1
 	SubnetId *string `json:"subnetId,omitempty"`
 
 	// TenantSettings: A dictionary of tenant settings

--- a/v2/api/cache/v1api20230701/arm/redis_enterprise_database_spec_types_gen.go
+++ b/v2/api/cache/v1api20230701/arm/redis_enterprise_database_spec_types_gen.go
@@ -142,6 +142,7 @@ type Persistence struct {
 
 // Specifies details of a linked database resource.
 type LinkedDatabase struct {
+	// Id: Resource ID of a database resource to link with this database.
 	Id *string `json:"id,omitempty"`
 }
 

--- a/v2/api/cache/v1api20230801/arm/redis_linked_server_spec_types_gen.go
+++ b/v2/api/cache/v1api20230801/arm/redis_linked_server_spec_types_gen.go
@@ -31,6 +31,7 @@ func (server *RedisLinkedServer_Spec) GetType() string {
 
 // Create properties for a linked server
 type RedisLinkedServerCreateProperties struct {
+	// LinkedRedisCacheId: Fully qualified resourceId of the linked redis cache.
 	LinkedRedisCacheId *string `json:"linkedRedisCacheId,omitempty"`
 
 	// LinkedRedisCacheLocation: Location of the linked redis cache.

--- a/v2/api/cache/v1api20230801/arm/redis_spec_types_gen.go
+++ b/v2/api/cache/v1api20230801/arm/redis_spec_types_gen.go
@@ -86,6 +86,9 @@ type RedisCreateProperties struct {
 	// StaticIP: Static IP address. Optionally, may be specified when deploying a Redis cache inside an existing Azure Virtual
 	// Network; auto assigned by default.
 	StaticIP *string `json:"staticIP,omitempty"`
+
+	// SubnetId: The full resource ID of a subnet in a virtual network to deploy the Redis cache in. Example format:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/Microsoft.{Network|ClassicNetwork}/VirtualNetworks/vnet1/subnets/subnet1
 	SubnetId *string `json:"subnetId,omitempty"`
 
 	// TenantSettings: A dictionary of tenant settings

--- a/v2/api/cache/v1api20250401/arm/redis_enterprise_database_spec_types_gen.go
+++ b/v2/api/cache/v1api20250401/arm/redis_enterprise_database_spec_types_gen.go
@@ -180,6 +180,7 @@ type Persistence struct {
 
 // Specifies details of a linked database resource.
 type LinkedDatabase struct {
+	// Id: Resource ID of a database resource to link with this database.
 	Id *string `json:"id,omitempty"`
 }
 

--- a/v2/api/cache/v1api20250401/arm/redis_enterprise_spec_types_gen.go
+++ b/v2/api/cache/v1api20250401/arm/redis_enterprise_spec_types_gen.go
@@ -286,8 +286,12 @@ type ClusterProperties_Encryption_CustomerManagedKeyEncryption struct {
 
 type ClusterProperties_Encryption_CustomerManagedKeyEncryption_KeyEncryptionKeyIdentity struct {
 	// IdentityType: Only userAssignedIdentity is supported in this API version; other types may be supported in the future
-	IdentityType                   *ClusterProperties_Encryption_CustomerManagedKeyEncryption_KeyEncryptionKeyIdentity_IdentityType `json:"identityType,omitempty"`
-	UserAssignedIdentityResourceId *string                                                                                          `json:"userAssignedIdentityResourceId,omitempty"`
+	IdentityType *ClusterProperties_Encryption_CustomerManagedKeyEncryption_KeyEncryptionKeyIdentity_IdentityType `json:"identityType,omitempty"`
+
+	// UserAssignedIdentityResourceId: User assigned identity to use for accessing key encryption key Url. Ex:
+	// /subscriptions/<sub uuid>/resourceGroups/<resource
+	// group>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myId.
+	UserAssignedIdentityResourceId *string `json:"userAssignedIdentityResourceId,omitempty"`
 }
 
 // +kubebuilder:validation:Enum={"systemAssignedIdentity","userAssignedIdentity"}

--- a/v2/api/cdn/v1api20210601/arm/profiles_endpoint_spec_types_gen.go
+++ b/v2/api/cdn/v1api20210601/arm/profiles_endpoint_spec_types_gen.go
@@ -130,6 +130,7 @@ type EndpointProperties_DeliveryPolicy struct {
 }
 
 type EndpointProperties_WebApplicationFirewallPolicyLink struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
@@ -189,6 +190,7 @@ var queryStringCachingBehavior_Values = map[string]QueryStringCachingBehavior{
 
 // Reference to another resource.
 type ResourceReference struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
@@ -250,8 +252,13 @@ type DeepCreatedOriginProperties struct {
 
 	// PrivateLinkApprovalMessage: A custom message to be included in the approval request to connect to the Private Link.
 	PrivateLinkApprovalMessage *string `json:"privateLinkApprovalMessage,omitempty"`
-	PrivateLinkLocation        *string `json:"privateLinkLocation,omitempty"`
-	PrivateLinkResourceId      *string `json:"privateLinkResourceId,omitempty"`
+
+	// PrivateLinkLocation: The location of the Private Link resource. Required only if 'privateLinkResourceId' is populated
+	PrivateLinkLocation *string `json:"privateLinkLocation,omitempty"`
+
+	// PrivateLinkResourceId: The Resource Id of the Private Link resource. Populating this optional field indicates that this
+	// backend is 'Private'
+	PrivateLinkResourceId *string `json:"privateLinkResourceId,omitempty"`
 
 	// Weight: Weight of the origin in given origin group for load balancing. Must be between 1 and 1000
 	Weight *int `json:"weight,omitempty"`

--- a/v2/api/cdn/v1api20230501/arm/afd_custom_domain_spec_types_gen.go
+++ b/v2/api/cdn/v1api20230501/arm/afd_custom_domain_spec_types_gen.go
@@ -63,6 +63,7 @@ type AFDDomainHttpsParameters struct {
 
 // Reference to another resource.
 type ResourceReference struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 

--- a/v2/api/cdn/v1api20230501/arm/route_spec_types_gen.go
+++ b/v2/api/cdn/v1api20230501/arm/route_spec_types_gen.go
@@ -70,6 +70,7 @@ type RouteProperties struct {
 
 // Reference to another resource along with its state.
 type ActivatedResourceReference struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 

--- a/v2/api/cognitiveservices/v1api20250601/arm/account_spec_types_gen.go
+++ b/v2/api/cognitiveservices/v1api20250601/arm/account_spec_types_gen.go
@@ -219,8 +219,10 @@ type MultiRegionSettings struct {
 type NetworkInjections struct {
 	// Scenario: Specifies what features in AI Foundry network injection applies to. Currently only supports 'agent' for agent
 	// scenarios. 'none' means no network injection.
-	Scenario    *NetworkInjections_Scenario `json:"scenario,omitempty"`
-	SubnetArmId *string                     `json:"subnetArmId,omitempty"`
+	Scenario *NetworkInjections_Scenario `json:"scenario,omitempty"`
+
+	// SubnetArmId: Specify the subnet for which your Agent Client is injected into.
+	SubnetArmId *string `json:"subnetArmId,omitempty"`
 
 	// UseMicrosoftManagedNetwork: Boolean to enable Microsoft Managed Network for subnet delegation
 	UseMicrosoftManagedNetwork *bool `json:"useMicrosoftManagedNetwork,omitempty"`
@@ -244,6 +246,7 @@ type NetworkRuleSet struct {
 
 // Cognitive Services Rai Monitor Config.
 type RaiMonitorConfig struct {
+	// AdxStorageResourceId: The storage resource Id.
 	AdxStorageResourceId *string `json:"adxStorageResourceId,omitempty"`
 
 	// IdentityClientId: The identity client Id to access the storage.
@@ -278,13 +281,17 @@ type UserAssignedIdentityDetails struct {
 type UserOwnedAmlWorkspace struct {
 	// IdentityClientId: Identity Client id of a AML account resource.
 	IdentityClientId *string `json:"identityClientId,omitempty"`
-	ResourceId       *string `json:"resourceId,omitempty"`
+
+	// ResourceId: Full resource id of a AML account resource.
+	ResourceId *string `json:"resourceId,omitempty"`
 }
 
 // The user owned storage for Cognitive Services account.
 type UserOwnedStorage struct {
 	IdentityClientId *string `json:"identityClientId,omitempty"`
-	ResourceId       *string `json:"resourceId,omitempty"`
+
+	// ResourceId: Full resource id of a Microsoft.Storage resource.
+	ResourceId *string `json:"resourceId,omitempty"`
 }
 
 // +kubebuilder:validation:Enum={"Microsoft.CognitiveServices","Microsoft.KeyVault"}
@@ -394,6 +401,8 @@ type RegionSetting struct {
 
 // A rule governing the accessibility from a specific virtual network.
 type VirtualNetworkRule struct {
+	// Id: Full resource id of a vnet subnet, such as
+	// '/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/subnet1'.
 	Id *string `json:"id,omitempty"`
 
 	// IgnoreMissingVnetServiceEndpoint: Ignore missing vnet service endpoint or not.

--- a/v2/api/cognitiveservices/v1api20250601/arm/deployment_spec_types_gen.go
+++ b/v2/api/cognitiveservices/v1api20250601/arm/deployment_spec_types_gen.go
@@ -79,8 +79,12 @@ type DeploymentModel struct {
 	Name *string `json:"name,omitempty" optionalConfigMapPair:"Name"`
 
 	// Publisher: Deployment model publisher.
-	Publisher     *string `json:"publisher,omitempty" optionalConfigMapPair:"Publisher"`
-	Source        *string `json:"source,omitempty"`
+	Publisher *string `json:"publisher,omitempty" optionalConfigMapPair:"Publisher"`
+
+	// Source: Optional. Deployment model source ARM resource ID.
+	Source *string `json:"source,omitempty"`
+
+	// SourceAccount: Optional. Source of the model, another Microsoft.CognitiveServices accounts ARM resource ID.
 	SourceAccount *string `json:"sourceAccount,omitempty"`
 
 	// Version: Optional. Deployment model version. If version is not specified, a default version will be assigned. The

--- a/v2/api/compute/v1api20200930/arm/disk_spec_types_gen.go
+++ b/v2/api/compute/v1api20200930/arm/disk_spec_types_gen.go
@@ -51,7 +51,9 @@ type DiskProperties struct {
 
 	// CreationData: Disk source information. CreationData information cannot be changed after the disk has been created.
 	CreationData *CreationData `json:"creationData,omitempty"`
-	DiskAccessId *string       `json:"diskAccessId,omitempty"`
+
+	// DiskAccessId: ARM id of the DiskAccess resource for using private endpoints on disks.
+	DiskAccessId *string `json:"diskAccessId,omitempty"`
 
 	// DiskIOPSReadOnly: The total number of IOPS that will be allowed across all VMs mounting the shared disk as ReadOnly. One
 	// operation can transfer between 4k and 256k bytes.
@@ -131,8 +133,10 @@ type CreationData struct {
 	ImageReference *ImageDiskReference `json:"imageReference,omitempty"`
 
 	// LogicalSectorSize: Logical sector size in bytes for Ultra disks. Supported values are 512 ad 4096. 4096 is the default.
-	LogicalSectorSize *int    `json:"logicalSectorSize,omitempty"`
-	SourceResourceId  *string `json:"sourceResourceId,omitempty"`
+	LogicalSectorSize *int `json:"logicalSectorSize,omitempty"`
+
+	// SourceResourceId: If createOption is Copy, this is the ARM id of the source snapshot or disk.
+	SourceResourceId *string `json:"sourceResourceId,omitempty"`
 
 	// SourceUri: If createOption is Import, this is the URI of a blob to be imported into a managed disk.
 	SourceUri *string `json:"sourceUri,omitempty"`
@@ -195,6 +199,7 @@ var diskSku_Name_Values = map[string]DiskSku_Name{
 
 // Encryption at rest settings for disk or snapshot
 type Encryption struct {
+	// DiskEncryptionSetId: ResourceId of the disk encryption set to use for enabling encryption at rest.
 	DiskEncryptionSetId *string `json:"diskEncryptionSetId,omitempty"`
 
 	// Type: The type of key used to encrypt the data of the disk.
@@ -313,6 +318,7 @@ var encryptionType_Values = map[string]EncryptionType{
 
 // The source image used for creating the disk.
 type ImageDiskReference struct {
+	// Id: A relative uri containing either a Platform Image Repository or user image reference.
 	Id *string `json:"id,omitempty"`
 
 	// Lun: If the disk is created from an image's data disk, this is an index that indicates which of the data disks in the
@@ -341,5 +347,6 @@ type KeyVaultAndSecretReference struct {
 // The vault id is an Azure Resource Manager Resource id in the form
 // /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{vaultName}
 type SourceVault struct {
+	// Id: Resource Id
 	Id *string `json:"id,omitempty"`
 }

--- a/v2/api/compute/v1api20200930/arm/snapshot_spec_types_gen.go
+++ b/v2/api/compute/v1api20200930/arm/snapshot_spec_types_gen.go
@@ -45,7 +45,9 @@ func (snapshot *Snapshot_Spec) GetType() string {
 type SnapshotProperties struct {
 	// CreationData: Disk source information. CreationData information cannot be changed after the disk has been created.
 	CreationData *CreationData `json:"creationData,omitempty"`
-	DiskAccessId *string       `json:"diskAccessId,omitempty"`
+
+	// DiskAccessId: ARM id of the DiskAccess resource for using private endpoints on disks.
+	DiskAccessId *string `json:"diskAccessId,omitempty"`
 
 	// DiskSizeGB: If creationData.createOption is Empty, this field is mandatory and it indicates the size of the disk to
 	// create. If this field is present for updates or creation with other options, it indicates a resize. Resizes are only

--- a/v2/api/compute/v1api20201201/arm/virtual_machine_scale_set_spec_types_gen.go
+++ b/v2/api/compute/v1api20201201/arm/virtual_machine_scale_set_spec_types_gen.go
@@ -221,6 +221,7 @@ type ScaleInPolicy struct {
 }
 
 type SubResource struct {
+	// Id: Resource Id
 	Id *string `json:"id,omitempty"`
 }
 
@@ -497,6 +498,7 @@ type VirtualMachineScaleSetStorageProfile struct {
 
 // The API entity reference.
 type ApiEntityReference struct {
+	// Id: The ARM resource id in the form of /subscriptions/{SubscriptionId}/resourceGroups/{ResourceGroupName}/...
 	Id *string `json:"id,omitempty"`
 }
 
@@ -561,6 +563,7 @@ type VirtualMachineScaleSetExtension struct {
 
 // Describes a virtual machine scale set network profile's network configurations.
 type VirtualMachineScaleSetNetworkConfiguration struct {
+	// Id: Resource Id
 	Id *string `json:"id,omitempty"`
 
 	// Name: The network configuration name.
@@ -668,6 +671,7 @@ var virtualMachineScaleSetOSDisk_OsType_Values = map[string]VirtualMachineScaleS
 
 // Describes a virtual machine scale set network profile's IP configuration.
 type VirtualMachineScaleSetIPConfiguration struct {
+	// Id: Resource Id
 	Id *string `json:"id,omitempty"`
 
 	// Name: The IP configuration name.

--- a/v2/api/compute/v1api20201201/arm/virtual_machine_spec_types_gen.go
+++ b/v2/api/compute/v1api20201201/arm/virtual_machine_spec_types_gen.go
@@ -450,6 +450,7 @@ type DataDisk struct {
 // machine image, but is not used in other creation operations. NOTE: Image reference publisher and offer can only be set
 // when you create the scale set.
 type ImageReference struct {
+	// Id: Resource Id
 	Id *string `json:"id,omitempty"`
 
 	// Offer: Specifies the offer of the platform image or marketplace image used to create the virtual machine.
@@ -492,6 +493,7 @@ type LinuxConfiguration struct {
 
 // Describes a network interface reference.
 type NetworkInterfaceReference struct {
+	// Id: Resource Id
 	Id *string `json:"id,omitempty"`
 
 	// Properties: Describes a network interface reference properties.
@@ -745,7 +747,9 @@ type LinuxPatchSettings struct {
 type ManagedDiskParameters struct {
 	// DiskEncryptionSet: Specifies the customer managed disk encryption set resource id for the managed disk.
 	DiskEncryptionSet *SubResource `json:"diskEncryptionSet,omitempty"`
-	Id                *string      `json:"id,omitempty"`
+
+	// Id: Resource Id
+	Id *string `json:"id,omitempty"`
 
 	// StorageAccountType: Specifies the storage account type for the managed disk. Managed OS disk storage account type can
 	// only be set when you create the scale set. NOTE: UltraSSD_LRS can only be used with data disks, it cannot be used with

--- a/v2/api/compute/v1api20210701/arm/image_spec_types_gen.go
+++ b/v2/api/compute/v1api20210701/arm/image_spec_types_gen.go
@@ -105,6 +105,7 @@ type ImageStorageProfile struct {
 }
 
 type SubResource struct {
+	// Id: Resource Id
 	Id *string `json:"id,omitempty"`
 }
 

--- a/v2/api/compute/v1api20220301/arm/image_spec_types_gen.go
+++ b/v2/api/compute/v1api20220301/arm/image_spec_types_gen.go
@@ -105,6 +105,7 @@ type ImageStorageProfile struct {
 }
 
 type SubResource struct {
+	// Id: Resource Id
 	Id *string `json:"id,omitempty"`
 }
 

--- a/v2/api/compute/v1api20220301/arm/virtual_machine_scale_set_spec_types_gen.go
+++ b/v2/api/compute/v1api20220301/arm/virtual_machine_scale_set_spec_types_gen.go
@@ -545,6 +545,7 @@ type VirtualMachineScaleSetStorageProfile struct {
 
 // The API entity reference.
 type ApiEntityReference struct {
+	// Id: The ARM resource id in the form of /subscriptions/{SubscriptionId}/resourceGroups/{ResourceGroupName}/...
 	Id *string `json:"id,omitempty"`
 }
 
@@ -607,6 +608,7 @@ type VirtualMachineScaleSetExtension struct {
 
 // Describes a virtual machine scale set network profile's network configurations.
 type VirtualMachineScaleSetNetworkConfiguration struct {
+	// Id: Resource Id
 	Id *string `json:"id,omitempty"`
 
 	// Name: The network configuration name.
@@ -739,6 +741,7 @@ var virtualMachineScaleSetOSDisk_OsType_Values = map[string]VirtualMachineScaleS
 
 // Describes a virtual machine scale set network profile's IP configuration.
 type VirtualMachineScaleSetIPConfiguration struct {
+	// Id: Resource Id
 	Id *string `json:"id,omitempty"`
 
 	// Name: The IP configuration name.

--- a/v2/api/compute/v1api20220301/arm/virtual_machine_spec_types_gen.go
+++ b/v2/api/compute/v1api20220301/arm/virtual_machine_spec_types_gen.go
@@ -504,7 +504,9 @@ type ImageReference struct {
 	// CommunityGalleryImageId: Specified the community gallery image unique id for vm deployment. This can be fetched from
 	// community gallery image GET call.
 	CommunityGalleryImageId *string `json:"communityGalleryImageId,omitempty"`
-	Id                      *string `json:"id,omitempty"`
+
+	// Id: Resource Id
+	Id *string `json:"id,omitempty"`
 
 	// Offer: Specifies the offer of the platform image or marketplace image used to create the virtual machine.
 	Offer *string `json:"offer,omitempty"`
@@ -552,6 +554,7 @@ type LinuxConfiguration struct {
 
 // Describes a network interface reference.
 type NetworkInterfaceReference struct {
+	// Id: Resource Id
 	Id *string `json:"id,omitempty"`
 
 	// Properties: Describes a network interface reference properties.
@@ -699,7 +702,10 @@ type VMGalleryApplication struct {
 	EnableAutomaticUpgrade *bool `json:"enableAutomaticUpgrade,omitempty"`
 
 	// Order: Optional, Specifies the order in which the packages have to be installed
-	Order              *int    `json:"order,omitempty"`
+	Order *int `json:"order,omitempty"`
+
+	// PackageReferenceId: Specifies the GalleryApplicationVersion resource id on the form of
+	// /subscriptions/{SubscriptionId}/resourceGroups/{ResourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/applications/{application}/versions/{version}
 	PackageReferenceId *string `json:"packageReferenceId,omitempty"`
 
 	// Tags: Optional, Specifies a passthrough value for more generic context.
@@ -914,7 +920,9 @@ type LinuxPatchSettings struct {
 type ManagedDiskParameters struct {
 	// DiskEncryptionSet: Specifies the customer managed disk encryption set resource id for the managed disk.
 	DiskEncryptionSet *SubResource `json:"diskEncryptionSet,omitempty"`
-	Id                *string      `json:"id,omitempty"`
+
+	// Id: Resource Id
+	Id *string `json:"id,omitempty"`
 
 	// SecurityProfile: Specifies the security profile for the managed disk.
 	SecurityProfile *VMDiskSecurityProfile `json:"securityProfile,omitempty"`

--- a/v2/api/compute/v1api20220702/arm/disk_encryption_set_spec_types_gen.go
+++ b/v2/api/compute/v1api20220702/arm/disk_encryption_set_spec_types_gen.go
@@ -115,5 +115,6 @@ type UserAssignedIdentityDetails struct {
 // The vault id is an Azure Resource Manager Resource id in the form
 // /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{vaultName}
 type SourceVault struct {
+	// Id: Resource Id
 	Id *string `json:"id,omitempty"`
 }

--- a/v2/api/compute/v1api20240302/arm/disk_encryption_set_spec_types_gen.go
+++ b/v2/api/compute/v1api20240302/arm/disk_encryption_set_spec_types_gen.go
@@ -115,5 +115,6 @@ type UserAssignedIdentityDetails struct {
 // The vault id is an Azure Resource Manager Resource id in the form
 // /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{vaultName}
 type SourceVault struct {
+	// Id: Resource Id
 	Id *string `json:"id,omitempty"`
 }

--- a/v2/api/compute/v1api20240302/arm/disk_spec_types_gen.go
+++ b/v2/api/compute/v1api20240302/arm/disk_spec_types_gen.go
@@ -58,7 +58,9 @@ type DiskProperties struct {
 
 	// DataAccessAuthMode: Additional authentication requirements when exporting or uploading to a disk or snapshot.
 	DataAccessAuthMode *DataAccessAuthMode `json:"dataAccessAuthMode,omitempty"`
-	DiskAccessId       *string             `json:"diskAccessId,omitempty"`
+
+	// DiskAccessId: ARM id of the DiskAccess resource for using private endpoints on disks.
+	DiskAccessId *string `json:"diskAccessId,omitempty"`
 
 	// DiskIOPSReadOnly: The total number of IOPS that will be allowed across all VMs mounting the shared disk as ReadOnly. One
 	// operation can transfer between 4k and 256k bytes.
@@ -138,8 +140,11 @@ type DiskSku struct {
 // Data used when creating a disk.
 type CreationData struct {
 	// CreateOption: This enumerates the possible sources of a disk's creation.
-	CreateOption         *CreationData_CreateOption `json:"createOption,omitempty"`
-	ElasticSanResourceId *string                    `json:"elasticSanResourceId,omitempty"`
+	CreateOption *CreationData_CreateOption `json:"createOption,omitempty"`
+
+	// ElasticSanResourceId: Required if createOption is CopyFromSanSnapshot. This is the ARM id of the source elastic san
+	// volume snapshot.
+	ElasticSanResourceId *string `json:"elasticSanResourceId,omitempty"`
 
 	// GalleryImageReference: Required if creating from a Gallery Image. The id/sharedGalleryImageId/communityGalleryImageId of
 	// the ImageDiskReference will be the ARM id of the shared galley image version from which to create a disk.
@@ -160,7 +165,9 @@ type CreationData struct {
 	ProvisionedBandwidthCopySpeed *CreationData_ProvisionedBandwidthCopySpeed `json:"provisionedBandwidthCopySpeed,omitempty"`
 
 	// SecurityDataUri: If createOption is ImportSecure, this is the URI of a blob to be imported into VM guest state.
-	SecurityDataUri  *string `json:"securityDataUri,omitempty"`
+	SecurityDataUri *string `json:"securityDataUri,omitempty"`
+
+	// SourceResourceId: If createOption is Copy, this is the ARM id of the source snapshot or disk.
 	SourceResourceId *string `json:"sourceResourceId,omitempty"`
 
 	// SourceUri: If createOption is Import, this is the URI of a blob to be imported into a managed disk.
@@ -221,6 +228,8 @@ var diskProperties_OsType_Values = map[string]DiskProperties_OsType{
 
 // Contains the security related information for the resource.
 type DiskSecurityProfile struct {
+	// SecureVMDiskEncryptionSetId: ResourceId of the disk encryption set associated to Confidential VM supported disk
+	// encrypted with customer managed key
 	SecureVMDiskEncryptionSetId *string `json:"secureVMDiskEncryptionSetId,omitempty"`
 
 	// SecurityType: Specifies the SecurityType of the VM. Applicable for OS disks only.
@@ -253,6 +262,7 @@ var diskSku_Name_Values = map[string]DiskSku_Name{
 
 // Encryption at rest settings for disk or snapshot
 type Encryption struct {
+	// DiskEncryptionSetId: ResourceId of the disk encryption set to use for enabling encryption at rest.
 	DiskEncryptionSetId *string `json:"diskEncryptionSetId,omitempty"`
 
 	// Type: The type of key used to encrypt the data of the disk.
@@ -432,7 +442,9 @@ var encryptionType_Values = map[string]EncryptionType{
 type ImageDiskReference struct {
 	// CommunityGalleryImageId: A relative uri containing a community Azure Compute Gallery image reference.
 	CommunityGalleryImageId *string `json:"communityGalleryImageId,omitempty"`
-	Id                      *string `json:"id,omitempty"`
+
+	// Id: A relative uri containing either a Platform Image Repository, user image, or Azure Compute Gallery image reference.
+	Id *string `json:"id,omitempty"`
 
 	// Lun: If the disk is created from an image's data disk, this is an index that indicates which of the data disks in the
 	// image to use. For OS disks, this field is null.

--- a/v2/api/compute/v1api20240302/arm/snapshot_spec_types_gen.go
+++ b/v2/api/compute/v1api20240302/arm/snapshot_spec_types_gen.go
@@ -55,7 +55,9 @@ type SnapshotProperties struct {
 
 	// DataAccessAuthMode: Additional authentication requirements when exporting or uploading to a disk or snapshot.
 	DataAccessAuthMode *DataAccessAuthMode `json:"dataAccessAuthMode,omitempty"`
-	DiskAccessId       *string             `json:"diskAccessId,omitempty"`
+
+	// DiskAccessId: ARM id of the DiskAccess resource for using private endpoints on disks.
+	DiskAccessId *string `json:"diskAccessId,omitempty"`
 
 	// DiskSizeGB: If creationData.createOption is Empty, this field is mandatory and it indicates the size of the disk to
 	// create. If this field is present for updates or creation with other options, it indicates a resize. Resizes are only

--- a/v2/api/compute/v1api20241101/arm/availability_set_spec_types_gen.go
+++ b/v2/api/compute/v1api20241101/arm/availability_set_spec_types_gen.go
@@ -88,6 +88,7 @@ type ScheduledEventsPolicy struct {
 }
 
 type SubResource struct {
+	// Id: Resource Id
 	Id *string `json:"id,omitempty"`
 }
 

--- a/v2/api/containerinstance/v1api20211001/arm/container_group_spec_types_gen.go
+++ b/v2/api/containerinstance/v1api20211001/arm/container_group_spec_types_gen.go
@@ -173,6 +173,7 @@ var containerGroupSku_Values = map[string]ContainerGroupSku{
 
 // Container group subnet information.
 type ContainerGroupSubnetId struct {
+	// Id: Resource ID of virtual network and subnet.
 	Id *string `json:"id,omitempty"`
 
 	// Name: Friendly name for the subnet.
@@ -393,7 +394,9 @@ type LogAnalytics struct {
 	WorkspaceId *string `json:"workspaceId,omitempty"`
 
 	// WorkspaceKey: The workspace key for log analytics
-	WorkspaceKey        *string `json:"workspaceKey,omitempty"`
+	WorkspaceKey *string `json:"workspaceKey,omitempty"`
+
+	// WorkspaceResourceId: The workspace resource id for log analytics
 	WorkspaceResourceId *string `json:"workspaceResourceId,omitempty"`
 }
 

--- a/v2/api/containerservice/v1api20210501/arm/managed_clusters_agent_pool_spec_types_gen.go
+++ b/v2/api/containerservice/v1api20210501/arm/managed_clusters_agent_pool_spec_types_gen.go
@@ -88,8 +88,11 @@ type ManagedClusterAgentPoolProfileProperties struct {
 	Mode *AgentPoolMode `json:"mode,omitempty"`
 
 	// NodeLabels: The node labels to be persisted across all nodes in agent pool.
-	NodeLabels           map[string]string `json:"nodeLabels" serializationType:"explicitEmptyCollection"`
-	NodePublicIPPrefixID *string           `json:"nodePublicIPPrefixID,omitempty"`
+	NodeLabels map[string]string `json:"nodeLabels" serializationType:"explicitEmptyCollection"`
+
+	// NodePublicIPPrefixID: This is of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}
+	NodePublicIPPrefixID *string `json:"nodePublicIPPrefixID,omitempty"`
 
 	// NodeTaints: The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule.
 	NodeTaints []string `json:"nodeTaints" serializationType:"explicitEmptyCollection"`
@@ -111,7 +114,11 @@ type ManagedClusterAgentPoolProfileProperties struct {
 	OsSKU *OSSKU `json:"osSKU,omitempty"`
 
 	// OsType: The operating system type. The default is Linux.
-	OsType      *OSType `json:"osType,omitempty"`
+	OsType *OSType `json:"osType,omitempty"`
+
+	// PodSubnetID: If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is
+	// of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
 	PodSubnetID *string `json:"podSubnetID,omitempty"`
 
 	// ProximityPlacementGroupID: The ID for Proximity Placement Group.
@@ -141,7 +148,11 @@ type ManagedClusterAgentPoolProfileProperties struct {
 	// VmSize: VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods
 	// might fail to run correctly. For more details on restricted VM sizes, see:
 	// https://docs.microsoft.com/azure/aks/quotas-skus-regions
-	VmSize       *string `json:"vmSize,omitempty"`
+	VmSize *string `json:"vmSize,omitempty"`
+
+	// VnetSubnetID: If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified,
+	// this applies to nodes and pods, otherwise it applies to just nodes. This is of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
 	VnetSubnetID *string `json:"vnetSubnetID,omitempty"`
 }
 

--- a/v2/api/containerservice/v1api20230201/arm/managed_clusters_agent_pool_spec_types_gen.go
+++ b/v2/api/containerservice/v1api20230201/arm/managed_clusters_agent_pool_spec_types_gen.go
@@ -67,7 +67,11 @@ type ManagedClusterAgentPoolProfileProperties struct {
 
 	// GpuInstanceProfile: GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU.
 	GpuInstanceProfile *GPUInstanceProfile `json:"gpuInstanceProfile,omitempty"`
-	HostGroupID        *string             `json:"hostGroupID,omitempty"`
+
+	// HostGroupID: This is of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}.
+	// For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts).
+	HostGroupID *string `json:"hostGroupID,omitempty"`
 
 	// KubeletConfig: The Kubelet configuration on the agent pool nodes.
 	KubeletConfig *KubeletConfig `json:"kubeletConfig,omitempty"`
@@ -93,8 +97,11 @@ type ManagedClusterAgentPoolProfileProperties struct {
 	Mode *AgentPoolMode `json:"mode,omitempty"`
 
 	// NodeLabels: The node labels to be persisted across all nodes in agent pool.
-	NodeLabels           map[string]string `json:"nodeLabels" serializationType:"explicitEmptyCollection"`
-	NodePublicIPPrefixID *string           `json:"nodePublicIPPrefixID,omitempty"`
+	NodeLabels map[string]string `json:"nodeLabels" serializationType:"explicitEmptyCollection"`
+
+	// NodePublicIPPrefixID: This is of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}
+	NodePublicIPPrefixID *string `json:"nodePublicIPPrefixID,omitempty"`
 
 	// NodeTaints: The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule.
 	NodeTaints []string `json:"nodeTaints" serializationType:"explicitEmptyCollection"`
@@ -120,14 +127,20 @@ type ManagedClusterAgentPoolProfileProperties struct {
 	OsSKU *OSSKU `json:"osSKU,omitempty"`
 
 	// OsType: The operating system type. The default is Linux.
-	OsType      *OSType `json:"osType,omitempty"`
+	OsType *OSType `json:"osType,omitempty"`
+
+	// PodSubnetID: If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is
+	// of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
 	PodSubnetID *string `json:"podSubnetID,omitempty"`
 
 	// PowerState: When an Agent Pool is first created it is initially Running. The Agent Pool can be stopped by setting this
 	// field to Stopped. A stopped Agent Pool stops all of its VMs and does not accrue billing charges. An Agent Pool can only
 	// be stopped if it is Running and provisioning state is Succeeded
-	PowerState                *PowerState `json:"powerState,omitempty"`
-	ProximityPlacementGroupID *string     `json:"proximityPlacementGroupID,omitempty"`
+	PowerState *PowerState `json:"powerState,omitempty"`
+
+	// ProximityPlacementGroupID: The ID for Proximity Placement Group.
+	ProximityPlacementGroupID *string `json:"proximityPlacementGroupID,omitempty"`
 
 	// ScaleDownMode: This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete.
 	ScaleDownMode *ScaleDownMode `json:"scaleDownMode,omitempty"`
@@ -156,7 +169,11 @@ type ManagedClusterAgentPoolProfileProperties struct {
 	// VmSize: VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods
 	// might fail to run correctly. For more details on restricted VM sizes, see:
 	// https://docs.microsoft.com/azure/aks/quotas-skus-regions
-	VmSize       *string `json:"vmSize,omitempty"`
+	VmSize *string `json:"vmSize,omitempty"`
+
+	// VnetSubnetID: If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified,
+	// this applies to nodes and pods, otherwise it applies to just nodes. This is of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
 	VnetSubnetID *string `json:"vnetSubnetID,omitempty"`
 
 	// WorkloadRuntime: Determines the type of workload a node can run.

--- a/v2/api/containerservice/v1api20230315preview/arm/fleets_member_spec_types_gen.go
+++ b/v2/api/containerservice/v1api20230315preview/arm/fleets_member_spec_types_gen.go
@@ -31,6 +31,8 @@ func (member *FleetsMember_Spec) GetType() string {
 
 // A member of the Fleet. It contains a reference to an existing Kubernetes cluster on Azure.
 type FleetMemberProperties struct {
+	// ClusterResourceId: The ARM resource id of the cluster that joins the Fleet. Must be a valid Azure resource id. e.g.:
+	// '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{clusterName}'.
 	ClusterResourceId *string `json:"clusterResourceId,omitempty"`
 
 	// Group: The group this member belongs to for multi-cluster update management.

--- a/v2/api/containerservice/v1api20231001/arm/managed_cluster_spec_types_gen.go
+++ b/v2/api/containerservice/v1api20231001/arm/managed_cluster_spec_types_gen.go
@@ -90,8 +90,11 @@ type ManagedClusterProperties struct {
 	// DisableLocalAccounts: If set to true, getting static credentials will be disabled for this cluster. This must only be
 	// used on Managed Clusters that are AAD enabled. For more details see [disable local
 	// accounts](https://docs.microsoft.com/azure/aks/managed-aad#disable-local-accounts-preview).
-	DisableLocalAccounts *bool   `json:"disableLocalAccounts,omitempty"`
-	DiskEncryptionSetID  *string `json:"diskEncryptionSetID,omitempty"`
+	DisableLocalAccounts *bool `json:"disableLocalAccounts,omitempty"`
+
+	// DiskEncryptionSetID: This is of the form:
+	// '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/diskEncryptionSets/{encryptionSetName}'
+	DiskEncryptionSetID *string `json:"diskEncryptionSetID,omitempty"`
 
 	// DnsPrefix: This cannot be updated once the Managed Cluster has been created.
 	DnsPrefix *string `json:"dnsPrefix,omitempty"`
@@ -258,7 +261,9 @@ type DelegatedResource struct {
 
 	// ReferralResource: The delegation id of the referral delegation (optional) - internal use only.
 	ReferralResource *string `json:"referralResource,omitempty"`
-	ResourceId       *string `json:"resourceId,omitempty"`
+
+	// ResourceId: The ARM resource id of the delegated resource - internal use only.
+	ResourceId *string `json:"resourceId,omitempty"`
 
 	// TenantId: The tenant id of the delegated resource - internal use only.
 	TenantId *string `json:"tenantId,omitempty"`
@@ -328,8 +333,10 @@ type ManagedClusterAddonProfile struct {
 type ManagedClusterAgentPoolProfile struct {
 	// AvailabilityZones: The list of Availability zones to use for nodes. This can only be specified if the AgentPoolType
 	// property is 'VirtualMachineScaleSets'.
-	AvailabilityZones          []string `json:"availabilityZones"`
-	CapacityReservationGroupID *string  `json:"capacityReservationGroupID,omitempty"`
+	AvailabilityZones []string `json:"availabilityZones"`
+
+	// CapacityReservationGroupID: AKS will associate the specified agent pool with the Capacity Reservation Group.
+	CapacityReservationGroupID *string `json:"capacityReservationGroupID,omitempty"`
 
 	// Count: Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive)
 	// for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1.
@@ -363,7 +370,11 @@ type ManagedClusterAgentPoolProfile struct {
 
 	// GpuInstanceProfile: GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU.
 	GpuInstanceProfile *GPUInstanceProfile `json:"gpuInstanceProfile,omitempty"`
-	HostGroupID        *string             `json:"hostGroupID,omitempty"`
+
+	// HostGroupID: This is of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}.
+	// For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts).
+	HostGroupID *string `json:"hostGroupID,omitempty"`
 
 	// KubeletConfig: The Kubelet configuration on the agent pool nodes.
 	KubeletConfig *KubeletConfig `json:"kubeletConfig,omitempty"`
@@ -395,8 +406,11 @@ type ManagedClusterAgentPoolProfile struct {
 	NetworkProfile *AgentPoolNetworkProfile `json:"networkProfile,omitempty"`
 
 	// NodeLabels: The node labels to be persisted across all nodes in agent pool.
-	NodeLabels           map[string]string `json:"nodeLabels" serializationType:"explicitEmptyCollection"`
-	NodePublicIPPrefixID *string           `json:"nodePublicIPPrefixID,omitempty"`
+	NodeLabels map[string]string `json:"nodeLabels" serializationType:"explicitEmptyCollection"`
+
+	// NodePublicIPPrefixID: This is of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}
+	NodePublicIPPrefixID *string `json:"nodePublicIPPrefixID,omitempty"`
 
 	// NodeTaints: The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule.
 	NodeTaints []string `json:"nodeTaints" serializationType:"explicitEmptyCollection"`
@@ -422,14 +436,20 @@ type ManagedClusterAgentPoolProfile struct {
 	OsSKU *OSSKU `json:"osSKU,omitempty"`
 
 	// OsType: The operating system type. The default is Linux.
-	OsType      *OSType `json:"osType,omitempty"`
+	OsType *OSType `json:"osType,omitempty"`
+
+	// PodSubnetID: If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is
+	// of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
 	PodSubnetID *string `json:"podSubnetID,omitempty"`
 
 	// PowerState: When an Agent Pool is first created it is initially Running. The Agent Pool can be stopped by setting this
 	// field to Stopped. A stopped Agent Pool stops all of its VMs and does not accrue billing charges. An Agent Pool can only
 	// be stopped if it is Running and provisioning state is Succeeded
-	PowerState                *PowerState `json:"powerState,omitempty"`
-	ProximityPlacementGroupID *string     `json:"proximityPlacementGroupID,omitempty"`
+	PowerState *PowerState `json:"powerState,omitempty"`
+
+	// ProximityPlacementGroupID: The ID for Proximity Placement Group.
+	ProximityPlacementGroupID *string `json:"proximityPlacementGroupID,omitempty"`
 
 	// ScaleDownMode: This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete.
 	ScaleDownMode *ScaleDownMode `json:"scaleDownMode,omitempty"`
@@ -458,7 +478,11 @@ type ManagedClusterAgentPoolProfile struct {
 	// VmSize: VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods
 	// might fail to run correctly. For more details on restricted VM sizes, see:
 	// https://docs.microsoft.com/azure/aks/quotas-skus-regions
-	VmSize       *string `json:"vmSize,omitempty"`
+	VmSize *string `json:"vmSize,omitempty"`
+
+	// VnetSubnetID: If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified,
+	// this applies to nodes and pods, otherwise it applies to just nodes. This is of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
 	VnetSubnetID *string `json:"vnetSubnetID,omitempty"`
 
 	// WorkloadRuntime: Determines the type of workload a node can run.
@@ -754,7 +778,9 @@ type ManagedClusterWorkloadAutoScalerProfile struct {
 type PrivateLinkResource struct {
 	// GroupId: The group ID of the resource.
 	GroupId *string `json:"groupId,omitempty"`
-	Id      *string `json:"id,omitempty"`
+
+	// Id: The ID of the private link resource.
+	Id *string `json:"id,omitempty"`
 
 	// Name: The name of the private link resource.
 	Name *string `json:"name,omitempty"`
@@ -781,7 +807,9 @@ type UserAssignedIdentity struct {
 	ClientId *string `json:"clientId,omitempty"`
 
 	// ObjectId: The object ID of the user assigned identity.
-	ObjectId   *string `json:"objectId,omitempty"`
+	ObjectId *string `json:"objectId,omitempty"`
+
+	// ResourceId: The resource ID of the user assigned identity.
 	ResourceId *string `json:"resourceId,omitempty"`
 }
 
@@ -804,7 +832,10 @@ type AzureKeyVaultKms struct {
 	// key vault allows public access from all networks. `Private` means the key vault disables public access and enables
 	// private link. The default value is `Public`.
 	KeyVaultNetworkAccess *AzureKeyVaultKms_KeyVaultNetworkAccess `json:"keyVaultNetworkAccess,omitempty"`
-	KeyVaultResourceId    *string                                 `json:"keyVaultResourceId,omitempty"`
+
+	// KeyVaultResourceId: Resource ID of key vault. When keyVaultNetworkAccess is `Private`, this field is required and must
+	// be a valid resource ID. When keyVaultNetworkAccess is `Public`, leave the field empty.
+	KeyVaultResourceId *string `json:"keyVaultResourceId,omitempty"`
 }
 
 // +kubebuilder:validation:Enum={"IPv4","IPv6"}
@@ -1068,6 +1099,9 @@ var managedClusterProperties_AutoScalerProfile_Expander_Values = map[string]Mana
 
 // Microsoft Defender settings for the security profile.
 type ManagedClusterSecurityProfileDefender struct {
+	// LogAnalyticsWorkspaceResourceId: Resource ID of the Log Analytics workspace to be associated with Microsoft Defender.
+	// When Microsoft Defender is enabled, this field is required and must be a valid workspace resource ID. When Microsoft
+	// Defender is disabled, leave the field empty.
 	LogAnalyticsWorkspaceResourceId *string `json:"logAnalyticsWorkspaceResourceId,omitempty"`
 
 	// SecurityMonitoring: Microsoft Defender threat detection for Cloud settings for the security profile.
@@ -1297,6 +1331,7 @@ type ManagedClusterSecurityProfileDefenderSecurityMonitoring struct {
 
 // A reference to an Azure resource.
 type ResourceReference struct {
+	// Id: The fully qualified Azure resource id.
 	Id *string `json:"id,omitempty"`
 }
 
@@ -1329,7 +1364,9 @@ type IstioPluginCertificateAuthority struct {
 
 	// KeyObjectName: Intermediate certificate private key object name in Azure Key Vault.
 	KeyObjectName *string `json:"keyObjectName,omitempty"`
-	KeyVaultId    *string `json:"keyVaultId,omitempty"`
+
+	// KeyVaultId: The resource ID of the Key Vault.
+	KeyVaultId *string `json:"keyVaultId,omitempty"`
 
 	// RootCertObjectName: Root certificate object name in Azure Key Vault.
 	RootCertObjectName *string `json:"rootCertObjectName,omitempty"`

--- a/v2/api/containerservice/v1api20231001/arm/managed_clusters_agent_pool_spec_types_gen.go
+++ b/v2/api/containerservice/v1api20231001/arm/managed_clusters_agent_pool_spec_types_gen.go
@@ -33,8 +33,10 @@ func (pool *ManagedClustersAgentPool_Spec) GetType() string {
 type ManagedClusterAgentPoolProfileProperties struct {
 	// AvailabilityZones: The list of Availability zones to use for nodes. This can only be specified if the AgentPoolType
 	// property is 'VirtualMachineScaleSets'.
-	AvailabilityZones          []string `json:"availabilityZones"`
-	CapacityReservationGroupID *string  `json:"capacityReservationGroupID,omitempty"`
+	AvailabilityZones []string `json:"availabilityZones"`
+
+	// CapacityReservationGroupID: AKS will associate the specified agent pool with the Capacity Reservation Group.
+	CapacityReservationGroupID *string `json:"capacityReservationGroupID,omitempty"`
 
 	// Count: Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive)
 	// for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1.
@@ -68,7 +70,11 @@ type ManagedClusterAgentPoolProfileProperties struct {
 
 	// GpuInstanceProfile: GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU.
 	GpuInstanceProfile *GPUInstanceProfile `json:"gpuInstanceProfile,omitempty"`
-	HostGroupID        *string             `json:"hostGroupID,omitempty"`
+
+	// HostGroupID: This is of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}.
+	// For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts).
+	HostGroupID *string `json:"hostGroupID,omitempty"`
 
 	// KubeletConfig: The Kubelet configuration on the agent pool nodes.
 	KubeletConfig *KubeletConfig `json:"kubeletConfig,omitempty"`
@@ -97,8 +103,11 @@ type ManagedClusterAgentPoolProfileProperties struct {
 	NetworkProfile *AgentPoolNetworkProfile `json:"networkProfile,omitempty"`
 
 	// NodeLabels: The node labels to be persisted across all nodes in agent pool.
-	NodeLabels           map[string]string `json:"nodeLabels" serializationType:"explicitEmptyCollection"`
-	NodePublicIPPrefixID *string           `json:"nodePublicIPPrefixID,omitempty"`
+	NodeLabels map[string]string `json:"nodeLabels" serializationType:"explicitEmptyCollection"`
+
+	// NodePublicIPPrefixID: This is of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}
+	NodePublicIPPrefixID *string `json:"nodePublicIPPrefixID,omitempty"`
 
 	// NodeTaints: The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule.
 	NodeTaints []string `json:"nodeTaints" serializationType:"explicitEmptyCollection"`
@@ -124,14 +133,20 @@ type ManagedClusterAgentPoolProfileProperties struct {
 	OsSKU *OSSKU `json:"osSKU,omitempty"`
 
 	// OsType: The operating system type. The default is Linux.
-	OsType      *OSType `json:"osType,omitempty"`
+	OsType *OSType `json:"osType,omitempty"`
+
+	// PodSubnetID: If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is
+	// of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
 	PodSubnetID *string `json:"podSubnetID,omitempty"`
 
 	// PowerState: When an Agent Pool is first created it is initially Running. The Agent Pool can be stopped by setting this
 	// field to Stopped. A stopped Agent Pool stops all of its VMs and does not accrue billing charges. An Agent Pool can only
 	// be stopped if it is Running and provisioning state is Succeeded
-	PowerState                *PowerState `json:"powerState,omitempty"`
-	ProximityPlacementGroupID *string     `json:"proximityPlacementGroupID,omitempty"`
+	PowerState *PowerState `json:"powerState,omitempty"`
+
+	// ProximityPlacementGroupID: The ID for Proximity Placement Group.
+	ProximityPlacementGroupID *string `json:"proximityPlacementGroupID,omitempty"`
 
 	// ScaleDownMode: This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete.
 	ScaleDownMode *ScaleDownMode `json:"scaleDownMode,omitempty"`
@@ -160,7 +175,11 @@ type ManagedClusterAgentPoolProfileProperties struct {
 	// VmSize: VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods
 	// might fail to run correctly. For more details on restricted VM sizes, see:
 	// https://docs.microsoft.com/azure/aks/quotas-skus-regions
-	VmSize       *string `json:"vmSize,omitempty"`
+	VmSize *string `json:"vmSize,omitempty"`
+
+	// VnetSubnetID: If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified,
+	// this applies to nodes and pods, otherwise it applies to just nodes. This is of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
 	VnetSubnetID *string `json:"vnetSubnetID,omitempty"`
 
 	// WorkloadRuntime: Determines the type of workload a node can run.
@@ -186,8 +205,10 @@ var agentPoolMode_Values = map[string]AgentPoolMode{
 // Network settings of an agent pool.
 type AgentPoolNetworkProfile struct {
 	// AllowedHostPorts: The port ranges that are allowed to access. The specified ranges are allowed to overlap.
-	AllowedHostPorts          []PortRange `json:"allowedHostPorts"`
-	ApplicationSecurityGroups []string    `json:"applicationSecurityGroups,omitempty"`
+	AllowedHostPorts []PortRange `json:"allowedHostPorts"`
+
+	// ApplicationSecurityGroups: The IDs of the application security groups which agent pool will associate when created.
+	ApplicationSecurityGroups []string `json:"applicationSecurityGroups,omitempty"`
 
 	// NodePublicIPTags: IPTags of instance-level public IPs.
 	NodePublicIPTags []IPTag `json:"nodePublicIPTags"`
@@ -224,6 +245,7 @@ type AgentPoolUpgradeSettings struct {
 
 // Data used when creating a target resource from a source resource.
 type CreationData struct {
+	// SourceResourceId: This is the ARM ID of the source object to be used to create the target object.
 	SourceResourceId *string `json:"sourceResourceId,omitempty"`
 }
 

--- a/v2/api/containerservice/v1api20231001/arm/trusted_access_role_binding_spec_types_gen.go
+++ b/v2/api/containerservice/v1api20231001/arm/trusted_access_role_binding_spec_types_gen.go
@@ -33,6 +33,8 @@ func (binding *TrustedAccessRoleBinding_Spec) GetType() string {
 type TrustedAccessRoleBindingProperties struct {
 	// Roles: A list of roles to bind, each item is a resource type qualified role name. For example:
 	// 'Microsoft.MachineLearningServices/workspaces/reader'.
-	Roles            []string `json:"roles"`
-	SourceResourceId *string  `json:"sourceResourceId,omitempty"`
+	Roles []string `json:"roles"`
+
+	// SourceResourceId: The ARM resource ID of source resource that trusted access is configured for.
+	SourceResourceId *string `json:"sourceResourceId,omitempty"`
 }

--- a/v2/api/containerservice/v1api20231102preview/arm/managed_clusters_agent_pool_spec_types_gen.go
+++ b/v2/api/containerservice/v1api20231102preview/arm/managed_clusters_agent_pool_spec_types_gen.go
@@ -36,8 +36,10 @@ type ManagedClusterAgentPoolProfileProperties struct {
 
 	// AvailabilityZones: The list of Availability zones to use for nodes. This can only be specified if the AgentPoolType
 	// property is 'VirtualMachineScaleSets'.
-	AvailabilityZones          []string `json:"availabilityZones"`
-	CapacityReservationGroupID *string  `json:"capacityReservationGroupID,omitempty"`
+	AvailabilityZones []string `json:"availabilityZones"`
+
+	// CapacityReservationGroupID: AKS will associate the specified agent pool with the Capacity Reservation Group.
+	CapacityReservationGroupID *string `json:"capacityReservationGroupID,omitempty"`
 
 	// Count: Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive)
 	// for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1.
@@ -78,8 +80,12 @@ type ManagedClusterAgentPoolProfileProperties struct {
 	GpuInstanceProfile *GPUInstanceProfile `json:"gpuInstanceProfile,omitempty"`
 
 	// GpuProfile: The GPU settings of an agent pool.
-	GpuProfile  *AgentPoolGPUProfile `json:"gpuProfile,omitempty"`
-	HostGroupID *string              `json:"hostGroupID,omitempty"`
+	GpuProfile *AgentPoolGPUProfile `json:"gpuProfile,omitempty"`
+
+	// HostGroupID: This is of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}.
+	// For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts).
+	HostGroupID *string `json:"hostGroupID,omitempty"`
 
 	// KubeletConfig: The Kubelet configuration on the agent pool nodes.
 	KubeletConfig *KubeletConfig `json:"kubeletConfig,omitempty"`
@@ -120,8 +126,11 @@ type ManagedClusterAgentPoolProfileProperties struct {
 	NodeInitializationTaints []string `json:"nodeInitializationTaints"`
 
 	// NodeLabels: The node labels to be persisted across all nodes in agent pool.
-	NodeLabels           map[string]string `json:"nodeLabels" serializationType:"explicitEmptyCollection"`
-	NodePublicIPPrefixID *string           `json:"nodePublicIPPrefixID,omitempty"`
+	NodeLabels map[string]string `json:"nodeLabels" serializationType:"explicitEmptyCollection"`
+
+	// NodePublicIPPrefixID: This is of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}
+	NodePublicIPPrefixID *string `json:"nodePublicIPPrefixID,omitempty"`
 
 	// NodeTaints: The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule.
 	NodeTaints []string `json:"nodeTaints" serializationType:"explicitEmptyCollection"`
@@ -147,14 +156,20 @@ type ManagedClusterAgentPoolProfileProperties struct {
 	OsSKU *OSSKU `json:"osSKU,omitempty"`
 
 	// OsType: The operating system type. The default is Linux.
-	OsType      *OSType `json:"osType,omitempty"`
+	OsType *OSType `json:"osType,omitempty"`
+
+	// PodSubnetID: If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is
+	// of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
 	PodSubnetID *string `json:"podSubnetID,omitempty"`
 
 	// PowerState: When an Agent Pool is first created it is initially Running. The Agent Pool can be stopped by setting this
 	// field to Stopped. A stopped Agent Pool stops all of its VMs and does not accrue billing charges. An Agent Pool can only
 	// be stopped if it is Running and provisioning state is Succeeded
-	PowerState                *PowerState `json:"powerState,omitempty"`
-	ProximityPlacementGroupID *string     `json:"proximityPlacementGroupID,omitempty"`
+	PowerState *PowerState `json:"powerState,omitempty"`
+
+	// ProximityPlacementGroupID: The ID for Proximity Placement Group.
+	ProximityPlacementGroupID *string `json:"proximityPlacementGroupID,omitempty"`
 
 	// ScaleDownMode: This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete.
 	ScaleDownMode *ScaleDownMode `json:"scaleDownMode,omitempty"`
@@ -190,7 +205,11 @@ type ManagedClusterAgentPoolProfileProperties struct {
 	// VmSize: VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods
 	// might fail to run correctly. For more details on restricted VM sizes, see:
 	// https://docs.microsoft.com/azure/aks/quotas-skus-regions
-	VmSize       *string `json:"vmSize,omitempty"`
+	VmSize *string `json:"vmSize,omitempty"`
+
+	// VnetSubnetID: If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified,
+	// this applies to nodes and pods, otherwise it applies to just nodes. This is of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
 	VnetSubnetID *string `json:"vnetSubnetID,omitempty"`
 
 	// WindowsProfile: The Windows agent pool's specific profile.

--- a/v2/api/containerservice/v1api20240402preview/arm/managed_cluster_spec_types_gen.go
+++ b/v2/api/containerservice/v1api20240402preview/arm/managed_cluster_spec_types_gen.go
@@ -103,8 +103,11 @@ type ManagedClusterProperties struct {
 	// DisableLocalAccounts: If set to true, getting static credentials will be disabled for this cluster. This must only be
 	// used on Managed Clusters that are AAD enabled. For more details see [disable local
 	// accounts](https://docs.microsoft.com/azure/aks/managed-aad#disable-local-accounts-preview).
-	DisableLocalAccounts *bool   `json:"disableLocalAccounts,omitempty"`
-	DiskEncryptionSetID  *string `json:"diskEncryptionSetID,omitempty"`
+	DisableLocalAccounts *bool `json:"disableLocalAccounts,omitempty"`
+
+	// DiskEncryptionSetID: This is of the form:
+	// '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/diskEncryptionSets/{encryptionSetName}'
+	DiskEncryptionSetID *string `json:"diskEncryptionSetID,omitempty"`
 
 	// DnsPrefix: This cannot be updated once the Managed Cluster has been created.
 	DnsPrefix *string `json:"dnsPrefix,omitempty"`
@@ -300,6 +303,7 @@ type ContainerServiceNetworkProfile struct {
 
 // Data used when creating a target resource from a source resource.
 type CreationData struct {
+	// SourceResourceId: This is the ARM ID of the source object to be used to create the target object.
 	SourceResourceId *string `json:"sourceResourceId,omitempty"`
 }
 
@@ -310,7 +314,9 @@ type DelegatedResource struct {
 
 	// ReferralResource: The delegation id of the referral delegation (optional) - internal use only.
 	ReferralResource *string `json:"referralResource,omitempty"`
-	ResourceId       *string `json:"resourceId,omitempty"`
+
+	// ResourceId: The ARM resource id of the delegated resource - internal use only.
+	ResourceId *string `json:"resourceId,omitempty"`
 
 	// TenantId: The tenant id of the delegated resource - internal use only.
 	TenantId *string `json:"tenantId,omitempty"`
@@ -383,8 +389,10 @@ type ManagedClusterAgentPoolProfile struct {
 
 	// AvailabilityZones: The list of Availability zones to use for nodes. This can only be specified if the AgentPoolType
 	// property is 'VirtualMachineScaleSets'.
-	AvailabilityZones          []string `json:"availabilityZones"`
-	CapacityReservationGroupID *string  `json:"capacityReservationGroupID,omitempty"`
+	AvailabilityZones []string `json:"availabilityZones"`
+
+	// CapacityReservationGroupID: AKS will associate the specified agent pool with the Capacity Reservation Group.
+	CapacityReservationGroupID *string `json:"capacityReservationGroupID,omitempty"`
 
 	// Count: Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive)
 	// for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1.
@@ -429,8 +437,12 @@ type ManagedClusterAgentPoolProfile struct {
 	GpuInstanceProfile *GPUInstanceProfile `json:"gpuInstanceProfile,omitempty"`
 
 	// GpuProfile: The GPU settings of an agent pool.
-	GpuProfile  *AgentPoolGPUProfile `json:"gpuProfile,omitempty"`
-	HostGroupID *string              `json:"hostGroupID,omitempty"`
+	GpuProfile *AgentPoolGPUProfile `json:"gpuProfile,omitempty"`
+
+	// HostGroupID: This is of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}.
+	// For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts).
+	HostGroupID *string `json:"hostGroupID,omitempty"`
 
 	// KubeletConfig: The Kubelet configuration on the agent pool nodes.
 	KubeletConfig *KubeletConfig `json:"kubeletConfig,omitempty"`
@@ -474,8 +486,11 @@ type ManagedClusterAgentPoolProfile struct {
 	NodeInitializationTaints []string `json:"nodeInitializationTaints"`
 
 	// NodeLabels: The node labels to be persisted across all nodes in agent pool.
-	NodeLabels           map[string]string `json:"nodeLabels" serializationType:"explicitEmptyCollection"`
-	NodePublicIPPrefixID *string           `json:"nodePublicIPPrefixID,omitempty"`
+	NodeLabels map[string]string `json:"nodeLabels" serializationType:"explicitEmptyCollection"`
+
+	// NodePublicIPPrefixID: This is of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}
+	NodePublicIPPrefixID *string `json:"nodePublicIPPrefixID,omitempty"`
 
 	// NodeTaints: The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule.
 	NodeTaints []string `json:"nodeTaints" serializationType:"explicitEmptyCollection"`
@@ -506,13 +521,19 @@ type ManagedClusterAgentPoolProfile struct {
 	// PodIPAllocationMode: The IP allocation mode for pods in the agent pool. Must be used with podSubnetId. The default is
 	// 'DynamicIndividual'.
 	PodIPAllocationMode *PodIPAllocationMode `json:"podIPAllocationMode,omitempty"`
-	PodSubnetID         *string              `json:"podSubnetID,omitempty"`
+
+	// PodSubnetID: If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is
+	// of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
+	PodSubnetID *string `json:"podSubnetID,omitempty"`
 
 	// PowerState: When an Agent Pool is first created it is initially Running. The Agent Pool can be stopped by setting this
 	// field to Stopped. A stopped Agent Pool stops all of its VMs and does not accrue billing charges. An Agent Pool can only
 	// be stopped if it is Running and provisioning state is Succeeded
-	PowerState                *PowerState `json:"powerState,omitempty"`
-	ProximityPlacementGroupID *string     `json:"proximityPlacementGroupID,omitempty"`
+	PowerState *PowerState `json:"powerState,omitempty"`
+
+	// ProximityPlacementGroupID: The ID for Proximity Placement Group.
+	ProximityPlacementGroupID *string `json:"proximityPlacementGroupID,omitempty"`
 
 	// ScaleDownMode: This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete.
 	ScaleDownMode *ScaleDownMode `json:"scaleDownMode,omitempty"`
@@ -548,7 +569,11 @@ type ManagedClusterAgentPoolProfile struct {
 	// VmSize: VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods
 	// might fail to run correctly. For more details on restricted VM sizes, see:
 	// https://docs.microsoft.com/azure/aks/quotas-skus-regions
-	VmSize       *string `json:"vmSize,omitempty"`
+	VmSize *string `json:"vmSize,omitempty"`
+
+	// VnetSubnetID: If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified,
+	// this applies to nodes and pods, otherwise it applies to just nodes. This is of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
 	VnetSubnetID *string `json:"vnetSubnetID,omitempty"`
 
 	// WindowsProfile: The Windows agent pool's specific profile.
@@ -624,8 +649,11 @@ type ManagedClusterAzureMonitorProfile struct {
 // The bootstrap profile.
 type ManagedClusterBootstrapProfile struct {
 	// ArtifactSource: The source where the artifacts are downloaded from.
-	ArtifactSource      *ManagedClusterBootstrapProfile_ArtifactSource `json:"artifactSource,omitempty"`
-	ContainerRegistryId *string                                        `json:"containerRegistryId,omitempty"`
+	ArtifactSource *ManagedClusterBootstrapProfile_ArtifactSource `json:"artifactSource,omitempty"`
+
+	// ContainerRegistryId: The resource Id of Azure Container Registry. The registry must have private network access, premium
+	// SKU and zone redundancy.
+	ContainerRegistryId *string `json:"containerRegistryId,omitempty"`
 }
 
 // Cluster HTTP proxy configuration.
@@ -930,7 +958,9 @@ type ManagedClusterWorkloadAutoScalerProfile struct {
 type PrivateLinkResource struct {
 	// GroupId: The group ID of the resource.
 	GroupId *string `json:"groupId,omitempty"`
-	Id      *string `json:"id,omitempty"`
+
+	// Id: The ID of the private link resource.
+	Id *string `json:"id,omitempty"`
 
 	// Name: The name of the private link resource.
 	Name *string `json:"name,omitempty"`
@@ -970,7 +1000,9 @@ type UserAssignedIdentity struct {
 	ClientId *string `json:"clientId,omitempty"`
 
 	// ObjectId: The object ID of the user assigned identity.
-	ObjectId   *string `json:"objectId,omitempty"`
+	ObjectId *string `json:"objectId,omitempty"`
+
+	// ResourceId: The resource ID of the user assigned identity.
 	ResourceId *string `json:"resourceId,omitempty"`
 }
 
@@ -1000,7 +1032,10 @@ type AzureKeyVaultKms struct {
 	// key vault allows public access from all networks. `Private` means the key vault disables public access and enables
 	// private link. The default value is `Public`.
 	KeyVaultNetworkAccess *AzureKeyVaultKms_KeyVaultNetworkAccess `json:"keyVaultNetworkAccess,omitempty"`
-	KeyVaultResourceId    *string                                 `json:"keyVaultResourceId,omitempty"`
+
+	// KeyVaultResourceId: Resource ID of key vault. When keyVaultNetworkAccess is `Private`, this field is required and must
+	// be a valid resource ID. When keyVaultNetworkAccess is `Public`, leave the field empty.
+	KeyVaultResourceId *string `json:"keyVaultResourceId,omitempty"`
 }
 
 type ContainerServiceNetworkProfile_KubeProxyConfig struct {
@@ -1180,7 +1215,10 @@ type ManagedClusterAzureMonitorProfileContainerInsights struct {
 	DisablePrometheusMetricsScraping *bool `json:"disablePrometheusMetricsScraping,omitempty"`
 
 	// Enabled: Indicates if Azure Monitor Container Insights Logs Addon is enabled or not.
-	Enabled                         *bool   `json:"enabled,omitempty"`
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// LogAnalyticsWorkspaceResourceId: Fully Qualified ARM Resource Id of Azure Log Analytics Workspace for storing Azure
+	// Monitor Container Insights Logs.
 	LogAnalyticsWorkspaceResourceId *string `json:"logAnalyticsWorkspaceResourceId,omitempty"`
 
 	// SyslogPort: The syslog host port. If not specified, the default port is 28330.
@@ -1220,6 +1258,9 @@ type ManagedClusterCostAnalysis struct {
 
 // Web App Routing settings for the ingress profile.
 type ManagedClusterIngressProfileWebAppRouting struct {
+	// DnsZoneResourceIds: Resource IDs of the DNS zones to be associated with the Web App Routing add-on. Used only when Web
+	// App Routing is enabled. Public and private DNS zones can be in different resource groups, but all public DNS zones must
+	// be in the same resource group and all private DNS zones must be in the same resource group.
 	DnsZoneResourceIds []string `json:"dnsZoneResourceIds,omitempty"`
 
 	// Enabled: Whether to enable Web App Routing.
@@ -1329,6 +1370,9 @@ type ManagedClusterPodIdentityException struct {
 
 // Microsoft Defender settings for the security profile.
 type ManagedClusterSecurityProfileDefender struct {
+	// LogAnalyticsWorkspaceResourceId: Resource ID of the Log Analytics workspace to be associated with Microsoft Defender.
+	// When Microsoft Defender is enabled, this field is required and must be a valid workspace resource ID. When Microsoft
+	// Defender is disabled, leave the field empty.
 	LogAnalyticsWorkspaceResourceId *string `json:"logAnalyticsWorkspaceResourceId,omitempty"`
 
 	// SecurityMonitoring: Microsoft Defender threat detection for Cloud settings for the security profile.
@@ -1763,6 +1807,7 @@ var managedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_AddonAutoscalin
 
 // A reference to an Azure resource.
 type ResourceReference struct {
+	// Id: The fully qualified Azure resource id.
 	Id *string `json:"id,omitempty"`
 }
 
@@ -1806,7 +1851,9 @@ type IstioPluginCertificateAuthority struct {
 
 	// KeyObjectName: Intermediate certificate private key object name in Azure Key Vault.
 	KeyObjectName *string `json:"keyObjectName,omitempty"`
-	KeyVaultId    *string `json:"keyVaultId,omitempty"`
+
+	// KeyVaultId: The resource ID of the Key Vault.
+	KeyVaultId *string `json:"keyVaultId,omitempty"`
 
 	// RootCertObjectName: Root certificate object name in Azure Key Vault.
 	RootCertObjectName *string `json:"rootCertObjectName,omitempty"`

--- a/v2/api/containerservice/v1api20240402preview/arm/managed_clusters_agent_pool_spec_types_gen.go
+++ b/v2/api/containerservice/v1api20240402preview/arm/managed_clusters_agent_pool_spec_types_gen.go
@@ -36,8 +36,10 @@ type ManagedClusterAgentPoolProfileProperties struct {
 
 	// AvailabilityZones: The list of Availability zones to use for nodes. This can only be specified if the AgentPoolType
 	// property is 'VirtualMachineScaleSets'.
-	AvailabilityZones          []string `json:"availabilityZones"`
-	CapacityReservationGroupID *string  `json:"capacityReservationGroupID,omitempty"`
+	AvailabilityZones []string `json:"availabilityZones"`
+
+	// CapacityReservationGroupID: AKS will associate the specified agent pool with the Capacity Reservation Group.
+	CapacityReservationGroupID *string `json:"capacityReservationGroupID,omitempty"`
 
 	// Count: Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive)
 	// for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1.
@@ -82,8 +84,12 @@ type ManagedClusterAgentPoolProfileProperties struct {
 	GpuInstanceProfile *GPUInstanceProfile `json:"gpuInstanceProfile,omitempty"`
 
 	// GpuProfile: The GPU settings of an agent pool.
-	GpuProfile  *AgentPoolGPUProfile `json:"gpuProfile,omitempty"`
-	HostGroupID *string              `json:"hostGroupID,omitempty"`
+	GpuProfile *AgentPoolGPUProfile `json:"gpuProfile,omitempty"`
+
+	// HostGroupID: This is of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}.
+	// For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts).
+	HostGroupID *string `json:"hostGroupID,omitempty"`
 
 	// KubeletConfig: The Kubelet configuration on the agent pool nodes.
 	KubeletConfig *KubeletConfig `json:"kubeletConfig,omitempty"`
@@ -124,8 +130,11 @@ type ManagedClusterAgentPoolProfileProperties struct {
 	NodeInitializationTaints []string `json:"nodeInitializationTaints"`
 
 	// NodeLabels: The node labels to be persisted across all nodes in agent pool.
-	NodeLabels           map[string]string `json:"nodeLabels" serializationType:"explicitEmptyCollection"`
-	NodePublicIPPrefixID *string           `json:"nodePublicIPPrefixID,omitempty"`
+	NodeLabels map[string]string `json:"nodeLabels" serializationType:"explicitEmptyCollection"`
+
+	// NodePublicIPPrefixID: This is of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}
+	NodePublicIPPrefixID *string `json:"nodePublicIPPrefixID,omitempty"`
 
 	// NodeTaints: The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule.
 	NodeTaints []string `json:"nodeTaints" serializationType:"explicitEmptyCollection"`
@@ -156,13 +165,19 @@ type ManagedClusterAgentPoolProfileProperties struct {
 	// PodIPAllocationMode: The IP allocation mode for pods in the agent pool. Must be used with podSubnetId. The default is
 	// 'DynamicIndividual'.
 	PodIPAllocationMode *PodIPAllocationMode `json:"podIPAllocationMode,omitempty"`
-	PodSubnetID         *string              `json:"podSubnetID,omitempty"`
+
+	// PodSubnetID: If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is
+	// of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
+	PodSubnetID *string `json:"podSubnetID,omitempty"`
 
 	// PowerState: When an Agent Pool is first created it is initially Running. The Agent Pool can be stopped by setting this
 	// field to Stopped. A stopped Agent Pool stops all of its VMs and does not accrue billing charges. An Agent Pool can only
 	// be stopped if it is Running and provisioning state is Succeeded
-	PowerState                *PowerState `json:"powerState,omitempty"`
-	ProximityPlacementGroupID *string     `json:"proximityPlacementGroupID,omitempty"`
+	PowerState *PowerState `json:"powerState,omitempty"`
+
+	// ProximityPlacementGroupID: The ID for Proximity Placement Group.
+	ProximityPlacementGroupID *string `json:"proximityPlacementGroupID,omitempty"`
 
 	// ScaleDownMode: This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete.
 	ScaleDownMode *ScaleDownMode `json:"scaleDownMode,omitempty"`
@@ -198,7 +213,11 @@ type ManagedClusterAgentPoolProfileProperties struct {
 	// VmSize: VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods
 	// might fail to run correctly. For more details on restricted VM sizes, see:
 	// https://docs.microsoft.com/azure/aks/quotas-skus-regions
-	VmSize       *string `json:"vmSize,omitempty"`
+	VmSize *string `json:"vmSize,omitempty"`
+
+	// VnetSubnetID: If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified,
+	// this applies to nodes and pods, otherwise it applies to just nodes. This is of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
 	VnetSubnetID *string `json:"vnetSubnetID,omitempty"`
 
 	// WindowsProfile: The Windows agent pool's specific profile.
@@ -253,8 +272,10 @@ var agentPoolMode_Values = map[string]AgentPoolMode{
 // Network settings of an agent pool.
 type AgentPoolNetworkProfile struct {
 	// AllowedHostPorts: The port ranges that are allowed to access. The specified ranges are allowed to overlap.
-	AllowedHostPorts          []PortRange `json:"allowedHostPorts"`
-	ApplicationSecurityGroups []string    `json:"applicationSecurityGroups,omitempty"`
+	AllowedHostPorts []PortRange `json:"allowedHostPorts"`
+
+	// ApplicationSecurityGroups: The IDs of the application security groups which agent pool will associate when created.
+	ApplicationSecurityGroups []string `json:"applicationSecurityGroups,omitempty"`
 
 	// NodePublicIPTags: IPTags of instance-level public IPs.
 	NodePublicIPTags []IPTag `json:"nodePublicIPTags"`

--- a/v2/api/containerservice/v1api20240402preview/arm/trusted_access_role_binding_spec_types_gen.go
+++ b/v2/api/containerservice/v1api20240402preview/arm/trusted_access_role_binding_spec_types_gen.go
@@ -33,6 +33,8 @@ func (binding *TrustedAccessRoleBinding_Spec) GetType() string {
 type TrustedAccessRoleBindingProperties struct {
 	// Roles: A list of roles to bind, each item is a resource type qualified role name. For example:
 	// 'Microsoft.MachineLearningServices/workspaces/reader'.
-	Roles            []string `json:"roles"`
-	SourceResourceId *string  `json:"sourceResourceId,omitempty"`
+	Roles []string `json:"roles"`
+
+	// SourceResourceId: The ARM resource ID of source resource that trusted access is configured for.
+	SourceResourceId *string `json:"sourceResourceId,omitempty"`
 }

--- a/v2/api/containerservice/v1api20240901/arm/managed_cluster_spec_types_gen.go
+++ b/v2/api/containerservice/v1api20240901/arm/managed_cluster_spec_types_gen.go
@@ -90,8 +90,11 @@ type ManagedClusterProperties struct {
 	// DisableLocalAccounts: If set to true, getting static credentials will be disabled for this cluster. This must only be
 	// used on Managed Clusters that are AAD enabled. For more details see [disable local
 	// accounts](https://docs.microsoft.com/azure/aks/managed-aad#disable-local-accounts-preview).
-	DisableLocalAccounts *bool   `json:"disableLocalAccounts,omitempty"`
-	DiskEncryptionSetID  *string `json:"diskEncryptionSetID,omitempty"`
+	DisableLocalAccounts *bool `json:"disableLocalAccounts,omitempty"`
+
+	// DiskEncryptionSetID: This is of the form:
+	// '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/diskEncryptionSets/{encryptionSetName}'
+	DiskEncryptionSetID *string `json:"diskEncryptionSetID,omitempty"`
 
 	// DnsPrefix: This cannot be updated once the Managed Cluster has been created.
 	DnsPrefix *string `json:"dnsPrefix,omitempty"`
@@ -273,7 +276,9 @@ type DelegatedResource struct {
 
 	// ReferralResource: The delegation id of the referral delegation (optional) - internal use only.
 	ReferralResource *string `json:"referralResource,omitempty"`
-	ResourceId       *string `json:"resourceId,omitempty"`
+
+	// ResourceId: The ARM resource id of the delegated resource - internal use only.
+	ResourceId *string `json:"resourceId,omitempty"`
 
 	// TenantId: The tenant id of the delegated resource - internal use only.
 	TenantId *string `json:"tenantId,omitempty"`
@@ -343,8 +348,10 @@ type ManagedClusterAddonProfile struct {
 type ManagedClusterAgentPoolProfile struct {
 	// AvailabilityZones: The list of Availability zones to use for nodes. This can only be specified if the AgentPoolType
 	// property is 'VirtualMachineScaleSets'.
-	AvailabilityZones          []string `json:"availabilityZones"`
-	CapacityReservationGroupID *string  `json:"capacityReservationGroupID,omitempty"`
+	AvailabilityZones []string `json:"availabilityZones"`
+
+	// CapacityReservationGroupID: AKS will associate the specified agent pool with the Capacity Reservation Group.
+	CapacityReservationGroupID *string `json:"capacityReservationGroupID,omitempty"`
 
 	// Count: Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive)
 	// for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1.
@@ -378,7 +385,11 @@ type ManagedClusterAgentPoolProfile struct {
 
 	// GpuInstanceProfile: GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU.
 	GpuInstanceProfile *GPUInstanceProfile `json:"gpuInstanceProfile,omitempty"`
-	HostGroupID        *string             `json:"hostGroupID,omitempty"`
+
+	// HostGroupID: This is of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}.
+	// For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts).
+	HostGroupID *string `json:"hostGroupID,omitempty"`
 
 	// KubeletConfig: The Kubelet configuration on the agent pool nodes.
 	KubeletConfig *KubeletConfig `json:"kubeletConfig,omitempty"`
@@ -410,8 +421,11 @@ type ManagedClusterAgentPoolProfile struct {
 	NetworkProfile *AgentPoolNetworkProfile `json:"networkProfile,omitempty"`
 
 	// NodeLabels: The node labels to be persisted across all nodes in agent pool.
-	NodeLabels           map[string]string `json:"nodeLabels" serializationType:"explicitEmptyCollection"`
-	NodePublicIPPrefixID *string           `json:"nodePublicIPPrefixID,omitempty"`
+	NodeLabels map[string]string `json:"nodeLabels" serializationType:"explicitEmptyCollection"`
+
+	// NodePublicIPPrefixID: This is of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}
+	NodePublicIPPrefixID *string `json:"nodePublicIPPrefixID,omitempty"`
 
 	// NodeTaints: The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule.
 	NodeTaints []string `json:"nodeTaints" serializationType:"explicitEmptyCollection"`
@@ -437,14 +451,20 @@ type ManagedClusterAgentPoolProfile struct {
 	OsSKU *OSSKU `json:"osSKU,omitempty"`
 
 	// OsType: The operating system type. The default is Linux.
-	OsType      *OSType `json:"osType,omitempty"`
+	OsType *OSType `json:"osType,omitempty"`
+
+	// PodSubnetID: If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is
+	// of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
 	PodSubnetID *string `json:"podSubnetID,omitempty"`
 
 	// PowerState: When an Agent Pool is first created it is initially Running. The Agent Pool can be stopped by setting this
 	// field to Stopped. A stopped Agent Pool stops all of its VMs and does not accrue billing charges. An Agent Pool can only
 	// be stopped if it is Running and provisioning state is Succeeded
-	PowerState                *PowerState `json:"powerState,omitempty"`
-	ProximityPlacementGroupID *string     `json:"proximityPlacementGroupID,omitempty"`
+	PowerState *PowerState `json:"powerState,omitempty"`
+
+	// ProximityPlacementGroupID: The ID for Proximity Placement Group.
+	ProximityPlacementGroupID *string `json:"proximityPlacementGroupID,omitempty"`
 
 	// ScaleDownMode: This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete.
 	ScaleDownMode *ScaleDownMode `json:"scaleDownMode,omitempty"`
@@ -476,7 +496,11 @@ type ManagedClusterAgentPoolProfile struct {
 	// VmSize: VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods
 	// might fail to run correctly. For more details on restricted VM sizes, see:
 	// https://docs.microsoft.com/azure/aks/quotas-skus-regions
-	VmSize       *string `json:"vmSize,omitempty"`
+	VmSize *string `json:"vmSize,omitempty"`
+
+	// VnetSubnetID: If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified,
+	// this applies to nodes and pods, otherwise it applies to just nodes. This is of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
 	VnetSubnetID *string `json:"vnetSubnetID,omitempty"`
 
 	// WindowsProfile: The Windows agent pool's specific profile.
@@ -809,7 +833,9 @@ type ManagedClusterWorkloadAutoScalerProfile struct {
 type PrivateLinkResource struct {
 	// GroupId: The group ID of the resource.
 	GroupId *string `json:"groupId,omitempty"`
-	Id      *string `json:"id,omitempty"`
+
+	// Id: The ID of the private link resource.
+	Id *string `json:"id,omitempty"`
 
 	// Name: The name of the private link resource.
 	Name *string `json:"name,omitempty"`
@@ -836,7 +862,9 @@ type UserAssignedIdentity struct {
 	ClientId *string `json:"clientId,omitempty"`
 
 	// ObjectId: The object ID of the user assigned identity.
-	ObjectId   *string `json:"objectId,omitempty"`
+	ObjectId *string `json:"objectId,omitempty"`
+
+	// ResourceId: The resource ID of the user assigned identity.
 	ResourceId *string `json:"resourceId,omitempty"`
 }
 
@@ -874,7 +902,10 @@ type AzureKeyVaultKms struct {
 	// key vault allows public access from all networks. `Private` means the key vault disables public access and enables
 	// private link. The default value is `Public`.
 	KeyVaultNetworkAccess *AzureKeyVaultKms_KeyVaultNetworkAccess `json:"keyVaultNetworkAccess,omitempty"`
-	KeyVaultResourceId    *string                                 `json:"keyVaultResourceId,omitempty"`
+
+	// KeyVaultResourceId: Resource ID of key vault. When keyVaultNetworkAccess is `Private`, this field is required and must
+	// be a valid resource ID. When keyVaultNetworkAccess is `Public`, leave the field empty.
+	KeyVaultResourceId *string `json:"keyVaultResourceId,omitempty"`
 }
 
 // +kubebuilder:validation:Enum={"IPv4","IPv6"}
@@ -1078,6 +1109,9 @@ type ManagedClusterCostAnalysis struct {
 
 // Application Routing add-on settings for the ingress profile.
 type ManagedClusterIngressProfileWebAppRouting struct {
+	// DnsZoneResourceIds: Resource IDs of the DNS zones to be associated with the Application Routing add-on. Used only when
+	// Application Routing add-on is enabled. Public and private DNS zones can be in different resource groups, but all public
+	// DNS zones must be in the same resource group and all private DNS zones must be in the same resource group.
 	DnsZoneResourceIds []string `json:"dnsZoneResourceIds,omitempty"`
 
 	// Enabled: Whether to enable the Application Routing add-on.
@@ -1188,6 +1222,9 @@ var managedClusterProperties_AutoScalerProfile_Expander_Values = map[string]Mana
 
 // Microsoft Defender settings for the security profile.
 type ManagedClusterSecurityProfileDefender struct {
+	// LogAnalyticsWorkspaceResourceId: Resource ID of the Log Analytics workspace to be associated with Microsoft Defender.
+	// When Microsoft Defender is enabled, this field is required and must be a valid workspace resource ID. When Microsoft
+	// Defender is disabled, leave the field empty.
 	LogAnalyticsWorkspaceResourceId *string `json:"logAnalyticsWorkspaceResourceId,omitempty"`
 
 	// SecurityMonitoring: Microsoft Defender threat detection for Cloud settings for the security profile.
@@ -1414,6 +1451,7 @@ type ManagedClusterSecurityProfileDefenderSecurityMonitoring struct {
 
 // A reference to an Azure resource.
 type ResourceReference struct {
+	// Id: The fully qualified Azure resource id.
 	Id *string `json:"id,omitempty"`
 }
 
@@ -1443,7 +1481,9 @@ type IstioPluginCertificateAuthority struct {
 
 	// KeyObjectName: Intermediate certificate private key object name in Azure Key Vault.
 	KeyObjectName *string `json:"keyObjectName,omitempty"`
-	KeyVaultId    *string `json:"keyVaultId,omitempty"`
+
+	// KeyVaultId: The resource ID of the Key Vault.
+	KeyVaultId *string `json:"keyVaultId,omitempty"`
 
 	// RootCertObjectName: Root certificate object name in Azure Key Vault.
 	RootCertObjectName *string `json:"rootCertObjectName,omitempty"`

--- a/v2/api/containerservice/v1api20240901/arm/managed_clusters_agent_pool_spec_types_gen.go
+++ b/v2/api/containerservice/v1api20240901/arm/managed_clusters_agent_pool_spec_types_gen.go
@@ -33,8 +33,10 @@ func (pool *ManagedClustersAgentPool_Spec) GetType() string {
 type ManagedClusterAgentPoolProfileProperties struct {
 	// AvailabilityZones: The list of Availability zones to use for nodes. This can only be specified if the AgentPoolType
 	// property is 'VirtualMachineScaleSets'.
-	AvailabilityZones          []string `json:"availabilityZones"`
-	CapacityReservationGroupID *string  `json:"capacityReservationGroupID,omitempty"`
+	AvailabilityZones []string `json:"availabilityZones"`
+
+	// CapacityReservationGroupID: AKS will associate the specified agent pool with the Capacity Reservation Group.
+	CapacityReservationGroupID *string `json:"capacityReservationGroupID,omitempty"`
 
 	// Count: Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive)
 	// for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1.
@@ -68,7 +70,11 @@ type ManagedClusterAgentPoolProfileProperties struct {
 
 	// GpuInstanceProfile: GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU.
 	GpuInstanceProfile *GPUInstanceProfile `json:"gpuInstanceProfile,omitempty"`
-	HostGroupID        *string             `json:"hostGroupID,omitempty"`
+
+	// HostGroupID: This is of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}.
+	// For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts).
+	HostGroupID *string `json:"hostGroupID,omitempty"`
 
 	// KubeletConfig: The Kubelet configuration on the agent pool nodes.
 	KubeletConfig *KubeletConfig `json:"kubeletConfig,omitempty"`
@@ -97,8 +103,11 @@ type ManagedClusterAgentPoolProfileProperties struct {
 	NetworkProfile *AgentPoolNetworkProfile `json:"networkProfile,omitempty"`
 
 	// NodeLabels: The node labels to be persisted across all nodes in agent pool.
-	NodeLabels           map[string]string `json:"nodeLabels" serializationType:"explicitEmptyCollection"`
-	NodePublicIPPrefixID *string           `json:"nodePublicIPPrefixID,omitempty"`
+	NodeLabels map[string]string `json:"nodeLabels" serializationType:"explicitEmptyCollection"`
+
+	// NodePublicIPPrefixID: This is of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}
+	NodePublicIPPrefixID *string `json:"nodePublicIPPrefixID,omitempty"`
 
 	// NodeTaints: The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule.
 	NodeTaints []string `json:"nodeTaints" serializationType:"explicitEmptyCollection"`
@@ -124,14 +133,20 @@ type ManagedClusterAgentPoolProfileProperties struct {
 	OsSKU *OSSKU `json:"osSKU,omitempty"`
 
 	// OsType: The operating system type. The default is Linux.
-	OsType      *OSType `json:"osType,omitempty"`
+	OsType *OSType `json:"osType,omitempty"`
+
+	// PodSubnetID: If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is
+	// of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
 	PodSubnetID *string `json:"podSubnetID,omitempty"`
 
 	// PowerState: When an Agent Pool is first created it is initially Running. The Agent Pool can be stopped by setting this
 	// field to Stopped. A stopped Agent Pool stops all of its VMs and does not accrue billing charges. An Agent Pool can only
 	// be stopped if it is Running and provisioning state is Succeeded
-	PowerState                *PowerState `json:"powerState,omitempty"`
-	ProximityPlacementGroupID *string     `json:"proximityPlacementGroupID,omitempty"`
+	PowerState *PowerState `json:"powerState,omitempty"`
+
+	// ProximityPlacementGroupID: The ID for Proximity Placement Group.
+	ProximityPlacementGroupID *string `json:"proximityPlacementGroupID,omitempty"`
 
 	// ScaleDownMode: This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete.
 	ScaleDownMode *ScaleDownMode `json:"scaleDownMode,omitempty"`
@@ -163,7 +178,11 @@ type ManagedClusterAgentPoolProfileProperties struct {
 	// VmSize: VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods
 	// might fail to run correctly. For more details on restricted VM sizes, see:
 	// https://docs.microsoft.com/azure/aks/quotas-skus-regions
-	VmSize       *string `json:"vmSize,omitempty"`
+	VmSize *string `json:"vmSize,omitempty"`
+
+	// VnetSubnetID: If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified,
+	// this applies to nodes and pods, otherwise it applies to just nodes. This is of the form:
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
 	VnetSubnetID *string `json:"vnetSubnetID,omitempty"`
 
 	// WindowsProfile: The Windows agent pool's specific profile.
@@ -192,8 +211,10 @@ var agentPoolMode_Values = map[string]AgentPoolMode{
 // Network settings of an agent pool.
 type AgentPoolNetworkProfile struct {
 	// AllowedHostPorts: The port ranges that are allowed to access. The specified ranges are allowed to overlap.
-	AllowedHostPorts          []PortRange `json:"allowedHostPorts"`
-	ApplicationSecurityGroups []string    `json:"applicationSecurityGroups,omitempty"`
+	AllowedHostPorts []PortRange `json:"allowedHostPorts"`
+
+	// ApplicationSecurityGroups: The IDs of the application security groups which agent pool will associate when created.
+	ApplicationSecurityGroups []string `json:"applicationSecurityGroups,omitempty"`
 
 	// NodePublicIPTags: IPTags of instance-level public IPs.
 	NodePublicIPTags []IPTag `json:"nodePublicIPTags"`
@@ -252,6 +273,7 @@ type AgentPoolWindowsProfile struct {
 
 // Data used when creating a target resource from a source resource.
 type CreationData struct {
+	// SourceResourceId: This is the ARM ID of the source object to be used to create the target object.
 	SourceResourceId *string `json:"sourceResourceId,omitempty"`
 }
 

--- a/v2/api/containerservice/v1api20240901/arm/trusted_access_role_binding_spec_types_gen.go
+++ b/v2/api/containerservice/v1api20240901/arm/trusted_access_role_binding_spec_types_gen.go
@@ -33,6 +33,8 @@ func (binding *TrustedAccessRoleBinding_Spec) GetType() string {
 type TrustedAccessRoleBindingProperties struct {
 	// Roles: A list of roles to bind, each item is a resource type qualified role name. For example:
 	// 'Microsoft.MachineLearningServices/workspaces/reader'.
-	Roles            []string `json:"roles"`
-	SourceResourceId *string  `json:"sourceResourceId,omitempty"`
+	Roles []string `json:"roles"`
+
+	// SourceResourceId: The ARM resource ID of source resource that trusted access is configured for.
+	SourceResourceId *string `json:"sourceResourceId,omitempty"`
 }

--- a/v2/api/datafactory/v1api20180601/arm/factory_spec_types_gen.go
+++ b/v2/api/datafactory/v1api20180601/arm/factory_spec_types_gen.go
@@ -167,6 +167,7 @@ type GlobalParameterSpecification struct {
 
 // Purview configuration.
 type PurviewConfiguration struct {
+	// PurviewResourceId: Purview resource id.
 	PurviewResourceId *string `json:"purviewResourceId,omitempty"`
 }
 
@@ -176,6 +177,7 @@ type UserAssignedIdentityDetails struct {
 
 // Managed Identity used for CMK.
 type CMKIdentityDefinition struct {
+	// UserAssignedIdentity: The resource id of the user assigned identity to authenticate to customer's key vault.
 	UserAssignedIdentity *string `json:"userAssignedIdentity,omitempty"`
 }
 

--- a/v2/api/dataprotection/v1api20231101/arm/backup_vaults_backup_instance_spec_types_gen.go
+++ b/v2/api/dataprotection/v1api20231101/arm/backup_vaults_backup_instance_spec_types_gen.go
@@ -114,6 +114,9 @@ type Datasource struct {
 
 	// ObjectType: Type of Datasource object, used to initialize the right inherited type
 	ObjectType *string `json:"objectType,omitempty"`
+
+	// ResourceID: Full ARM ID of the resource. For azure resources, this is ARM ID. For non azure resources, this will be the
+	// ID created by backup service via Fabric/Vault.
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// ResourceLocation: Location of datasource.
@@ -139,6 +142,9 @@ type DatasourceSet struct {
 
 	// ObjectType: Type of Datasource object, used to initialize the right inherited type
 	ObjectType *string `json:"objectType,omitempty"`
+
+	// ResourceID: Full ARM ID of the resource. For azure resources, this is ARM ID. For non azure resources, this will be the
+	// ID created by backup service via Fabric/Vault.
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// ResourceLocation: Location of datasource.
@@ -326,8 +332,10 @@ type AzureOperationalStoreParameters struct {
 	DataStoreType *AzureOperationalStoreParameters_DataStoreType `json:"dataStoreType,omitempty"`
 
 	// ObjectType: Type of the specific object - used for deserializing
-	ObjectType      AzureOperationalStoreParameters_ObjectType `json:"objectType,omitempty"`
-	ResourceGroupId *string                                    `json:"resourceGroupId,omitempty"`
+	ObjectType AzureOperationalStoreParameters_ObjectType `json:"objectType,omitempty"`
+
+	// ResourceGroupId: Gets or sets the Snapshot Resource Group Uri.
+	ResourceGroupId *string `json:"resourceGroupId,omitempty"`
 }
 
 type BlobBackupDatasourceParameters struct {

--- a/v2/api/dbformysql/v1api20210501/arm/flexible_server_spec_types_gen.go
+++ b/v2/api/dbformysql/v1api20210501/arm/flexible_server_spec_types_gen.go
@@ -114,11 +114,16 @@ type Backup struct {
 // The date encryption for cmk.
 type DataEncryption struct {
 	// GeoBackupKeyURI: Geo backup key uri as key vault can't cross region, need cmk in same region as geo backup
-	GeoBackupKeyURI                 *string `json:"geoBackupKeyURI,omitempty"`
+	GeoBackupKeyURI *string `json:"geoBackupKeyURI,omitempty"`
+
+	// GeoBackupUserAssignedIdentityId: Geo backup user identity resource id as identity can't cross region, need identity in
+	// same region as geo backup
 	GeoBackupUserAssignedIdentityId *string `json:"geoBackupUserAssignedIdentityId,omitempty"`
 
 	// PrimaryKeyURI: Primary key uri
-	PrimaryKeyURI                 *string `json:"primaryKeyURI,omitempty"`
+	PrimaryKeyURI *string `json:"primaryKeyURI,omitempty"`
+
+	// PrimaryUserAssignedIdentityId: Primary user identity resource id
 	PrimaryUserAssignedIdentityId *string `json:"primaryUserAssignedIdentityId,omitempty"`
 
 	// Type: The key type, AzureKeyVault for enable cmk, SystemManaged for disable cmk.
@@ -161,8 +166,11 @@ type MaintenanceWindow struct {
 
 // Network related properties of a server
 type Network struct {
+	// DelegatedSubnetResourceId: Delegated subnet resource id used to setup vnet for a server.
 	DelegatedSubnetResourceId *string `json:"delegatedSubnetResourceId,omitempty"`
-	PrivateDnsZoneResourceId  *string `json:"privateDnsZoneResourceId,omitempty"`
+
+	// PrivateDnsZoneResourceId: Private DNS zone resource id.
+	PrivateDnsZoneResourceId *string `json:"privateDnsZoneResourceId,omitempty"`
 }
 
 // The replication role.

--- a/v2/api/dbformysql/v1api20220101/arm/flexible_servers_administrator_spec_types_gen.go
+++ b/v2/api/dbformysql/v1api20220101/arm/flexible_servers_administrator_spec_types_gen.go
@@ -32,8 +32,10 @@ func (administrator *FlexibleServersAdministrator_Spec) GetType() string {
 // The properties of an administrator.
 type AdministratorProperties struct {
 	// AdministratorType: Type of the sever administrator.
-	AdministratorType  *AdministratorProperties_AdministratorType `json:"administratorType,omitempty"`
-	IdentityResourceId *string                                    `json:"identityResourceId,omitempty"`
+	AdministratorType *AdministratorProperties_AdministratorType `json:"administratorType,omitempty"`
+
+	// IdentityResourceId: The resource id of the identity used for AAD Authentication.
+	IdentityResourceId *string `json:"identityResourceId,omitempty"`
 
 	// Login: Login name of the server administrator.
 	Login *string `json:"login,omitempty"`

--- a/v2/api/dbformysql/v1api20230630/arm/flexible_server_spec_types_gen.go
+++ b/v2/api/dbformysql/v1api20230630/arm/flexible_server_spec_types_gen.go
@@ -93,7 +93,9 @@ type ServerProperties struct {
 	ReplicationRole *ReplicationRole `json:"replicationRole,omitempty"`
 
 	// RestorePointInTime: Restore point creation time (ISO8601 format), specifying the time to restore from.
-	RestorePointInTime     *string `json:"restorePointInTime,omitempty"`
+	RestorePointInTime *string `json:"restorePointInTime,omitempty"`
+
+	// SourceServerResourceId: The source MySQL server id.
 	SourceServerResourceId *string `json:"sourceServerResourceId,omitempty"`
 
 	// Storage: Storage related properties of a server.
@@ -115,11 +117,16 @@ type Backup struct {
 // The date encryption for cmk.
 type DataEncryption struct {
 	// GeoBackupKeyURI: Geo backup key uri as key vault can't cross region, need cmk in same region as geo backup
-	GeoBackupKeyURI                 *string `json:"geoBackupKeyURI,omitempty"`
+	GeoBackupKeyURI *string `json:"geoBackupKeyURI,omitempty"`
+
+	// GeoBackupUserAssignedIdentityId: Geo backup user identity resource id as identity can't cross region, need identity in
+	// same region as geo backup
 	GeoBackupUserAssignedIdentityId *string `json:"geoBackupUserAssignedIdentityId,omitempty"`
 
 	// PrimaryKeyURI: Primary key uri
-	PrimaryKeyURI                 *string `json:"primaryKeyURI,omitempty"`
+	PrimaryKeyURI *string `json:"primaryKeyURI,omitempty"`
+
+	// PrimaryUserAssignedIdentityId: Primary user identity resource id
 	PrimaryUserAssignedIdentityId *string `json:"primaryUserAssignedIdentityId,omitempty"`
 
 	// Type: The key type, AzureKeyVault for enable cmk, SystemManaged for disable cmk.
@@ -193,8 +200,11 @@ var mySQLServerSku_Tier_Values = map[string]MySQLServerSku_Tier{
 
 // Network related properties of a server
 type Network struct {
+	// DelegatedSubnetResourceId: Delegated subnet resource id used to setup vnet for a server.
 	DelegatedSubnetResourceId *string `json:"delegatedSubnetResourceId,omitempty"`
-	PrivateDnsZoneResourceId  *string `json:"privateDnsZoneResourceId,omitempty"`
+
+	// PrivateDnsZoneResourceId: Private DNS zone resource id.
+	PrivateDnsZoneResourceId *string `json:"privateDnsZoneResourceId,omitempty"`
 
 	// PublicNetworkAccess: Whether or not public network access is allowed for this server. Value is 'Disabled' when server
 	// has VNet integration.

--- a/v2/api/dbformysql/v1api20230630/arm/flexible_servers_administrator_spec_types_gen.go
+++ b/v2/api/dbformysql/v1api20230630/arm/flexible_servers_administrator_spec_types_gen.go
@@ -32,8 +32,10 @@ func (administrator *FlexibleServersAdministrator_Spec) GetType() string {
 // The properties of an administrator.
 type AdministratorProperties struct {
 	// AdministratorType: Type of the sever administrator.
-	AdministratorType  *AdministratorProperties_AdministratorType `json:"administratorType,omitempty"`
-	IdentityResourceId *string                                    `json:"identityResourceId,omitempty"`
+	AdministratorType *AdministratorProperties_AdministratorType `json:"administratorType,omitempty"`
+
+	// IdentityResourceId: The resource id of the identity used for AAD Authentication.
+	IdentityResourceId *string `json:"identityResourceId,omitempty"`
 
 	// Login: Login name of the server administrator.
 	Login *string `json:"login,omitempty"`

--- a/v2/api/dbformysql/v1api20231230/arm/flexible_server_spec_types_gen.go
+++ b/v2/api/dbformysql/v1api20231230/arm/flexible_server_spec_types_gen.go
@@ -93,7 +93,9 @@ type ServerProperties struct {
 	ReplicationRole *ReplicationRole `json:"replicationRole,omitempty"`
 
 	// RestorePointInTime: Restore point creation time (ISO8601 format), specifying the time to restore from.
-	RestorePointInTime     *string `json:"restorePointInTime,omitempty"`
+	RestorePointInTime *string `json:"restorePointInTime,omitempty"`
+
+	// SourceServerResourceId: The source MySQL server id.
 	SourceServerResourceId *string `json:"sourceServerResourceId,omitempty"`
 
 	// Storage: Storage related properties of a server.
@@ -118,11 +120,16 @@ type Backup struct {
 // The date encryption for cmk.
 type DataEncryption struct {
 	// GeoBackupKeyURI: Geo backup key uri as key vault can't cross region, need cmk in same region as geo backup
-	GeoBackupKeyURI                 *string `json:"geoBackupKeyURI,omitempty"`
+	GeoBackupKeyURI *string `json:"geoBackupKeyURI,omitempty"`
+
+	// GeoBackupUserAssignedIdentityId: Geo backup user identity resource id as identity can't cross region, need identity in
+	// same region as geo backup
 	GeoBackupUserAssignedIdentityId *string `json:"geoBackupUserAssignedIdentityId,omitempty"`
 
 	// PrimaryKeyURI: Primary key uri
-	PrimaryKeyURI                 *string `json:"primaryKeyURI,omitempty"`
+	PrimaryKeyURI *string `json:"primaryKeyURI,omitempty"`
+
+	// PrimaryUserAssignedIdentityId: Primary user identity resource id
 	PrimaryUserAssignedIdentityId *string `json:"primaryUserAssignedIdentityId,omitempty"`
 
 	// Type: The key type, AzureKeyVault for enable cmk, SystemManaged for disable cmk.
@@ -196,8 +203,11 @@ var mySQLServerSku_Tier_Values = map[string]MySQLServerSku_Tier{
 
 // Network related properties of a server
 type Network struct {
+	// DelegatedSubnetResourceId: Delegated subnet resource id used to setup vnet for a server.
 	DelegatedSubnetResourceId *string `json:"delegatedSubnetResourceId,omitempty"`
-	PrivateDnsZoneResourceId  *string `json:"privateDnsZoneResourceId,omitempty"`
+
+	// PrivateDnsZoneResourceId: Private DNS zone resource id.
+	PrivateDnsZoneResourceId *string `json:"privateDnsZoneResourceId,omitempty"`
 
 	// PublicNetworkAccess: Whether or not public network access is allowed for this server. Value is 'Disabled' when server
 	// has VNet integration.

--- a/v2/api/dbformysql/v1api20231230/arm/flexible_servers_administrator_spec_types_gen.go
+++ b/v2/api/dbformysql/v1api20231230/arm/flexible_servers_administrator_spec_types_gen.go
@@ -32,8 +32,10 @@ func (administrator *FlexibleServersAdministrator_Spec) GetType() string {
 // The properties of an administrator.
 type AdministratorProperties struct {
 	// AdministratorType: Type of the sever administrator.
-	AdministratorType  *AdministratorProperties_AdministratorType `json:"administratorType,omitempty"`
-	IdentityResourceId *string                                    `json:"identityResourceId,omitempty"`
+	AdministratorType *AdministratorProperties_AdministratorType `json:"administratorType,omitempty"`
+
+	// IdentityResourceId: The resource id of the identity used for AAD Authentication.
+	IdentityResourceId *string `json:"identityResourceId,omitempty"`
 
 	// Login: Login name of the server administrator.
 	Login *string `json:"login,omitempty"`

--- a/v2/api/dbforpostgresql/v1api20210601/arm/flexible_server_spec_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20210601/arm/flexible_server_spec_types_gen.go
@@ -66,7 +66,10 @@ type ServerProperties struct {
 
 	// PointInTimeUTC: Restore point creation time (ISO8601 format), specifying the time to restore from. It's required when
 	// 'createMode' is 'PointInTimeRestore'.
-	PointInTimeUTC         *string `json:"pointInTimeUTC,omitempty"`
+	PointInTimeUTC *string `json:"pointInTimeUTC,omitempty"`
+
+	// SourceServerResourceId: The source server resource ID to restore from. It's required when 'createMode' is
+	// 'PointInTimeRestore'.
 	SourceServerResourceId *string `json:"sourceServerResourceId,omitempty"`
 
 	// Storage: Storage properties of a server.
@@ -120,7 +123,10 @@ type MaintenanceWindow struct {
 
 // Network properties of a server
 type Network struct {
-	DelegatedSubnetResourceId   *string `json:"delegatedSubnetResourceId,omitempty"`
+	// DelegatedSubnetResourceId: delegated subnet arm resource id.
+	DelegatedSubnetResourceId *string `json:"delegatedSubnetResourceId,omitempty"`
+
+	// PrivateDnsZoneArmResourceId: private dns zone arm resource id.
 	PrivateDnsZoneArmResourceId *string `json:"privateDnsZoneArmResourceId,omitempty"`
 }
 

--- a/v2/api/dbforpostgresql/v1api20220120preview/arm/flexible_server_spec_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20220120preview/arm/flexible_server_spec_types_gen.go
@@ -66,7 +66,10 @@ type ServerProperties struct {
 
 	// PointInTimeUTC: Restore point creation time (ISO8601 format), specifying the time to restore from. It's required when
 	// 'createMode' is 'PointInTimeRestore'.
-	PointInTimeUTC         *string `json:"pointInTimeUTC,omitempty"`
+	PointInTimeUTC *string `json:"pointInTimeUTC,omitempty"`
+
+	// SourceServerResourceId: The source server resource ID to restore from. It's required when 'createMode' is
+	// 'PointInTimeRestore'.
 	SourceServerResourceId *string `json:"sourceServerResourceId,omitempty"`
 
 	// Storage: Storage properties of a server.
@@ -120,7 +123,10 @@ type MaintenanceWindow struct {
 
 // Network properties of a server
 type Network struct {
-	DelegatedSubnetResourceId   *string `json:"delegatedSubnetResourceId,omitempty"`
+	// DelegatedSubnetResourceId: delegated subnet arm resource id.
+	DelegatedSubnetResourceId *string `json:"delegatedSubnetResourceId,omitempty"`
+
+	// PrivateDnsZoneArmResourceId: private dns zone arm resource id.
 	PrivateDnsZoneArmResourceId *string `json:"privateDnsZoneArmResourceId,omitempty"`
 }
 

--- a/v2/api/dbforpostgresql/v1api20221201/arm/flexible_server_spec_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20221201/arm/flexible_server_spec_types_gen.go
@@ -79,8 +79,11 @@ type ServerProperties struct {
 	PointInTimeUTC *string `json:"pointInTimeUTC,omitempty"`
 
 	// ReplicationRole: Replication role of the server
-	ReplicationRole        *ReplicationRole `json:"replicationRole,omitempty"`
-	SourceServerResourceId *string          `json:"sourceServerResourceId,omitempty"`
+	ReplicationRole *ReplicationRole `json:"replicationRole,omitempty"`
+
+	// SourceServerResourceId: The source server resource ID to restore from. It's required when 'createMode' is
+	// 'PointInTimeRestore' or 'GeoRestore' or 'Replica'. This property is returned only for Replica server
+	SourceServerResourceId *string `json:"sourceServerResourceId,omitempty"`
 
 	// Storage: Storage properties of a server.
 	Storage *Storage `json:"storage,omitempty"`
@@ -129,7 +132,10 @@ type Backup struct {
 // Data encryption properties of a server
 type DataEncryption struct {
 	// PrimaryKeyURI: URI for the key for data encryption for primary server.
-	PrimaryKeyURI                 *string `json:"primaryKeyURI,omitempty" optionalConfigMapPair:"PrimaryKeyURI"`
+	PrimaryKeyURI *string `json:"primaryKeyURI,omitempty" optionalConfigMapPair:"PrimaryKeyURI"`
+
+	// PrimaryUserAssignedIdentityId: Resource Id for the User assigned identity to be used for data encryption for primary
+	// server.
 	PrimaryUserAssignedIdentityId *string `json:"primaryUserAssignedIdentityId,omitempty"`
 
 	// Type: Data encryption type to depict if it is System Managed vs Azure Key vault.
@@ -162,7 +168,14 @@ type MaintenanceWindow struct {
 
 // Network properties of a server.
 type Network struct {
-	DelegatedSubnetResourceId   *string `json:"delegatedSubnetResourceId,omitempty"`
+	// DelegatedSubnetResourceId: Delegated subnet arm resource id. This is required to be passed during create, in case we
+	// want the server to be VNET injected, i.e. Private access server. During update, pass this only if we want to update the
+	// value for Private DNS zone.
+	DelegatedSubnetResourceId *string `json:"delegatedSubnetResourceId,omitempty"`
+
+	// PrivateDnsZoneArmResourceId: Private dns zone arm resource id. This is required to be passed during create, in case we
+	// want the server to be VNET injected, i.e. Private access server. During update, pass this only if we want to update the
+	// value for Private DNS zone.
 	PrivateDnsZoneArmResourceId *string `json:"privateDnsZoneArmResourceId,omitempty"`
 }
 

--- a/v2/api/dbforpostgresql/v1api20230601preview/arm/flexible_server_spec_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20230601preview/arm/flexible_server_spec_types_gen.go
@@ -83,8 +83,11 @@ type ServerProperties struct {
 	Replica *Replica `json:"replica,omitempty"`
 
 	// ReplicationRole: Replication role of the server
-	ReplicationRole        *ReplicationRole `json:"replicationRole,omitempty"`
-	SourceServerResourceId *string          `json:"sourceServerResourceId,omitempty"`
+	ReplicationRole *ReplicationRole `json:"replicationRole,omitempty"`
+
+	// SourceServerResourceId: The source server resource ID to restore from. It's required when 'createMode' is
+	// 'PointInTimeRestore' or 'GeoRestore' or 'Replica' or 'ReviveDropped'. This property is returned only for Replica server
+	SourceServerResourceId *string `json:"sourceServerResourceId,omitempty"`
 
 	// Storage: Storage properties of a server.
 	Storage *Storage `json:"storage,omitempty"`
@@ -136,14 +139,20 @@ type DataEncryption struct {
 	GeoBackupEncryptionKeyStatus *DataEncryption_GeoBackupEncryptionKeyStatus `json:"geoBackupEncryptionKeyStatus,omitempty"`
 
 	// GeoBackupKeyURI: URI for the key in keyvault for data encryption for geo-backup of server.
-	GeoBackupKeyURI                 *string `json:"geoBackupKeyURI,omitempty" optionalConfigMapPair:"GeoBackupKeyURI"`
+	GeoBackupKeyURI *string `json:"geoBackupKeyURI,omitempty" optionalConfigMapPair:"GeoBackupKeyURI"`
+
+	// GeoBackupUserAssignedIdentityId: Resource Id for the User assigned identity to be used for data encryption for
+	// geo-backup of server.
 	GeoBackupUserAssignedIdentityId *string `json:"geoBackupUserAssignedIdentityId,omitempty"`
 
 	// PrimaryEncryptionKeyStatus: Primary encryption key status for Data encryption enabled server.
 	PrimaryEncryptionKeyStatus *DataEncryption_PrimaryEncryptionKeyStatus `json:"primaryEncryptionKeyStatus,omitempty"`
 
 	// PrimaryKeyURI: URI for the key in keyvault for data encryption of the primary server.
-	PrimaryKeyURI                 *string `json:"primaryKeyURI,omitempty" optionalConfigMapPair:"PrimaryKeyURI"`
+	PrimaryKeyURI *string `json:"primaryKeyURI,omitempty" optionalConfigMapPair:"PrimaryKeyURI"`
+
+	// PrimaryUserAssignedIdentityId: Resource Id for the User assigned identity to be used for data encryption of the primary
+	// server.
 	PrimaryUserAssignedIdentityId *string `json:"primaryUserAssignedIdentityId,omitempty"`
 
 	// Type: Data encryption type to depict if it is System Managed vs Azure Key vault.
@@ -176,7 +185,14 @@ type MaintenanceWindow struct {
 
 // Network properties of a server.
 type Network struct {
-	DelegatedSubnetResourceId   *string `json:"delegatedSubnetResourceId,omitempty"`
+	// DelegatedSubnetResourceId: Delegated subnet arm resource id. This is required to be passed during create, in case we
+	// want the server to be VNET injected, i.e. Private access server. During update, pass this only if we want to update the
+	// value for Private DNS zone.
+	DelegatedSubnetResourceId *string `json:"delegatedSubnetResourceId,omitempty"`
+
+	// PrivateDnsZoneArmResourceId: Private dns zone arm resource id. This is required to be passed during create, in case we
+	// want the server to be VNET injected, i.e. Private access server. During update, pass this only if we want to update the
+	// value for Private DNS zone.
 	PrivateDnsZoneArmResourceId *string `json:"privateDnsZoneArmResourceId,omitempty"`
 
 	// PublicNetworkAccess: public network access is enabled or not

--- a/v2/api/dbforpostgresql/v1api20240801/arm/flexible_server_spec_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20240801/arm/flexible_server_spec_types_gen.go
@@ -85,8 +85,12 @@ type ServerProperties struct {
 	Replica *Replica `json:"replica,omitempty"`
 
 	// ReplicationRole: Role of the server in a replication set.
-	ReplicationRole        *ReplicationRole `json:"replicationRole,omitempty"`
-	SourceServerResourceId *string          `json:"sourceServerResourceId,omitempty"`
+	ReplicationRole *ReplicationRole `json:"replicationRole,omitempty"`
+
+	// SourceServerResourceId: Identifier of the flexible server to be used as the source of the new flexible server. Required
+	// when 'createMode' is 'PointInTimeRestore', 'GeoRestore', 'Replica', or 'ReviveDropped'. This property is returned only
+	// when the target flexible server is a read replica.
+	SourceServerResourceId *string `json:"sourceServerResourceId,omitempty"`
 
 	// Storage: Storage properties of a flexible server.
 	Storage *Storage `json:"storage,omitempty"`
@@ -145,7 +149,11 @@ type DataEncryption struct {
 	// GeoBackupKeyURI: Identifier of the user assigned managed identity used to access the key in Azure Key Vault for data
 	// encryption of the geographically redundant storage associated to a flexible server that is configured to support
 	// geographically redundant backups.
-	GeoBackupKeyURI                 *string `json:"geoBackupKeyURI,omitempty" optionalConfigMapPair:"GeoBackupKeyURI"`
+	GeoBackupKeyURI *string `json:"geoBackupKeyURI,omitempty" optionalConfigMapPair:"GeoBackupKeyURI"`
+
+	// GeoBackupUserAssignedIdentityId: Identifier of the user assigned managed identity used to access the key in Azure Key
+	// Vault for data encryption of the geographically redundant storage associated to a flexible server that is configured to
+	// support geographically redundant backups.
 	GeoBackupUserAssignedIdentityId *string `json:"geoBackupUserAssignedIdentityId,omitempty"`
 
 	// PrimaryEncryptionKeyStatus: Status of key used by a flexible server configured with data encryption based on customer
@@ -154,7 +162,10 @@ type DataEncryption struct {
 
 	// PrimaryKeyURI: URI of the key in Azure Key Vault used for data encryption of the primary storage associated to a
 	// flexible server.
-	PrimaryKeyURI                 *string `json:"primaryKeyURI,omitempty" optionalConfigMapPair:"PrimaryKeyURI"`
+	PrimaryKeyURI *string `json:"primaryKeyURI,omitempty" optionalConfigMapPair:"PrimaryKeyURI"`
+
+	// PrimaryUserAssignedIdentityId: Identifier of the user assigned managed identity used to access the key in Azure Key
+	// Vault for data encryption of the primary storage associated to a flexible server.
 	PrimaryUserAssignedIdentityId *string `json:"primaryUserAssignedIdentityId,omitempty"`
 
 	// Type: Data encryption type used by a flexible server.
@@ -188,7 +199,14 @@ type MaintenanceWindow struct {
 
 // Network properties of a flexible server.
 type Network struct {
-	DelegatedSubnetResourceId   *string `json:"delegatedSubnetResourceId,omitempty"`
+	// DelegatedSubnetResourceId: Resource identifier of the delegated subnet. Required during creation of a new server, in
+	// case you want the server to be integrated into your own virtual network. For an update operation, you only have to
+	// provide this property if you want to change the value assigned for the private DNS zone.
+	DelegatedSubnetResourceId *string `json:"delegatedSubnetResourceId,omitempty"`
+
+	// PrivateDnsZoneArmResourceId: Identifier of the private DNS zone. Required during creation of a new server, in case you
+	// want the server to be integrated into your own virtual network. For an update operation, you only have to provide this
+	// property if you want to change the value assigned for the private DNS zone.
 	PrivateDnsZoneArmResourceId *string `json:"privateDnsZoneArmResourceId,omitempty"`
 
 	// PublicNetworkAccess: Indicates if public network access is enabled or not.

--- a/v2/api/devices/v1api20210702/arm/iot_hub_spec_types_gen.go
+++ b/v2/api/devices/v1api20210702/arm/iot_hub_spec_types_gen.go
@@ -558,7 +558,9 @@ type RoutingEventHubProperties struct {
 
 	// EntityPath: Event hub name on the event hub namespace
 	EntityPath *string `json:"entityPath,omitempty"`
-	Id         *string `json:"id,omitempty"`
+
+	// Id: Id of the event hub endpoint
+	Id *string `json:"id,omitempty"`
 
 	// Identity: Managed identity properties of routing event hub endpoint.
 	Identity *ManagedIdentity `json:"identity,omitempty"`
@@ -588,7 +590,9 @@ type RoutingServiceBusQueueEndpointProperties struct {
 
 	// EntityPath: Queue name on the service bus namespace
 	EntityPath *string `json:"entityPath,omitempty"`
-	Id         *string `json:"id,omitempty"`
+
+	// Id: Id of the service bus queue endpoint
+	Id *string `json:"id,omitempty"`
 
 	// Identity: Managed identity properties of routing service bus queue endpoint.
 	Identity *ManagedIdentity `json:"identity,omitempty"`
@@ -618,7 +622,9 @@ type RoutingServiceBusTopicEndpointProperties struct {
 
 	// EntityPath: Queue name on the service bus topic
 	EntityPath *string `json:"entityPath,omitempty"`
-	Id         *string `json:"id,omitempty"`
+
+	// Id: Id of the service bus topic endpoint
+	Id *string `json:"id,omitempty"`
 
 	// Identity: Managed identity properties of routing service bus topic endpoint.
 	Identity *ManagedIdentity `json:"identity,omitempty"`
@@ -660,7 +666,9 @@ type RoutingStorageContainerProperties struct {
 	// FileNameFormat: File name format for the blob. Default format is {iothub}/{partition}/{YYYY}/{MM}/{DD}/{HH}/{mm}. All
 	// parameters are mandatory but can be reordered.
 	FileNameFormat *string `json:"fileNameFormat,omitempty"`
-	Id             *string `json:"id,omitempty"`
+
+	// Id: Id of the storage container endpoint
+	Id *string `json:"id,omitempty"`
 
 	// Identity: Managed identity properties of routing storage endpoint.
 	Identity *ManagedIdentity `json:"identity,omitempty"`

--- a/v2/api/documentdb/v1api20210515/arm/database_account_spec_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/arm/database_account_spec_types_gen.go
@@ -335,6 +335,8 @@ type UserAssignedIdentityDetails struct {
 
 // Virtual Network ACL Rule object
 type VirtualNetworkRule struct {
+	// Id: Resource ID of a subnet, for example:
+	// /subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}.
 	Id *string `json:"id,omitempty"`
 
 	// IgnoreMissingVNetServiceEndpoint: Create firewall rule before the virtual network has vnet service endpoint enabled.

--- a/v2/api/documentdb/v1api20231115/arm/database_account_spec_types_gen.go
+++ b/v2/api/documentdb/v1api20231115/arm/database_account_spec_types_gen.go
@@ -144,8 +144,10 @@ type DatabaseAccountCreateUpdateProperties struct {
 	MinimalTlsVersion *MinimalTlsVersion `json:"minimalTlsVersion,omitempty"`
 
 	// NetworkAclBypass: Indicates what services are allowed to bypass firewall checks.
-	NetworkAclBypass            *NetworkAclBypass `json:"networkAclBypass,omitempty"`
-	NetworkAclBypassResourceIds []string          `json:"networkAclBypassResourceIds,omitempty"`
+	NetworkAclBypass *NetworkAclBypass `json:"networkAclBypass,omitempty"`
+
+	// NetworkAclBypassResourceIds: An array that contains the Resource Ids for Network Acl Bypass for the Cosmos DB account.
+	NetworkAclBypassResourceIds []string `json:"networkAclBypassResourceIds,omitempty"`
 
 	// PublicNetworkAccess: Whether requests from Public Network are allowed
 	PublicNetworkAccess *PublicNetworkAccess `json:"publicNetworkAccess,omitempty"`
@@ -423,6 +425,8 @@ type UserAssignedIdentityDetails struct {
 
 // Virtual Network ACL Rule object
 type VirtualNetworkRule struct {
+	// Id: Resource ID of a subnet, for example:
+	// /subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}.
 	Id *string `json:"id,omitempty"`
 
 	// IgnoreMissingVNetServiceEndpoint: Create firewall rule before the virtual network has vnet service endpoint enabled.

--- a/v2/api/documentdb/v1api20240701/arm/mongo_cluster_spec_types_gen.go
+++ b/v2/api/documentdb/v1api20240701/arm/mongo_cluster_spec_types_gen.go
@@ -115,14 +115,18 @@ type HighAvailabilityProperties struct {
 // Parameters used for replica operations.
 type MongoClusterReplicaParameters struct {
 	// SourceLocation: The location of the source cluster
-	SourceLocation   *string `json:"sourceLocation,omitempty"`
+	SourceLocation *string `json:"sourceLocation,omitempty"`
+
+	// SourceResourceId: The id of the replication source cluster.
 	SourceResourceId *string `json:"sourceResourceId,omitempty"`
 }
 
 // Parameters used for restore operations
 type MongoClusterRestoreParameters struct {
 	// PointInTimeUTC: UTC point in time to restore a mongo cluster
-	PointInTimeUTC   *string `json:"pointInTimeUTC,omitempty"`
+	PointInTimeUTC *string `json:"pointInTimeUTC,omitempty"`
+
+	// SourceResourceId: Resource ID to locate the source cluster to restore
 	SourceResourceId *string `json:"sourceResourceId,omitempty"`
 }
 

--- a/v2/api/documentdb/v1api20240815/arm/database_account_spec_types_gen.go
+++ b/v2/api/documentdb/v1api20240815/arm/database_account_spec_types_gen.go
@@ -144,8 +144,10 @@ type DatabaseAccountCreateUpdateProperties struct {
 	MinimalTlsVersion *MinimalTlsVersion `json:"minimalTlsVersion,omitempty"`
 
 	// NetworkAclBypass: Indicates what services are allowed to bypass firewall checks.
-	NetworkAclBypass            *NetworkAclBypass `json:"networkAclBypass,omitempty"`
-	NetworkAclBypassResourceIds []string          `json:"networkAclBypassResourceIds,omitempty"`
+	NetworkAclBypass *NetworkAclBypass `json:"networkAclBypass,omitempty"`
+
+	// NetworkAclBypassResourceIds: An array that contains the Resource Ids for Network Acl Bypass for the Cosmos DB account.
+	NetworkAclBypassResourceIds []string `json:"networkAclBypassResourceIds,omitempty"`
 
 	// PublicNetworkAccess: Whether requests from Public Network are allowed
 	PublicNetworkAccess *PublicNetworkAccess `json:"publicNetworkAccess,omitempty"`
@@ -427,6 +429,8 @@ type UserAssignedIdentityDetails struct {
 
 // Virtual Network ACL Rule object
 type VirtualNetworkRule struct {
+	// Id: Resource ID of a subnet, for example:
+	// /subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}.
 	Id *string `json:"id,omitempty"`
 
 	// IgnoreMissingVNetServiceEndpoint: Create firewall rule before the virtual network has vnet service endpoint enabled.

--- a/v2/api/eventgrid/v1api20200601/arm/event_subscription_spec_types_gen.go
+++ b/v2/api/eventgrid/v1api20200601/arm/event_subscription_spec_types_gen.go
@@ -465,8 +465,11 @@ type AzureFunctionEventSubscriptionDestinationProperties struct {
 	MaxEventsPerBatch *int `json:"maxEventsPerBatch,omitempty"`
 
 	// PreferredBatchSizeInKilobytes: Preferred batch size in Kilobytes.
-	PreferredBatchSizeInKilobytes *int    `json:"preferredBatchSizeInKilobytes,omitempty"`
-	ResourceId                    *string `json:"resourceId,omitempty"`
+	PreferredBatchSizeInKilobytes *int `json:"preferredBatchSizeInKilobytes,omitempty"`
+
+	// ResourceId: The Azure Resource Id that represents the endpoint of the Azure Function destination of an event
+	// subscription.
+	ResourceId *string `json:"resourceId,omitempty"`
 }
 
 type BoolEqualsAdvancedFilter struct {
@@ -492,6 +495,7 @@ var eventHubEventSubscriptionDestination_EndpointType_Values = map[string]EventH
 
 // The properties for a event hub destination.
 type EventHubEventSubscriptionDestinationProperties struct {
+	// ResourceId: The Azure Resource Id that represents the endpoint of an Event Hub destination of an event subscription.
 	ResourceId *string `json:"resourceId,omitempty"`
 }
 
@@ -507,6 +511,7 @@ var hybridConnectionEventSubscriptionDestination_EndpointType_Values = map[strin
 
 // The properties for a hybrid connection destination.
 type HybridConnectionEventSubscriptionDestinationProperties struct {
+	// ResourceId: The Azure Resource ID of an hybrid connection that is the destination of an event subscription.
 	ResourceId *string `json:"resourceId,omitempty"`
 }
 
@@ -588,6 +593,7 @@ var serviceBusQueueEventSubscriptionDestination_EndpointType_Values = map[string
 
 // The properties that represent the Service Bus destination of an event subscription.
 type ServiceBusQueueEventSubscriptionDestinationProperties struct {
+	// ResourceId: The Azure Resource Id that represents the endpoint of the Service Bus destination of an event subscription.
 	ResourceId *string `json:"resourceId,omitempty"`
 }
 
@@ -603,6 +609,8 @@ var serviceBusTopicEventSubscriptionDestination_EndpointType_Values = map[string
 
 // The properties that represent the Service Bus Topic destination of an event subscription.
 type ServiceBusTopicEventSubscriptionDestinationProperties struct {
+	// ResourceId: The Azure Resource Id that represents the endpoint of the Service Bus Topic destination of an event
+	// subscription.
 	ResourceId *string `json:"resourceId,omitempty"`
 }
 
@@ -620,7 +628,9 @@ var storageBlobDeadLetterDestination_EndpointType_Values = map[string]StorageBlo
 type StorageBlobDeadLetterDestinationProperties struct {
 	// BlobContainerName: The name of the Storage blob container that is the destination of the deadletter events
 	BlobContainerName *string `json:"blobContainerName,omitempty"`
-	ResourceId        *string `json:"resourceId,omitempty"`
+
+	// ResourceId: The Azure Resource ID of the storage account that is the destination of the deadletter events
+	ResourceId *string `json:"resourceId,omitempty"`
 }
 
 // +kubebuilder:validation:Enum={"StorageQueue"}
@@ -636,7 +646,10 @@ var storageQueueEventSubscriptionDestination_EndpointType_Values = map[string]St
 // The properties for a storage queue destination.
 type StorageQueueEventSubscriptionDestinationProperties struct {
 	// QueueName: The name of the Storage queue under a storage account that is the destination of an event subscription.
-	QueueName  *string `json:"queueName,omitempty"`
+	QueueName *string `json:"queueName,omitempty"`
+
+	// ResourceId: The Azure Resource ID of the storage account that contains the queue that is the destination of an event
+	// subscription.
 	ResourceId *string `json:"resourceId,omitempty"`
 }
 

--- a/v2/api/eventhub/v1api20211101/arm/namespace_spec_types_gen.go
+++ b/v2/api/eventhub/v1api20211101/arm/namespace_spec_types_gen.go
@@ -50,7 +50,9 @@ type Identity struct {
 type Namespace_Properties_Spec struct {
 	// AlternateName: Alternate name specified when alias and namespace names are same.
 	AlternateName *string `json:"alternateName,omitempty"`
-	ClusterArmId  *string `json:"clusterArmId,omitempty"`
+
+	// ClusterArmId: Cluster ARM ID of the Namespace.
+	ClusterArmId *string `json:"clusterArmId,omitempty"`
 
 	// DisableLocalAuth: This property disables SAS authentication for the Event Hubs namespace.
 	DisableLocalAuth *bool `json:"disableLocalAuth,omitempty"`
@@ -176,5 +178,6 @@ type KeyVaultProperties struct {
 }
 
 type UserAssignedIdentityProperties struct {
+	// UserAssignedIdentity: ARM ID of user Identity selected for encryption
 	UserAssignedIdentity *string `json:"userAssignedIdentity,omitempty"`
 }

--- a/v2/api/eventhub/v1api20211101/arm/namespaces_eventhub_spec_types_gen.go
+++ b/v2/api/eventhub/v1api20211101/arm/namespaces_eventhub_spec_types_gen.go
@@ -103,6 +103,8 @@ type Destination_Properties struct {
 	DataLakeFolderPath *string `json:"dataLakeFolderPath,omitempty"`
 
 	// DataLakeSubscriptionId: Subscription Id of Azure Data Lake Store
-	DataLakeSubscriptionId   *string `json:"dataLakeSubscriptionId,omitempty"`
+	DataLakeSubscriptionId *string `json:"dataLakeSubscriptionId,omitempty"`
+
+	// StorageAccountResourceId: Resource id of the storage account to be used to create the blobs
 	StorageAccountResourceId *string `json:"storageAccountResourceId,omitempty"`
 }

--- a/v2/api/eventhub/v1api20240101/arm/namespace_spec_types_gen.go
+++ b/v2/api/eventhub/v1api20240101/arm/namespace_spec_types_gen.go
@@ -50,7 +50,9 @@ type Identity struct {
 type Namespace_Properties_Spec struct {
 	// AlternateName: Alternate name specified when alias and namespace names are same.
 	AlternateName *string `json:"alternateName,omitempty"`
-	ClusterArmId  *string `json:"clusterArmId,omitempty"`
+
+	// ClusterArmId: Cluster ARM ID of the Namespace.
+	ClusterArmId *string `json:"clusterArmId,omitempty"`
 
 	// DisableLocalAuth: This property disables SAS authentication for the Event Hubs namespace.
 	DisableLocalAuth *bool `json:"disableLocalAuth,omitempty"`
@@ -214,5 +216,6 @@ type KeyVaultProperties struct {
 }
 
 type UserAssignedIdentityProperties struct {
+	// UserAssignedIdentity: ARM ID of user Identity selected for encryption
 	UserAssignedIdentity *string `json:"userAssignedIdentity,omitempty"`
 }

--- a/v2/api/eventhub/v1api20240101/arm/namespaces_eventhub_spec_types_gen.go
+++ b/v2/api/eventhub/v1api20240101/arm/namespaces_eventhub_spec_types_gen.go
@@ -129,8 +129,11 @@ var retentionDescription_CleanupPolicy_Values = map[string]RetentionDescription_
 // A value that indicates whether capture description is enabled.
 type CaptureIdentity struct {
 	// Type: Type of Azure Active Directory Managed Identity.
-	Type                 *CaptureIdentity_Type `json:"type,omitempty"`
-	UserAssignedIdentity *string               `json:"userAssignedIdentity,omitempty"`
+	Type *CaptureIdentity_Type `json:"type,omitempty"`
+
+	// UserAssignedIdentity: ARM ID of Managed User Identity. This property is required is the type is UserAssignedIdentity. If
+	// type is SystemAssigned, then the System Assigned Identity Associated with the namespace will be used.
+	UserAssignedIdentity *string `json:"userAssignedIdentity,omitempty"`
 }
 
 type Destination_Properties struct {
@@ -149,7 +152,9 @@ type Destination_Properties struct {
 	DataLakeFolderPath *string `json:"dataLakeFolderPath,omitempty"`
 
 	// DataLakeSubscriptionId: Subscription Id of Azure Data Lake Store
-	DataLakeSubscriptionId   *string `json:"dataLakeSubscriptionId,omitempty"`
+	DataLakeSubscriptionId *string `json:"dataLakeSubscriptionId,omitempty"`
+
+	// StorageAccountResourceId: Resource id of the storage account to be used to create the blobs
 	StorageAccountResourceId *string `json:"storageAccountResourceId,omitempty"`
 }
 

--- a/v2/api/insights/v1api20180301/arm/metric_alert_spec_types_gen.go
+++ b/v2/api/insights/v1api20180301/arm/metric_alert_spec_types_gen.go
@@ -57,8 +57,11 @@ type MetricAlertProperties struct {
 	Enabled *bool `json:"enabled,omitempty"`
 
 	// EvaluationFrequency: how often the metric alert is evaluated represented in ISO 8601 duration format.
-	EvaluationFrequency *string  `json:"evaluationFrequency,omitempty"`
-	Scopes              []string `json:"scopes,omitempty"`
+	EvaluationFrequency *string `json:"evaluationFrequency,omitempty"`
+
+	// Scopes: the list of resource id's that this metric alert is scoped to. You cannot change the scope of a metric rule
+	// based on logs.
+	Scopes []string `json:"scopes,omitempty"`
 
 	// Severity: Alert severity {0, 1, 2, 3, 4}
 	Severity *int `json:"severity,omitempty"`
@@ -161,7 +164,9 @@ type MetricAlertSingleResourceMultipleMetricCriteria struct {
 
 type WebtestLocationAvailabilityCriteria struct {
 	AdditionalProperties map[string]v1.JSON `json:"additionalProperties,omitempty"`
-	ComponentId          *string            `json:"componentId,omitempty"`
+
+	// ComponentId: The Application Insights resource Id.
+	ComponentId *string `json:"componentId,omitempty"`
 
 	// FailedLocationCount: The number of failed locations.
 	FailedLocationCount *float64 `json:"failedLocationCount,omitempty"`

--- a/v2/api/insights/v1api20200202/arm/component_spec_types_gen.go
+++ b/v2/api/insights/v1api20200202/arm/component_spec_types_gen.go
@@ -84,8 +84,11 @@ type ApplicationInsightsComponentProperties struct {
 
 	// SamplingPercentage: Percentage of the data produced by the application being monitored that is being sampled for
 	// Application Insights telemetry.
-	SamplingPercentage  *float64 `json:"SamplingPercentage,omitempty"`
-	WorkspaceResourceId *string  `json:"workspaceResourceId,omitempty"`
+	SamplingPercentage *float64 `json:"SamplingPercentage,omitempty"`
+
+	// WorkspaceResourceId: Resource Id of the log analytics workspace which the data will be ingested to. This property is
+	// required to create an application with this API version. Applications from older versions will not have this property.
+	WorkspaceResourceId *string `json:"workspaceResourceId,omitempty"`
 }
 
 // +kubebuilder:validation:Enum={"other","web"}

--- a/v2/api/insights/v1api20201001/arm/activity_log_alert_spec_types_gen.go
+++ b/v2/api/insights/v1api20201001/arm/activity_log_alert_spec_types_gen.go
@@ -48,8 +48,11 @@ type AlertRuleProperties struct {
 
 	// Enabled: Indicates whether this Activity Log Alert rule is enabled. If an Activity Log Alert rule is not enabled, then
 	// none of its actions will be activated.
-	Enabled *bool    `json:"enabled,omitempty"`
-	Scopes  []string `json:"scopes,omitempty"`
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// Scopes: A list of resource IDs that will be used as prefixes. The alert will only apply to Activity Log events with
+	// resource IDs that fall under one of these prefixes. This list must include at least one item.
+	Scopes []string `json:"scopes,omitempty"`
 }
 
 // A list of Activity Log Alert rule actions.
@@ -66,6 +69,7 @@ type AlertRuleAllOfCondition struct {
 
 // A pointer to an Azure Action Group.
 type ActionGroupReference struct {
+	// ActionGroupId: The resource ID of the Action Group. This cannot be null or empty.
 	ActionGroupId *string `json:"actionGroupId,omitempty"`
 
 	// WebhookProperties: the dictionary of custom properties to include with the post operation. These data are appended to

--- a/v2/api/insights/v1api20210501preview/arm/diagnostic_setting_spec_types_gen.go
+++ b/v2/api/insights/v1api20210501preview/arm/diagnostic_setting_spec_types_gen.go
@@ -31,6 +31,7 @@ func (setting *DiagnosticSetting_Spec) GetType() string {
 
 // The diagnostic settings.
 type DiagnosticSettings struct {
+	// EventHubAuthorizationRuleId: The resource Id for the event hub authorization rule.
 	EventHubAuthorizationRuleId *string `json:"eventHubAuthorizationRuleId,omitempty"`
 
 	// EventHubName: The name of the event hub. If none is specified, the default event hub will be selected.
@@ -42,16 +43,25 @@ type DiagnosticSettings struct {
 	LogAnalyticsDestinationType *string `json:"logAnalyticsDestinationType,omitempty"`
 
 	// Logs: The list of logs settings.
-	Logs                 []LogSettings `json:"logs,omitempty"`
-	MarketplacePartnerId *string       `json:"marketplacePartnerId,omitempty"`
+	Logs []LogSettings `json:"logs,omitempty"`
+
+	// MarketplacePartnerId: The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic
+	// Logs.
+	MarketplacePartnerId *string `json:"marketplacePartnerId,omitempty"`
 
 	// Metrics: The list of metric settings.
 	Metrics []MetricSettings `json:"metrics,omitempty"`
 
 	// ServiceBusRuleId: The service bus rule Id of the diagnostic setting. This is here to maintain backwards compatibility.
 	ServiceBusRuleId *string `json:"serviceBusRuleId,omitempty"`
+
+	// StorageAccountId: The resource ID of the storage account to which you would like to send Diagnostic Logs.
 	StorageAccountId *string `json:"storageAccountId,omitempty"`
-	WorkspaceId      *string `json:"workspaceId,omitempty"`
+
+	// WorkspaceId: The full ARM resource ID of the Log Analytics workspace to which you would like to send Diagnostic Logs.
+	// Example:
+	// /subscriptions/4b9e8510-67ab-4e9a-95a9-e2f1e570ea9c/resourceGroups/insights-integration/providers/Microsoft.OperationalInsights/workspaces/viruela2
+	WorkspaceId *string `json:"workspaceId,omitempty"`
 }
 
 // Part of MultiTenantDiagnosticSettings. Specifies the settings for a particular log.

--- a/v2/api/insights/v1api20220615/arm/scheduled_query_rule_spec_types_gen.go
+++ b/v2/api/insights/v1api20220615/arm/scheduled_query_rule_spec_types_gen.go
@@ -86,8 +86,10 @@ type ScheduledQueryRuleProperties struct {
 
 	// OverrideQueryTimeRange: If specified then overrides the query time range (default is
 	// WindowSize*NumberOfEvaluationPeriods). Relevant only for rules of the kind LogAlert.
-	OverrideQueryTimeRange *string  `json:"overrideQueryTimeRange,omitempty"`
-	Scopes                 []string `json:"scopes,omitempty"`
+	OverrideQueryTimeRange *string `json:"overrideQueryTimeRange,omitempty"`
+
+	// Scopes: The list of resource id's that this scheduled query rule is scoped to.
+	Scopes []string `json:"scopes,omitempty"`
 
 	// Severity: Severity of the alert. Should be an integer between [0-4]. Value of 0 is severest. Relevant and required only
 	// for rules of the kind LogAlert.
@@ -110,6 +112,7 @@ type ScheduledQueryRuleProperties struct {
 
 // Actions to invoke when the alert fires.
 type Actions struct {
+	// ActionGroups: Action Group resource Ids to invoke when the alert fires.
 	ActionGroups []string `json:"actionGroups,omitempty"`
 
 	// CustomProperties: The properties of an alert payload.
@@ -152,7 +155,10 @@ type Condition struct {
 	Operator *Condition_Operator `json:"operator,omitempty"`
 
 	// Query: Log query alert
-	Query            *string `json:"query,omitempty"`
+	Query *string `json:"query,omitempty"`
+
+	// ResourceIdColumn: The column containing the resource id. The content of the column must be a uri formatted as resource
+	// id. Relevant only for rules of the kind LogAlert.
 	ResourceIdColumn *string `json:"resourceIdColumn,omitempty"`
 
 	// Threshold: the criteria threshold value that activates the alert. Relevant and required only for rules of the kind

--- a/v2/api/insights/v1api20221001/arm/autoscale_setting_spec_types_gen.go
+++ b/v2/api/insights/v1api20221001/arm/autoscale_setting_spec_types_gen.go
@@ -56,7 +56,9 @@ type AutoscaleSettingProperties struct {
 
 	// TargetResourceLocation: the location of the resource that the autoscale setting should be added to.
 	TargetResourceLocation *string `json:"targetResourceLocation,omitempty"`
-	TargetResourceUri      *string `json:"targetResourceUri,omitempty"`
+
+	// TargetResourceUri: the resource identifier of the resource that the autoscale setting should be added to.
+	TargetResourceUri *string `json:"targetResourceUri,omitempty"`
 }
 
 // Autoscale notification.
@@ -232,7 +234,9 @@ type MetricTrigger struct {
 
 	// MetricResourceLocation: the location of the resource the rule monitors.
 	MetricResourceLocation *string `json:"metricResourceLocation,omitempty"`
-	MetricResourceUri      *string `json:"metricResourceUri,omitempty"`
+
+	// MetricResourceUri: the resource identifier of the resource the rule monitors.
+	MetricResourceUri *string `json:"metricResourceUri,omitempty"`
 
 	// Operator: the operator that is used to compare the metric data and the threshold.
 	Operator *MetricTrigger_Operator `json:"operator,omitempty"`

--- a/v2/api/insights/v1api20230101/arm/action_group_spec_types_gen.go
+++ b/v2/api/insights/v1api20230101/arm/action_group_spec_types_gen.go
@@ -108,8 +108,10 @@ type AutomationRunbookReceiver struct {
 	ServiceUri *string `json:"serviceUri,omitempty"`
 
 	// UseCommonAlertSchema: Indicates whether to use common alert schema.
-	UseCommonAlertSchema *bool   `json:"useCommonAlertSchema,omitempty"`
-	WebhookResourceId    *string `json:"webhookResourceId,omitempty"`
+	UseCommonAlertSchema *bool `json:"useCommonAlertSchema,omitempty"`
+
+	// WebhookResourceId: The resource id for webhook linked to this runbook.
+	WebhookResourceId *string `json:"webhookResourceId,omitempty"`
 }
 
 // The Azure mobile App push notification receiver.
@@ -123,6 +125,7 @@ type AzureAppPushReceiver struct {
 
 // An azure function receiver.
 type AzureFunctionReceiver struct {
+	// FunctionAppResourceId: The azure resource id of the function app.
 	FunctionAppResourceId *string `json:"functionAppResourceId,omitempty"`
 
 	// FunctionName: The function name in the function app.
@@ -197,7 +200,9 @@ type LogicAppReceiver struct {
 	CallbackUrl *string `json:"callbackUrl,omitempty"`
 
 	// Name: The name of the logic app receiver. Names must be unique across all receivers within an action group.
-	Name       *string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
+
+	// ResourceId: The azure resource id of the logic app receiver.
 	ResourceId *string `json:"resourceId,omitempty"`
 
 	// UseCommonAlertSchema: Indicates whether to use common alert schema.

--- a/v2/api/insights/v1api20230311/arm/data_collection_rule_association_spec_types_gen.go
+++ b/v2/api/insights/v1api20230311/arm/data_collection_rule_association_spec_types_gen.go
@@ -31,8 +31,11 @@ func (association *DataCollectionRuleAssociation_Spec) GetType() string {
 
 // Definition of association of a data collection rule with a monitored Azure resource.
 type DataCollectionRuleAssociationSpec struct {
+	// DataCollectionEndpointId: The resource ID of the data collection endpoint that is to be associated.
 	DataCollectionEndpointId *string `json:"dataCollectionEndpointId,omitempty"`
-	DataCollectionRuleId     *string `json:"dataCollectionRuleId,omitempty"`
+
+	// DataCollectionRuleId: The resource ID of the data collection rule that is to be associated.
+	DataCollectionRuleId *string `json:"dataCollectionRuleId,omitempty"`
 
 	// Description: Description of the association.
 	Description *string `json:"description,omitempty"`

--- a/v2/api/insights/v1api20230311/arm/data_collection_rule_spec_types_gen.go
+++ b/v2/api/insights/v1api20230311/arm/data_collection_rule_spec_types_gen.go
@@ -60,8 +60,10 @@ var dataCollectionRule_Kind_Spec_Values = map[string]DataCollectionRule_Kind_Spe
 // Definition of what monitoring data to collect and where that data should be sent.
 type DataCollectionRuleSpec struct {
 	// AgentSettings: Agent settings used to modify agent behavior on a given host
-	AgentSettings            *AgentSettingsSpec `json:"agentSettings,omitempty"`
-	DataCollectionEndpointId *string            `json:"dataCollectionEndpointId,omitempty"`
+	AgentSettings *AgentSettingsSpec `json:"agentSettings,omitempty"`
+
+	// DataCollectionEndpointId: The resource ID of the data collection endpoint that this rule can be used with.
+	DataCollectionEndpointId *string `json:"dataCollectionEndpointId,omitempty"`
 
 	// DataFlows: The specification of data flows.
 	DataFlows []DataFlow `json:"dataFlows,omitempty"`
@@ -197,7 +199,9 @@ type AdxDestination struct {
 
 	// Name: A friendly name for the destination.
 	// This name should be unique across all destinations (regardless of type) within the data collection rule.
-	Name       *string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
+
+	// ResourceId: The ARM resource id of the Adx resource.
 	ResourceId *string `json:"resourceId,omitempty"`
 }
 
@@ -259,6 +263,7 @@ type EnrichmentData struct {
 }
 
 type EventHubDestination struct {
+	// EventHubResourceId: The resource ID of the event hub.
 	EventHubResourceId *string `json:"eventHubResourceId,omitempty"`
 
 	// Name: A friendly name for the destination.
@@ -267,6 +272,7 @@ type EventHubDestination struct {
 }
 
 type EventHubDirectDestination struct {
+	// EventHubResourceId: The resource ID of the event hub.
 	EventHubResourceId *string `json:"eventHubResourceId,omitempty"`
 
 	// Name: A friendly name for the destination.
@@ -317,7 +323,9 @@ type IisLogsDataSource struct {
 type LogAnalyticsDestination struct {
 	// Name: A friendly name for the destination.
 	// This name should be unique across all destinations (regardless of type) within the data collection rule.
-	Name                *string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
+
+	// WorkspaceResourceId: The resource ID of the Log Analytics workspace.
 	WorkspaceResourceId *string `json:"workspaceResourceId,omitempty"`
 }
 
@@ -365,6 +373,7 @@ type MicrosoftFabricDestination struct {
 
 // Monitoring account destination.
 type MonitoringAccountDestination struct {
+	// AccountResourceId: The resource ID of the monitoring account.
 	AccountResourceId *string `json:"accountResourceId,omitempty"`
 
 	// Name: A friendly name for the destination.
@@ -428,14 +437,18 @@ type StorageBlobDestination struct {
 
 	// Name: A friendly name for the destination.
 	// This name should be unique across all destinations (regardless of type) within the data collection rule.
-	Name                     *string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
+
+	// StorageAccountResourceId: The resource ID of the storage account.
 	StorageAccountResourceId *string `json:"storageAccountResourceId,omitempty"`
 }
 
 type StorageTableDestination struct {
 	// Name: A friendly name for the destination.
 	// This name should be unique across all destinations (regardless of type) within the data collection rule.
-	Name                     *string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
+
+	// StorageAccountResourceId: The resource ID of the storage account.
 	StorageAccountResourceId *string `json:"storageAccountResourceId,omitempty"`
 
 	// TableName: The name of the Storage Table.
@@ -619,7 +632,9 @@ type StorageBlob struct {
 	LookupType *StorageBlob_LookupType `json:"lookupType,omitempty"`
 
 	// Name: The name of the enrichment data source used as an alias when referencing this data source in data flows
-	Name       *string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
+
+	// ResourceId: Resource Id of the storage account that hosts the blob
 	ResourceId *string `json:"resourceId,omitempty"`
 }
 

--- a/v2/api/insights/v1api20230601/arm/workbook_spec_types_gen.go
+++ b/v2/api/insights/v1api20230601/arm/workbook_spec_types_gen.go
@@ -70,8 +70,12 @@ type WorkbookProperties struct {
 
 	// SerializedData: Configuration of this particular workbook. Configuration data is a string containing valid JSON
 	SerializedData *string `json:"serializedData,omitempty"`
-	SourceId       *string `json:"sourceId,omitempty"`
-	StorageUri     *string `json:"storageUri,omitempty"`
+
+	// SourceId: ResourceId for a source resource.
+	SourceId *string `json:"sourceId,omitempty"`
+
+	// StorageUri: The resourceId to the storage account when bring your own storage is used
+	StorageUri *string `json:"storageUri,omitempty"`
 
 	// Tags: Being deprecated, please use the other tags field
 	Tags []string `json:"tags,omitempty"`

--- a/v2/api/insights/v1api20240101preview/arm/scheduled_query_rule_spec_types_gen.go
+++ b/v2/api/insights/v1api20240101preview/arm/scheduled_query_rule_spec_types_gen.go
@@ -102,7 +102,9 @@ type ScheduledQueryRuleProperties struct {
 
 	// ResolveConfiguration: Defines the configuration for resolving fired alerts. Relevant only for rules of the kind LogAlert.
 	ResolveConfiguration *RuleResolveConfiguration `json:"resolveConfiguration,omitempty"`
-	Scopes               []string                  `json:"scopes,omitempty"`
+
+	// Scopes: The list of resource id's that this scheduled query rule is scoped to.
+	Scopes []string `json:"scopes,omitempty"`
 
 	// Severity: Severity of the alert. Should be an integer between [0-4]. Value of 0 is severest. Relevant and required only
 	// for rules of the kind LogAlert.
@@ -125,6 +127,7 @@ type ScheduledQueryRuleProperties struct {
 
 // Actions to invoke when the alert fires.
 type Actions struct {
+	// ActionGroups: Action Group resource Ids to invoke when the alert fires.
 	ActionGroups []string `json:"actionGroups,omitempty"`
 
 	// ActionProperties: The properties of an action properties.
@@ -212,7 +215,10 @@ type Condition struct {
 	Operator *Condition_Operator `json:"operator,omitempty"`
 
 	// Query: Log query alert
-	Query            *string `json:"query,omitempty"`
+	Query *string `json:"query,omitempty"`
+
+	// ResourceIdColumn: The column containing the resource id. The content of the column must be a uri formatted as resource
+	// id. Relevant only for rules of the kind LogAlert.
 	ResourceIdColumn *string `json:"resourceIdColumn,omitempty"`
 
 	// Threshold: the criteria threshold value that activates the alert. Relevant and required only for static threshold rules

--- a/v2/api/keyvault/v1api20210401preview/arm/vault_spec_types_gen.go
+++ b/v2/api/keyvault/v1api20210401preview/arm/vault_spec_types_gen.go
@@ -244,6 +244,8 @@ var sku_Name_Values = map[string]Sku_Name{
 
 // A rule governing the accessibility of a vault from a specific virtual network.
 type VirtualNetworkRule struct {
+	// Id: Full resource id of a vnet subnet, such as
+	// '/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/subnet1'.
 	Id *string `json:"id,omitempty"`
 
 	// IgnoreMissingVnetServiceEndpoint: Property to specify whether NRP will ignore the check if parent subnet has

--- a/v2/api/keyvault/v1api20230701/arm/vault_spec_types_gen.go
+++ b/v2/api/keyvault/v1api20230701/arm/vault_spec_types_gen.go
@@ -250,6 +250,8 @@ var sku_Name_Values = map[string]Sku_Name{
 
 // A rule governing the accessibility of a vault from a specific virtual network.
 type VirtualNetworkRule struct {
+	// Id: Full resource id of a vnet subnet, such as
+	// '/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/subnet1'.
 	Id *string `json:"id,omitempty"`
 
 	// IgnoreMissingVnetServiceEndpoint: Property to specify whether NRP will ignore the check if parent subnet has

--- a/v2/api/kusto/v1api20230815/arm/cluster_spec_types_gen.go
+++ b/v2/api/kusto/v1api20230815/arm/cluster_spec_types_gen.go
@@ -364,7 +364,9 @@ type KeyVaultProperties struct {
 	KeyVaultUri *string `json:"keyVaultUri,omitempty"`
 
 	// KeyVersion: The version of the key vault key.
-	KeyVersion   *string `json:"keyVersion,omitempty"`
+	KeyVersion *string `json:"keyVersion,omitempty"`
+
+	// UserIdentity: The user assigned identity (ARM resource id) that has access to the key.
 	UserIdentity *string `json:"userIdentity,omitempty"`
 }
 
@@ -401,13 +403,18 @@ type UserAssignedIdentityDetails struct {
 
 // A class that contains virtual network definition.
 type VirtualNetworkConfiguration struct {
+	// DataManagementPublicIpId: Data management's service public IP address resource id.
 	DataManagementPublicIpId *string `json:"dataManagementPublicIpId,omitempty"`
-	EnginePublicIpId         *string `json:"enginePublicIpId,omitempty"`
+
+	// EnginePublicIpId: Engine service's public IP address resource id.
+	EnginePublicIpId *string `json:"enginePublicIpId,omitempty"`
 
 	// State: When enabled, the cluster is deployed into the configured subnet, when disabled it will be removed from the
 	// subnet.
-	State    *VirtualNetworkConfiguration_State `json:"state,omitempty"`
-	SubnetId *string                            `json:"subnetId,omitempty"`
+	State *VirtualNetworkConfiguration_State `json:"state,omitempty"`
+
+	// SubnetId: The subnet resource id.
+	SubnetId *string `json:"subnetId,omitempty"`
 }
 
 // The language extension object.

--- a/v2/api/kusto/v1api20230815/arm/data_connection_spec_types_gen.go
+++ b/v2/api/kusto/v1api20230815/arm/data_connection_spec_types_gen.go
@@ -150,13 +150,17 @@ var cosmosDbDataConnection_Kind_Values = map[string]CosmosDbDataConnection_Kind{
 
 // Class representing the Kusto CosmosDb data connection properties.
 type CosmosDbDataConnectionProperties struct {
+	// CosmosDbAccountResourceId: The resource ID of the Cosmos DB account used to create the data connection.
 	CosmosDbAccountResourceId *string `json:"cosmosDbAccountResourceId,omitempty"`
 
 	// CosmosDbContainer: The name of an existing container in the Cosmos DB database.
 	CosmosDbContainer *string `json:"cosmosDbContainer,omitempty"`
 
 	// CosmosDbDatabase: The name of an existing database in the Cosmos DB account.
-	CosmosDbDatabase          *string `json:"cosmosDbDatabase,omitempty"`
+	CosmosDbDatabase *string `json:"cosmosDbDatabase,omitempty"`
+
+	// ManagedIdentityResourceId: The resource ID of a managed system or user-assigned identity. The identity is used to
+	// authenticate with Cosmos DB.
 	ManagedIdentityResourceId *string `json:"managedIdentityResourceId,omitempty"`
 
 	// MappingRuleName: The name of an existing mapping rule to use when ingesting the retrieved data.
@@ -184,18 +188,27 @@ type EventGridConnectionProperties struct {
 
 	// DatabaseRouting: Indication for database routing information from the data connection, by default only database routing
 	// information is allowed
-	DatabaseRouting     *EventGridConnectionProperties_DatabaseRouting `json:"databaseRouting,omitempty"`
-	EventGridResourceId *string                                        `json:"eventGridResourceId,omitempty"`
-	EventHubResourceId  *string                                        `json:"eventHubResourceId,omitempty"`
+	DatabaseRouting *EventGridConnectionProperties_DatabaseRouting `json:"databaseRouting,omitempty"`
+
+	// EventGridResourceId: The resource ID of the event grid that is subscribed to the storage account events.
+	EventGridResourceId *string `json:"eventGridResourceId,omitempty"`
+
+	// EventHubResourceId: The resource ID where the event grid is configured to send events.
+	EventHubResourceId *string `json:"eventHubResourceId,omitempty"`
 
 	// IgnoreFirstRecord: A Boolean value that, if set to true, indicates that ingestion should ignore the first record of
 	// every file
-	IgnoreFirstRecord         *bool   `json:"ignoreFirstRecord,omitempty"`
+	IgnoreFirstRecord *bool `json:"ignoreFirstRecord,omitempty"`
+
+	// ManagedIdentityResourceId: The resource ID of a managed identity (system or user assigned) to be used to authenticate
+	// with event hub and storage account.
 	ManagedIdentityResourceId *string `json:"managedIdentityResourceId,omitempty"`
 
 	// MappingRuleName: The mapping rule to be used to ingest the data. Optionally the mapping information can be added to each
 	// message.
-	MappingRuleName          *string `json:"mappingRuleName,omitempty"`
+	MappingRuleName *string `json:"mappingRuleName,omitempty"`
+
+	// StorageAccountResourceId: The resource ID of the storage account where the data resides.
 	StorageAccountResourceId *string `json:"storageAccountResourceId,omitempty"`
 
 	// TableName: The table where the data should be ingested. Optionally the table information can be added to each message.
@@ -225,12 +238,17 @@ type EventHubConnectionProperties struct {
 
 	// DatabaseRouting: Indication for database routing information from the data connection, by default only database routing
 	// information is allowed
-	DatabaseRouting    *EventHubConnectionProperties_DatabaseRouting `json:"databaseRouting,omitempty"`
-	EventHubResourceId *string                                       `json:"eventHubResourceId,omitempty"`
+	DatabaseRouting *EventHubConnectionProperties_DatabaseRouting `json:"databaseRouting,omitempty"`
+
+	// EventHubResourceId: The resource ID of the event hub to be used to create a data connection.
+	EventHubResourceId *string `json:"eventHubResourceId,omitempty"`
 
 	// EventSystemProperties: System properties of the event hub
-	EventSystemProperties     []string `json:"eventSystemProperties,omitempty"`
-	ManagedIdentityResourceId *string  `json:"managedIdentityResourceId,omitempty"`
+	EventSystemProperties []string `json:"eventSystemProperties,omitempty"`
+
+	// ManagedIdentityResourceId: The resource ID of a managed identity (system or user assigned) to be used to authenticate
+	// with event hub.
+	ManagedIdentityResourceId *string `json:"managedIdentityResourceId,omitempty"`
 
 	// MappingRuleName: The mapping rule to be used to ingest the data. Optionally the mapping information can be added to each
 	// message.
@@ -268,7 +286,9 @@ type IotHubConnectionProperties struct {
 
 	// EventSystemProperties: System properties of the iot hub
 	EventSystemProperties []string `json:"eventSystemProperties,omitempty"`
-	IotHubResourceId      *string  `json:"iotHubResourceId,omitempty"`
+
+	// IotHubResourceId: The resource ID of the Iot hub to be used to create a data connection.
+	IotHubResourceId *string `json:"iotHubResourceId,omitempty"`
 
 	// MappingRuleName: The mapping rule to be used to ingest the data. Optionally the mapping information can be added to each
 	// message.

--- a/v2/api/kusto/v1api20240413/arm/cluster_spec_types_gen.go
+++ b/v2/api/kusto/v1api20240413/arm/cluster_spec_types_gen.go
@@ -379,7 +379,9 @@ type KeyVaultProperties struct {
 	KeyVaultUri *string `json:"keyVaultUri,omitempty"`
 
 	// KeyVersion: The version of the key vault key.
-	KeyVersion   *string `json:"keyVersion,omitempty"`
+	KeyVersion *string `json:"keyVersion,omitempty"`
+
+	// UserIdentity: The user assigned identity (ARM resource id) that has access to the key.
 	UserIdentity *string `json:"userIdentity,omitempty"`
 }
 
@@ -416,13 +418,18 @@ type UserAssignedIdentityDetails struct {
 
 // A class that contains virtual network definition.
 type VirtualNetworkConfiguration struct {
+	// DataManagementPublicIpId: Data management's service public IP address resource id.
 	DataManagementPublicIpId *string `json:"dataManagementPublicIpId,omitempty"`
-	EnginePublicIpId         *string `json:"enginePublicIpId,omitempty"`
+
+	// EnginePublicIpId: Engine service's public IP address resource id.
+	EnginePublicIpId *string `json:"enginePublicIpId,omitempty"`
 
 	// State: When enabled, the cluster is deployed into the configured subnet, when disabled it will be removed from the
 	// subnet.
-	State    *VirtualNetworkConfiguration_State `json:"state,omitempty"`
-	SubnetId *string                            `json:"subnetId,omitempty"`
+	State *VirtualNetworkConfiguration_State `json:"state,omitempty"`
+
+	// SubnetId: The subnet resource id.
+	SubnetId *string `json:"subnetId,omitempty"`
 }
 
 // +kubebuilder:validation:Enum={"azure_digital_twins","azure_openai","cosmosdb","external_data","genevametrics","kusto","mysql","postgresql","sandbox_artifacts","sql","webapi"}

--- a/v2/api/kusto/v1api20240413/arm/data_connection_spec_types_gen.go
+++ b/v2/api/kusto/v1api20240413/arm/data_connection_spec_types_gen.go
@@ -150,13 +150,17 @@ var cosmosDbDataConnection_Kind_Values = map[string]CosmosDbDataConnection_Kind{
 
 // Class representing the Kusto CosmosDb data connection properties.
 type CosmosDbDataConnectionProperties struct {
+	// CosmosDbAccountResourceId: The resource ID of the Cosmos DB account used to create the data connection.
 	CosmosDbAccountResourceId *string `json:"cosmosDbAccountResourceId,omitempty"`
 
 	// CosmosDbContainer: The name of an existing container in the Cosmos DB database.
 	CosmosDbContainer *string `json:"cosmosDbContainer,omitempty"`
 
 	// CosmosDbDatabase: The name of an existing database in the Cosmos DB account.
-	CosmosDbDatabase          *string `json:"cosmosDbDatabase,omitempty"`
+	CosmosDbDatabase *string `json:"cosmosDbDatabase,omitempty"`
+
+	// ManagedIdentityResourceId: The resource ID of a managed system or user-assigned identity. The identity is used to
+	// authenticate with Cosmos DB.
 	ManagedIdentityResourceId *string `json:"managedIdentityResourceId,omitempty"`
 
 	// MappingRuleName: The name of an existing mapping rule to use when ingesting the retrieved data.
@@ -184,18 +188,27 @@ type EventGridConnectionProperties struct {
 
 	// DatabaseRouting: Indication for database routing information from the data connection, by default only database routing
 	// information is allowed
-	DatabaseRouting     *EventGridConnectionProperties_DatabaseRouting `json:"databaseRouting,omitempty"`
-	EventGridResourceId *string                                        `json:"eventGridResourceId,omitempty"`
-	EventHubResourceId  *string                                        `json:"eventHubResourceId,omitempty"`
+	DatabaseRouting *EventGridConnectionProperties_DatabaseRouting `json:"databaseRouting,omitempty"`
+
+	// EventGridResourceId: The resource ID of the event grid that is subscribed to the storage account events.
+	EventGridResourceId *string `json:"eventGridResourceId,omitempty"`
+
+	// EventHubResourceId: The resource ID where the event grid is configured to send events.
+	EventHubResourceId *string `json:"eventHubResourceId,omitempty"`
 
 	// IgnoreFirstRecord: A Boolean value that, if set to true, indicates that ingestion should ignore the first record of
 	// every file
-	IgnoreFirstRecord         *bool   `json:"ignoreFirstRecord,omitempty"`
+	IgnoreFirstRecord *bool `json:"ignoreFirstRecord,omitempty"`
+
+	// ManagedIdentityResourceId: The resource ID of a managed identity (system or user assigned) to be used to authenticate
+	// with event hub and storage account.
 	ManagedIdentityResourceId *string `json:"managedIdentityResourceId,omitempty"`
 
 	// MappingRuleName: The mapping rule to be used to ingest the data. Optionally the mapping information can be added to each
 	// message.
-	MappingRuleName          *string `json:"mappingRuleName,omitempty"`
+	MappingRuleName *string `json:"mappingRuleName,omitempty"`
+
+	// StorageAccountResourceId: The resource ID of the storage account where the data resides.
 	StorageAccountResourceId *string `json:"storageAccountResourceId,omitempty"`
 
 	// TableName: The table where the data should be ingested. Optionally the table information can be added to each message.
@@ -225,12 +238,17 @@ type EventHubConnectionProperties struct {
 
 	// DatabaseRouting: Indication for database routing information from the data connection, by default only database routing
 	// information is allowed
-	DatabaseRouting    *EventHubConnectionProperties_DatabaseRouting `json:"databaseRouting,omitempty"`
-	EventHubResourceId *string                                       `json:"eventHubResourceId,omitempty"`
+	DatabaseRouting *EventHubConnectionProperties_DatabaseRouting `json:"databaseRouting,omitempty"`
+
+	// EventHubResourceId: The resource ID of the event hub to be used to create a data connection.
+	EventHubResourceId *string `json:"eventHubResourceId,omitempty"`
 
 	// EventSystemProperties: System properties of the event hub
-	EventSystemProperties     []string `json:"eventSystemProperties,omitempty"`
-	ManagedIdentityResourceId *string  `json:"managedIdentityResourceId,omitempty"`
+	EventSystemProperties []string `json:"eventSystemProperties,omitempty"`
+
+	// ManagedIdentityResourceId: The resource ID of a managed identity (system or user assigned) to be used to authenticate
+	// with event hub.
+	ManagedIdentityResourceId *string `json:"managedIdentityResourceId,omitempty"`
 
 	// MappingRuleName: The mapping rule to be used to ingest the data. Optionally the mapping information can be added to each
 	// message.
@@ -268,7 +286,9 @@ type IotHubConnectionProperties struct {
 
 	// EventSystemProperties: System properties of the iot hub
 	EventSystemProperties []string `json:"eventSystemProperties,omitempty"`
-	IotHubResourceId      *string  `json:"iotHubResourceId,omitempty"`
+
+	// IotHubResourceId: The resource ID of the Iot hub to be used to create a data connection.
+	IotHubResourceId *string `json:"iotHubResourceId,omitempty"`
 
 	// MappingRuleName: The mapping rule to be used to ingest the data. Optionally the mapping information can be added to each
 	// message.

--- a/v2/api/machinelearningservices/v1api20210701/arm/workspace_spec_types_gen.go
+++ b/v2/api/machinelearningservices/v1api20210701/arm/workspace_spec_types_gen.go
@@ -83,9 +83,15 @@ type SystemData struct {
 // The properties of a machine learning workspace.
 type WorkspaceProperties struct {
 	// AllowPublicAccessWhenBehindVnet: The flag to indicate whether to allow public access when behind VNet.
-	AllowPublicAccessWhenBehindVnet *bool   `json:"allowPublicAccessWhenBehindVnet,omitempty"`
-	ApplicationInsights             *string `json:"applicationInsights,omitempty"`
-	ContainerRegistry               *string `json:"containerRegistry,omitempty"`
+	AllowPublicAccessWhenBehindVnet *bool `json:"allowPublicAccessWhenBehindVnet,omitempty"`
+
+	// ApplicationInsights: ARM id of the application insights associated with this workspace. This cannot be changed once the
+	// workspace has been created
+	ApplicationInsights *string `json:"applicationInsights,omitempty"`
+
+	// ContainerRegistry: ARM id of the container registry associated with this workspace. This cannot be changed once the
+	// workspace has been created
+	ContainerRegistry *string `json:"containerRegistry,omitempty"`
 
 	// Description: The description of this workspace.
 	Description *string `json:"description,omitempty"`
@@ -103,8 +109,13 @@ type WorkspaceProperties struct {
 	HbiWorkspace *bool `json:"hbiWorkspace,omitempty"`
 
 	// ImageBuildCompute: The compute name for image build
-	ImageBuildCompute           *string `json:"imageBuildCompute,omitempty"`
-	KeyVault                    *string `json:"keyVault,omitempty"`
+	ImageBuildCompute *string `json:"imageBuildCompute,omitempty"`
+
+	// KeyVault: ARM id of the key vault associated with this workspace. This cannot be changed once the workspace has been
+	// created
+	KeyVault *string `json:"keyVault,omitempty"`
+
+	// PrimaryUserAssignedIdentity: The user assigned identity resource id that represents the workspace identity.
 	PrimaryUserAssignedIdentity *string `json:"primaryUserAssignedIdentity,omitempty"`
 
 	// PublicNetworkAccess: Whether requests from Public Network are allowed.
@@ -115,7 +126,10 @@ type WorkspaceProperties struct {
 
 	// SharedPrivateLinkResources: The list of shared private link resources in this workspace.
 	SharedPrivateLinkResources []SharedPrivateLinkResource `json:"sharedPrivateLinkResources,omitempty"`
-	StorageAccount             *string                     `json:"storageAccount,omitempty"`
+
+	// StorageAccount: ARM id of the storage account associated with this workspace. This cannot be changed once the workspace
+	// has been created
+	StorageAccount *string `json:"storageAccount,omitempty"`
 }
 
 type EncryptionProperty struct {
@@ -236,7 +250,9 @@ type KeyVaultProperties struct {
 // Properties of a shared private link resource.
 type SharedPrivateLinkResourceProperty struct {
 	// GroupId: The private link resource group id.
-	GroupId               *string `json:"groupId,omitempty"`
+	GroupId *string `json:"groupId,omitempty"`
+
+	// PrivateLinkResourceId: The resource id that private link links to.
 	PrivateLinkResourceId *string `json:"privateLinkResourceId,omitempty"`
 
 	// RequestMessage: Request message.

--- a/v2/api/machinelearningservices/v1api20210701/arm/workspaces_compute_spec_types_gen.go
+++ b/v2/api/machinelearningservices/v1api20210701/arm/workspaces_compute_spec_types_gen.go
@@ -192,7 +192,9 @@ type AKS struct {
 
 	// Properties: AKS properties
 	Properties *AKS_Properties `json:"properties,omitempty"`
-	ResourceId *string         `json:"resourceId,omitempty"`
+
+	// ResourceId: ARM resource id of the underlying compute
+	ResourceId *string `json:"resourceId,omitempty"`
 }
 
 type AmlCompute struct {
@@ -211,7 +213,9 @@ type AmlCompute struct {
 
 	// Properties: Properties of AmlCompute
 	Properties *AmlComputeProperties `json:"properties,omitempty"`
-	ResourceId *string               `json:"resourceId,omitempty"`
+
+	// ResourceId: ARM resource id of the underlying compute
+	ResourceId *string `json:"resourceId,omitempty"`
 }
 
 type ComputeInstance struct {
@@ -230,7 +234,9 @@ type ComputeInstance struct {
 
 	// Properties: Properties of ComputeInstance
 	Properties *ComputeInstanceProperties `json:"properties,omitempty"`
-	ResourceId *string                    `json:"resourceId,omitempty"`
+
+	// ResourceId: ARM resource id of the underlying compute
+	ResourceId *string `json:"resourceId,omitempty"`
 }
 
 type Databricks struct {
@@ -249,7 +255,9 @@ type Databricks struct {
 
 	// Properties: Properties of Databricks
 	Properties *DatabricksProperties `json:"properties,omitempty"`
-	ResourceId *string               `json:"resourceId,omitempty"`
+
+	// ResourceId: ARM resource id of the underlying compute
+	ResourceId *string `json:"resourceId,omitempty"`
 }
 
 type DataFactory struct {
@@ -264,8 +272,10 @@ type DataFactory struct {
 
 	// DisableLocalAuth: Opt-out of local authentication and ensure customers can use only MSI and AAD exclusively for
 	// authentication.
-	DisableLocalAuth *bool   `json:"disableLocalAuth,omitempty"`
-	ResourceId       *string `json:"resourceId,omitempty"`
+	DisableLocalAuth *bool `json:"disableLocalAuth,omitempty"`
+
+	// ResourceId: ARM resource id of the underlying compute
+	ResourceId *string `json:"resourceId,omitempty"`
 }
 
 type DataLakeAnalytics struct {
@@ -282,7 +292,9 @@ type DataLakeAnalytics struct {
 	// authentication.
 	DisableLocalAuth *bool                         `json:"disableLocalAuth,omitempty"`
 	Properties       *DataLakeAnalytics_Properties `json:"properties,omitempty"`
-	ResourceId       *string                       `json:"resourceId,omitempty"`
+
+	// ResourceId: ARM resource id of the underlying compute
+	ResourceId *string `json:"resourceId,omitempty"`
 }
 
 type HDInsight struct {
@@ -301,7 +313,9 @@ type HDInsight struct {
 
 	// Properties: HDInsight compute properties
 	Properties *HDInsightProperties `json:"properties,omitempty"`
-	ResourceId *string              `json:"resourceId,omitempty"`
+
+	// ResourceId: ARM resource id of the underlying compute
+	ResourceId *string `json:"resourceId,omitempty"`
 }
 
 type Kubernetes struct {
@@ -320,7 +334,9 @@ type Kubernetes struct {
 
 	// Properties: Properties of Kubernetes
 	Properties *KubernetesProperties `json:"properties,omitempty"`
-	ResourceId *string               `json:"resourceId,omitempty"`
+
+	// ResourceId: ARM resource id of the underlying compute
+	ResourceId *string `json:"resourceId,omitempty"`
 }
 
 type SynapseSpark struct {
@@ -337,7 +353,9 @@ type SynapseSpark struct {
 	// authentication.
 	DisableLocalAuth *bool                    `json:"disableLocalAuth,omitempty"`
 	Properties       *SynapseSpark_Properties `json:"properties,omitempty"`
-	ResourceId       *string                  `json:"resourceId,omitempty"`
+
+	// ResourceId: ARM resource id of the underlying compute
+	ResourceId *string `json:"resourceId,omitempty"`
 }
 
 type VirtualMachine struct {
@@ -354,7 +372,9 @@ type VirtualMachine struct {
 	// authentication.
 	DisableLocalAuth *bool                      `json:"disableLocalAuth,omitempty"`
 	Properties       *VirtualMachine_Properties `json:"properties,omitempty"`
-	ResourceId       *string                    `json:"resourceId,omitempty"`
+
+	// ResourceId: ARM resource id of the underlying compute
+	ResourceId *string `json:"resourceId,omitempty"`
 }
 
 // +kubebuilder:validation:Enum={"AKS"}
@@ -693,7 +713,9 @@ type AksNetworkingConfiguration struct {
 	// ServiceCidr: A CIDR notation IP range from which to assign service cluster IPs. It must not overlap with any Subnet IP
 	// ranges.
 	ServiceCidr *string `json:"serviceCidr,omitempty"`
-	SubnetId    *string `json:"subnetId,omitempty"`
+
+	// SubnetId: Virtual network subnet resource ID the compute nodes belong to
+	SubnetId *string `json:"subnetId,omitempty"`
 }
 
 // +kubebuilder:validation:Enum={"Linux","Windows"}
@@ -806,6 +828,7 @@ type PersonalComputeInstanceSettings struct {
 
 // Represents a resource ID. For example, for a subnet, it is the resource URL for the subnet.
 type ResourceId struct {
+	// Id: The ID of the resource
 	Id *string `json:"id,omitempty"`
 }
 
@@ -862,6 +885,7 @@ type UserAccountCredentials struct {
 
 // Virtual Machine image for Windows AML Compute
 type VirtualMachineImage struct {
+	// Id: Virtual Machine image path
 	Id *string `json:"id,omitempty"`
 }
 

--- a/v2/api/machinelearningservices/v1api20240401/arm/registry_spec_types_gen.go
+++ b/v2/api/machinelearningservices/v1api20240401/arm/registry_spec_types_gen.go
@@ -98,6 +98,10 @@ type Sku struct {
 
 // ARM ResourceId of a resource
 type ArmResourceId struct {
+	// ResourceId: Arm ResourceId is in the format
+	// "/subscriptions/{SubscriptionId}/resourceGroups/{ResourceGroupName}/providers/Microsoft.Storage/storageAccounts/{StorageAccountName}"
+	// or
+	// "/subscriptions/{SubscriptionId}/resourceGroups/{ResourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{AcrName}"
 	ResourceId *string `json:"resourceId,omitempty"`
 }
 
@@ -122,6 +126,9 @@ var managedServiceIdentityType_Values = map[string]ManagedServiceIdentityType{
 
 // Private endpoint connection definition.
 type RegistryPrivateEndpointConnection struct {
+	// Id: This is the private endpoint connection name created on SRP
+	// Full resource id:
+	// /subscriptions/{subId}/resourceGroups/{rgName}/providers/Microsoft.MachineLearningServices/{resourceType}/{resourceName}/registryPrivateEndpointConnections/{peConnectionName}
 	Id *string `json:"id,omitempty"`
 
 	// Location: Same as workspace location.
@@ -196,6 +203,7 @@ type StorageAccountDetails struct {
 
 // The PE network resource that is linked to this PE connection.
 type PrivateEndpointResource struct {
+	// SubnetArmId: The subnetId that the private endpoint is connected to.
 	SubnetArmId *string `json:"subnetArmId,omitempty"`
 }
 

--- a/v2/api/machinelearningservices/v1api20240401/arm/workspace_spec_types_gen.go
+++ b/v2/api/machinelearningservices/v1api20240401/arm/workspace_spec_types_gen.go
@@ -47,10 +47,14 @@ func (workspace *Workspace_Spec) GetType() string {
 // The properties of a machine learning workspace.
 type WorkspaceProperties struct {
 	// AllowPublicAccessWhenBehindVnet: The flag to indicate whether to allow public access when behind VNet.
-	AllowPublicAccessWhenBehindVnet *bool    `json:"allowPublicAccessWhenBehindVnet,omitempty"`
-	ApplicationInsights             *string  `json:"applicationInsights,omitempty"`
-	AssociatedWorkspaces            []string `json:"associatedWorkspaces,omitempty"`
-	ContainerRegistry               *string  `json:"containerRegistry,omitempty"`
+	AllowPublicAccessWhenBehindVnet *bool `json:"allowPublicAccessWhenBehindVnet,omitempty"`
+
+	// ApplicationInsights: ARM id of the application insights associated with this workspace.
+	ApplicationInsights  *string  `json:"applicationInsights,omitempty"`
+	AssociatedWorkspaces []string `json:"associatedWorkspaces,omitempty"`
+
+	// ContainerRegistry: ARM id of the container registry associated with this workspace.
+	ContainerRegistry *string `json:"containerRegistry,omitempty"`
 
 	// Description: The description of this workspace.
 	Description *string `json:"description,omitempty"`
@@ -74,11 +78,16 @@ type WorkspaceProperties struct {
 
 	// ImageBuildCompute: The compute name for image build
 	ImageBuildCompute *string `json:"imageBuildCompute,omitempty"`
-	KeyVault          *string `json:"keyVault,omitempty"`
+
+	// KeyVault: ARM id of the key vault associated with this workspace. This cannot be changed once the workspace has been
+	// created
+	KeyVault *string `json:"keyVault,omitempty"`
 
 	// ManagedNetwork: Managed Network settings for a machine learning workspace.
-	ManagedNetwork              *ManagedNetworkSettings `json:"managedNetwork,omitempty"`
-	PrimaryUserAssignedIdentity *string                 `json:"primaryUserAssignedIdentity,omitempty"`
+	ManagedNetwork *ManagedNetworkSettings `json:"managedNetwork,omitempty"`
+
+	// PrimaryUserAssignedIdentity: The user assigned identity resource id that represents the workspace identity.
+	PrimaryUserAssignedIdentity *string `json:"primaryUserAssignedIdentity,omitempty"`
 
 	// PublicNetworkAccess: Whether requests from Public Network are allowed.
 	PublicNetworkAccess *WorkspaceProperties_PublicNetworkAccess `json:"publicNetworkAccess,omitempty"`
@@ -91,7 +100,10 @@ type WorkspaceProperties struct {
 
 	// SharedPrivateLinkResources: The list of shared private link resources in this workspace.
 	SharedPrivateLinkResources []SharedPrivateLinkResource `json:"sharedPrivateLinkResources,omitempty"`
-	StorageAccount             *string                     `json:"storageAccount,omitempty"`
+
+	// StorageAccount: ARM id of the storage account associated with this workspace. This cannot be changed once the workspace
+	// has been created
+	StorageAccount *string `json:"storageAccount,omitempty"`
 
 	// V1LegacyMode: Enabling v1_legacy_mode may prevent you from using features provided by the v2 API.
 	V1LegacyMode *bool `json:"v1LegacyMode,omitempty"`
@@ -127,6 +139,8 @@ type ManagedNetworkSettings struct {
 }
 
 type ServerlessComputeSettings struct {
+	// ServerlessComputeCustomSubnet: The resource ID of an existing virtual network subnet in which serverless compute nodes
+	// should be deployed
 	ServerlessComputeCustomSubnet *string `json:"serverlessComputeCustomSubnet,omitempty"`
 
 	// ServerlessComputeNoPublicIP: The flag to signal if serverless compute nodes deployed in custom vNet would have no public
@@ -183,11 +197,14 @@ type EncryptionKeyVaultProperties struct {
 
 	// KeyIdentifier: Key vault uri to access the encryption key.
 	KeyIdentifier *string `json:"keyIdentifier,omitempty"`
+
+	// KeyVaultArmId: The ArmId of the keyVault where the customer owned encryption key is present.
 	KeyVaultArmId *string `json:"keyVaultArmId,omitempty"`
 }
 
 // Identity that will be used to access key vault for encryption at rest
 type IdentityForCmk struct {
+	// UserAssignedIdentity: The ArmId of the user assigned identity that will be used to access the customer managed key vault
 	UserAssignedIdentity *string `json:"userAssignedIdentity,omitempty"`
 }
 
@@ -272,7 +289,9 @@ func (rule *OutboundRule) UnmarshalJSON(data []byte) error {
 // Properties of a shared private link resource.
 type SharedPrivateLinkResourceProperty struct {
 	// GroupId: The private link resource group id.
-	GroupId               *string `json:"groupId,omitempty"`
+	GroupId *string `json:"groupId,omitempty"`
+
+	// PrivateLinkResourceId: The resource id that private link links to.
 	PrivateLinkResourceId *string `json:"privateLinkResourceId,omitempty"`
 
 	// RequestMessage: Request message.

--- a/v2/api/machinelearningservices/v1api20240401/arm/workspaces_compute_spec_types_gen.go
+++ b/v2/api/machinelearningservices/v1api20240401/arm/workspaces_compute_spec_types_gen.go
@@ -190,7 +190,9 @@ type AKS struct {
 
 	// Properties: AKS properties
 	Properties *AKS_Properties `json:"properties,omitempty"`
-	ResourceId *string         `json:"resourceId,omitempty"`
+
+	// ResourceId: ARM resource id of the underlying compute
+	ResourceId *string `json:"resourceId,omitempty"`
 }
 
 type AmlCompute struct {
@@ -209,7 +211,9 @@ type AmlCompute struct {
 
 	// Properties: Properties of AmlCompute
 	Properties *AmlComputeProperties `json:"properties,omitempty"`
-	ResourceId *string               `json:"resourceId,omitempty"`
+
+	// ResourceId: ARM resource id of the underlying compute
+	ResourceId *string `json:"resourceId,omitempty"`
 }
 
 type ComputeInstance struct {
@@ -228,7 +232,9 @@ type ComputeInstance struct {
 
 	// Properties: Properties of ComputeInstance
 	Properties *ComputeInstanceProperties `json:"properties,omitempty"`
-	ResourceId *string                    `json:"resourceId,omitempty"`
+
+	// ResourceId: ARM resource id of the underlying compute
+	ResourceId *string `json:"resourceId,omitempty"`
 }
 
 type Databricks struct {
@@ -247,7 +253,9 @@ type Databricks struct {
 
 	// Properties: Properties of Databricks
 	Properties *DatabricksProperties `json:"properties,omitempty"`
-	ResourceId *string               `json:"resourceId,omitempty"`
+
+	// ResourceId: ARM resource id of the underlying compute
+	ResourceId *string `json:"resourceId,omitempty"`
 }
 
 type DataFactory struct {
@@ -262,8 +270,10 @@ type DataFactory struct {
 
 	// DisableLocalAuth: Opt-out of local authentication and ensure customers can use only MSI and AAD exclusively for
 	// authentication.
-	DisableLocalAuth *bool   `json:"disableLocalAuth,omitempty"`
-	ResourceId       *string `json:"resourceId,omitempty"`
+	DisableLocalAuth *bool `json:"disableLocalAuth,omitempty"`
+
+	// ResourceId: ARM resource id of the underlying compute
+	ResourceId *string `json:"resourceId,omitempty"`
 }
 
 type DataLakeAnalytics struct {
@@ -280,7 +290,9 @@ type DataLakeAnalytics struct {
 	// authentication.
 	DisableLocalAuth *bool                         `json:"disableLocalAuth,omitempty"`
 	Properties       *DataLakeAnalytics_Properties `json:"properties,omitempty"`
-	ResourceId       *string                       `json:"resourceId,omitempty"`
+
+	// ResourceId: ARM resource id of the underlying compute
+	ResourceId *string `json:"resourceId,omitempty"`
 }
 
 type HDInsight struct {
@@ -299,7 +311,9 @@ type HDInsight struct {
 
 	// Properties: HDInsight compute properties
 	Properties *HDInsightProperties `json:"properties,omitempty"`
-	ResourceId *string              `json:"resourceId,omitempty"`
+
+	// ResourceId: ARM resource id of the underlying compute
+	ResourceId *string `json:"resourceId,omitempty"`
 }
 
 type Kubernetes struct {
@@ -318,7 +332,9 @@ type Kubernetes struct {
 
 	// Properties: Properties of Kubernetes
 	Properties *KubernetesProperties `json:"properties,omitempty"`
-	ResourceId *string               `json:"resourceId,omitempty"`
+
+	// ResourceId: ARM resource id of the underlying compute
+	ResourceId *string `json:"resourceId,omitempty"`
 }
 
 type SynapseSpark struct {
@@ -335,7 +351,9 @@ type SynapseSpark struct {
 	// authentication.
 	DisableLocalAuth *bool                    `json:"disableLocalAuth,omitempty"`
 	Properties       *SynapseSpark_Properties `json:"properties,omitempty"`
-	ResourceId       *string                  `json:"resourceId,omitempty"`
+
+	// ResourceId: ARM resource id of the underlying compute
+	ResourceId *string `json:"resourceId,omitempty"`
 }
 
 type VirtualMachine struct {
@@ -352,7 +370,9 @@ type VirtualMachine struct {
 	// authentication.
 	DisableLocalAuth *bool                      `json:"disableLocalAuth,omitempty"`
 	Properties       *VirtualMachine_Properties `json:"properties,omitempty"`
-	ResourceId       *string                    `json:"resourceId,omitempty"`
+
+	// ResourceId: ARM resource id of the underlying compute
+	ResourceId *string `json:"resourceId,omitempty"`
 }
 
 // +kubebuilder:validation:Enum={"AKS"}
@@ -379,8 +399,10 @@ type AKS_Properties struct {
 	ClusterFqdn *string `json:"clusterFqdn,omitempty"`
 
 	// ClusterPurpose: Intended usage of the cluster
-	ClusterPurpose     *AKS_Properties_ClusterPurpose `json:"clusterPurpose,omitempty"`
-	LoadBalancerSubnet *string                        `json:"loadBalancerSubnet,omitempty"`
+	ClusterPurpose *AKS_Properties_ClusterPurpose `json:"clusterPurpose,omitempty"`
+
+	// LoadBalancerSubnet: Load Balancer Subnet
+	LoadBalancerSubnet *string `json:"loadBalancerSubnet,omitempty"`
 
 	// LoadBalancerType: Load Balancer Type
 	LoadBalancerType *AKS_Properties_LoadBalancerType `json:"loadBalancerType,omitempty"`
@@ -706,7 +728,9 @@ type AksNetworkingConfiguration struct {
 	// ServiceCidr: A CIDR notation IP range from which to assign service cluster IPs. It must not overlap with any Subnet IP
 	// ranges.
 	ServiceCidr *string `json:"serviceCidr,omitempty"`
-	SubnetId    *string `json:"subnetId,omitempty"`
+
+	// SubnetId: Virtual network subnet resource ID the compute nodes belong to
+	SubnetId *string `json:"subnetId,omitempty"`
 }
 
 // +kubebuilder:validation:Enum={"Linux","Windows"}
@@ -846,6 +870,7 @@ type PersonalComputeInstanceSettings struct {
 
 // Represents a resource ID. For example, for a subnet, it is the resource URL for the subnet.
 type ResourceId struct {
+	// Id: The ID of the resource
 	Id *string `json:"id,omitempty"`
 }
 
@@ -902,6 +927,7 @@ type UserAccountCredentials struct {
 
 // Virtual Machine image for Windows AML Compute
 type VirtualMachineImage struct {
+	// Id: Virtual Machine image path
 	Id *string `json:"id,omitempty"`
 }
 
@@ -1184,6 +1210,7 @@ type Recurrence struct {
 }
 
 type ScheduleBase struct {
+	// Id: A system assigned id for the schedule.
 	Id *string `json:"id,omitempty"`
 
 	// ProvisioningStatus: The current deployment state of schedule.

--- a/v2/api/network/v1api20180501/arm/dns_zone_spec_types_gen.go
+++ b/v2/api/network/v1api20180501/arm/dns_zone_spec_types_gen.go
@@ -50,6 +50,7 @@ type ZoneProperties struct {
 
 // A reference to a another resource
 type SubResource struct {
+	// Id: Resource Id.
 	Id *string `json:"id,omitempty"`
 }
 

--- a/v2/api/network/v1api20200601/arm/private_dns_zones_virtual_network_link_spec_types_gen.go
+++ b/v2/api/network/v1api20200601/arm/private_dns_zones_virtual_network_link_spec_types_gen.go
@@ -49,5 +49,6 @@ type VirtualNetworkLinkProperties struct {
 
 // Reference to another subresource.
 type SubResource struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }

--- a/v2/api/network/v1api20201101/arm/load_balancer_spec_types_gen.go
+++ b/v2/api/network/v1api20201101/arm/load_balancer_spec_types_gen.go
@@ -412,11 +412,13 @@ var probePropertiesFormat_Protocol_Values = map[string]ProbePropertiesFormat_Pro
 
 // Public IP address resource.
 type PublicIPAddressSpec_LoadBalancer_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
 // Subnet in a virtual network resource.
 type Subnet_LoadBalancer_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 

--- a/v2/api/network/v1api20201101/arm/load_balancers_inbound_nat_rule_spec_types_gen.go
+++ b/v2/api/network/v1api20201101/arm/load_balancers_inbound_nat_rule_spec_types_gen.go
@@ -62,6 +62,7 @@ type InboundNatRulePropertiesFormat struct {
 
 // Reference to another subresource.
 type SubResource struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 

--- a/v2/api/network/v1api20201101/arm/network_interface_spec_types_gen.go
+++ b/v2/api/network/v1api20201101/arm/network_interface_spec_types_gen.go
@@ -97,11 +97,13 @@ var networkInterfacePropertiesFormat_NicType_Values = map[string]NetworkInterfac
 
 // NetworkSecurityGroup resource.
 type NetworkSecurityGroupSpec_NetworkInterface_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
 // Private link service resource.
 type PrivateLinkServiceSpec struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
@@ -143,35 +145,42 @@ type NetworkInterfaceIPConfigurationPropertiesFormat struct {
 
 // Backend Address Pool of an application gateway.
 type ApplicationGatewayBackendAddressPool_NetworkInterface_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
 // An application security group in a resource group.
 type ApplicationSecurityGroupSpec_NetworkInterface_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
 // Pool of backend IP addresses.
 type BackendAddressPool_NetworkInterface_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
 // Inbound NAT rule of the load balancer.
 type InboundNatRule_NetworkInterface_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
 // Public IP address resource.
 type PublicIPAddressSpec_NetworkInterface_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
 // Subnet in a virtual network resource.
 type Subnet_NetworkInterface_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
 // Virtual Network Tap resource.
 type VirtualNetworkTapSpec_NetworkInterface_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }

--- a/v2/api/network/v1api20201101/arm/network_security_group_spec_types_gen.go
+++ b/v2/api/network/v1api20201101/arm/network_security_group_spec_types_gen.go
@@ -42,6 +42,7 @@ type NetworkSecurityGroupPropertiesFormat struct {
 
 // Network security rule.
 type SecurityRule struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 
 	// Name: The name of the resource that is unique within a resource group. This name can be used to access the resource.
@@ -110,5 +111,6 @@ type SecurityRulePropertiesFormat_NetworkSecurityGroup_SubResourceEmbedded struc
 
 // An application security group in a resource group.
 type ApplicationSecurityGroupSpec_NetworkSecurityGroup_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }

--- a/v2/api/network/v1api20201101/arm/network_security_groups_security_rule_spec_types_gen.go
+++ b/v2/api/network/v1api20201101/arm/network_security_groups_security_rule_spec_types_gen.go
@@ -86,6 +86,7 @@ type SecurityRulePropertiesFormat_NetworkSecurityGroups_SecurityRule_SubResource
 
 // An application security group in a resource group.
 type ApplicationSecurityGroupSpec_NetworkSecurityGroups_SecurityRule_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 

--- a/v2/api/network/v1api20201101/arm/public_ip_address_spec_types_gen.go
+++ b/v2/api/network/v1api20201101/arm/public_ip_address_spec_types_gen.go
@@ -142,6 +142,7 @@ var iPVersion_Values = map[string]IPVersion{
 
 // Nat Gateway resource.
 type NatGatewaySpec_PublicIPAddress_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
@@ -192,6 +193,7 @@ var publicIPAddressSku_Tier_Values = map[string]PublicIPAddressSku_Tier{
 
 // Public IP address resource.
 type PublicIPAddressSpec_PublicIPAddress_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 

--- a/v2/api/network/v1api20201101/arm/route_table_spec_types_gen.go
+++ b/v2/api/network/v1api20201101/arm/route_table_spec_types_gen.go
@@ -45,6 +45,7 @@ type RouteTablePropertiesFormat struct {
 
 // Route resource.
 type Route struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 
 	// Name: The name of the resource that is unique within a resource group. This name can be used to access the resource.

--- a/v2/api/network/v1api20201101/arm/virtual_network_gateway_spec_types_gen.go
+++ b/v2/api/network/v1api20201101/arm/virtual_network_gateway_spec_types_gen.go
@@ -70,8 +70,11 @@ type VirtualNetworkGatewayPropertiesFormat struct {
 
 	// Sku: The reference to the VirtualNetworkGatewaySku resource which represents the SKU selected for Virtual network
 	// gateway.
-	Sku                            *VirtualNetworkGatewaySku `json:"sku,omitempty"`
-	VNetExtendedLocationResourceId *string                   `json:"vNetExtendedLocationResourceId,omitempty"`
+	Sku *VirtualNetworkGatewaySku `json:"sku,omitempty"`
+
+	// VNetExtendedLocationResourceId: Customer vnet resource id. VirtualNetworkGateway of type local gateway is associated
+	// with the customer vnet.
+	VNetExtendedLocationResourceId *string `json:"vNetExtendedLocationResourceId,omitempty"`
 
 	// VpnClientConfiguration: The reference to the VpnClientConfiguration resource which represents the P2S VpnClient
 	// configurations.

--- a/v2/api/network/v1api20201101/arm/virtual_network_spec_types_gen.go
+++ b/v2/api/network/v1api20201101/arm/virtual_network_spec_types_gen.go
@@ -77,6 +77,7 @@ type DhcpOptions struct {
 
 // Subnet in a virtual network resource.
 type Subnet_VirtualNetwork_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 
 	// Name: The name of the resource that is unique within a resource group. This name can be used to access the resource.
@@ -97,6 +98,7 @@ type VirtualNetworkBgpCommunities struct {
 
 // Peerings in a virtual network resource.
 type VirtualNetworkPeering struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 
 	// Name: The name of the resource that is unique within a resource group. This name can be used to access the resource.
@@ -150,20 +152,24 @@ type SubnetPropertiesFormat_VirtualNetwork_SubResourceEmbedded struct {
 
 // IP configuration of an application gateway. Currently 1 public and 1 private IP configuration is allowed.
 type ApplicationGatewayIPConfiguration_VirtualNetwork_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
 // NetworkSecurityGroup resource.
 type NetworkSecurityGroupSpec_VirtualNetwork_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
 // Route table resource.
 type RouteTableSpec_VirtualNetwork_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
 // Service End point policy resource.
 type ServiceEndpointPolicySpec_VirtualNetwork_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }

--- a/v2/api/network/v1api20201101/arm/virtual_networks_subnet_spec_types_gen.go
+++ b/v2/api/network/v1api20201101/arm/virtual_networks_subnet_spec_types_gen.go
@@ -71,6 +71,7 @@ type SubnetPropertiesFormat_VirtualNetworks_Subnet_SubResourceEmbedded struct {
 
 // IP configuration of an application gateway. Currently 1 public and 1 private IP configuration is allowed.
 type ApplicationGatewayIPConfiguration_VirtualNetworks_Subnet_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
@@ -85,16 +86,19 @@ type Delegation struct {
 
 // NetworkSecurityGroup resource.
 type NetworkSecurityGroupSpec_VirtualNetworks_Subnet_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
 // Route table resource.
 type RouteTableSpec_VirtualNetworks_Subnet_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
 // Service End point policy resource.
 type ServiceEndpointPolicySpec_VirtualNetworks_Subnet_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 

--- a/v2/api/network/v1api20220401/arm/traffic_manager_profiles_azure_endpoint_spec_types_gen.go
+++ b/v2/api/network/v1api20220401/arm/traffic_manager_profiles_azure_endpoint_spec_types_gen.go
@@ -82,7 +82,9 @@ type EndpointProperties struct {
 
 	// Target: The fully-qualified DNS name or IP address of the endpoint. Traffic Manager returns this value in DNS responses
 	// to direct traffic to this endpoint.
-	Target           *string `json:"target,omitempty"`
+	Target *string `json:"target,omitempty"`
+
+	// TargetResourceId: The Azure Resource URI of the of the endpoint. Not applicable to endpoints of type 'ExternalEndpoints'.
 	TargetResourceId *string `json:"targetResourceId,omitempty"`
 
 	// Weight: The weight of this endpoint when using the 'Weighted' traffic routing method. Possible values are from 1 to 1000.

--- a/v2/api/network/v1api20220701/arm/application_gateway_spec_types_gen.go
+++ b/v2/api/network/v1api20220701/arm/application_gateway_spec_types_gen.go
@@ -466,6 +466,7 @@ var managedServiceIdentity_Type_Values = map[string]ManagedServiceIdentity_Type{
 
 // Reference to another ARM resource.
 type SubResource struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
@@ -1113,6 +1114,7 @@ var applicationGatewayLoadDistributionAlgorithmEnum_Values = map[string]Applicat
 
 // Load Distribution Target of an application gateway.
 type ApplicationGatewayLoadDistributionTarget struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
@@ -1127,6 +1129,7 @@ type ApplicationGatewayPathRule struct {
 
 // The application gateway private link ip configuration.
 type ApplicationGatewayPrivateLinkIpConfiguration struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 

--- a/v2/api/network/v1api20220701/arm/private_endpoint_spec_types_gen.go
+++ b/v2/api/network/v1api20220701/arm/private_endpoint_spec_types_gen.go
@@ -71,6 +71,7 @@ type PrivateEndpointProperties struct {
 
 // An application security group in a resource group.
 type ApplicationSecurityGroupSpec_PrivateEndpoint_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
@@ -105,6 +106,7 @@ type PrivateLinkServiceConnection struct {
 
 // Subnet in a virtual network resource.
 type Subnet_PrivateEndpoint_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
@@ -128,7 +130,9 @@ type PrivateLinkServiceConnectionProperties struct {
 	// PrivateLinkServiceConnectionState: A collection of read-only information about the state of the connection to the remote
 	// resource.
 	PrivateLinkServiceConnectionState *PrivateLinkServiceConnectionState `json:"privateLinkServiceConnectionState,omitempty"`
-	PrivateLinkServiceId              *string                            `json:"privateLinkServiceId,omitempty"`
+
+	// PrivateLinkServiceId: The resource id of private link service.
+	PrivateLinkServiceId *string `json:"privateLinkServiceId,omitempty"`
 
 	// RequestMessage: A message passed to the owner of the remote resource with this connection request. Restricted to 140
 	// chars.

--- a/v2/api/network/v1api20220701/arm/private_endpoints_private_dns_zone_group_spec_types_gen.go
+++ b/v2/api/network/v1api20220701/arm/private_endpoints_private_dns_zone_group_spec_types_gen.go
@@ -47,5 +47,6 @@ type PrivateDnsZoneConfig struct {
 
 // Properties of the private dns zone configuration resource.
 type PrivateDnsZonePropertiesFormat struct {
+	// PrivateDnsZoneId: The resource id of the private dns zone.
 	PrivateDnsZoneId *string `json:"privateDnsZoneId,omitempty"`
 }

--- a/v2/api/network/v1api20220701/arm/private_link_service_spec_types_gen.go
+++ b/v2/api/network/v1api20220701/arm/private_link_service_spec_types_gen.go
@@ -60,6 +60,7 @@ type PrivateLinkServiceProperties struct {
 
 // Frontend IP address of the load balancer.
 type FrontendIPConfiguration_PrivateLinkService_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
@@ -98,5 +99,6 @@ type PrivateLinkServiceIpConfigurationProperties struct {
 
 // Subnet in a virtual network resource.
 type Subnet_PrivateLinkService_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }

--- a/v2/api/network/v1api20220701/arm/public_ip_prefix_spec_types_gen.go
+++ b/v2/api/network/v1api20220701/arm/public_ip_prefix_spec_types_gen.go
@@ -96,6 +96,7 @@ var iPVersion_Values = map[string]IPVersion{
 
 // Nat Gateway resource.
 type NatGatewaySpec_PublicIPPrefix_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 

--- a/v2/api/network/v1api20240301/arm/azure_firewall_spec_types_gen.go
+++ b/v2/api/network/v1api20240301/arm/azure_firewall_spec_types_gen.go
@@ -160,6 +160,7 @@ type HubIPAddresses struct {
 
 // Reference to another subresource.
 type SubResource struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 

--- a/v2/api/network/v1api20240301/arm/load_balancer_spec_types_gen.go
+++ b/v2/api/network/v1api20240301/arm/load_balancer_spec_types_gen.go
@@ -487,11 +487,13 @@ var probePropertiesFormat_Protocol_Values = map[string]ProbePropertiesFormat_Pro
 
 // Public IP address resource.
 type PublicIPAddressSpec_LoadBalancer_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
 // Subnet in a virtual network resource.
 type Subnet_LoadBalancer_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 

--- a/v2/api/network/v1api20240301/arm/network_interface_spec_types_gen.go
+++ b/v2/api/network/v1api20240301/arm/network_interface_spec_types_gen.go
@@ -148,11 +148,13 @@ var networkInterfacePropertiesFormat_NicType_Values = map[string]NetworkInterfac
 
 // NetworkSecurityGroup resource.
 type NetworkSecurityGroupSpec_NetworkInterface_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
 // Private link service resource.
 type PrivateLinkServiceSpec struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
@@ -202,35 +204,42 @@ type NetworkInterfaceIPConfigurationPropertiesFormat struct {
 
 // Backend Address Pool of an application gateway.
 type ApplicationGatewayBackendAddressPool_NetworkInterface_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
 // An application security group in a resource group.
 type ApplicationSecurityGroupSpec_NetworkInterface_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
 // Pool of backend IP addresses.
 type BackendAddressPool_NetworkInterface_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
 // Inbound NAT rule of the load balancer.
 type InboundNatRule_NetworkInterface_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
 // Public IP address resource.
 type PublicIPAddressSpec_NetworkInterface_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
 // Subnet in a virtual network resource.
 type Subnet_NetworkInterface_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
 // Virtual Network Tap resource.
 type VirtualNetworkTapSpec_NetworkInterface_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }

--- a/v2/api/network/v1api20240301/arm/network_security_group_spec_types_gen.go
+++ b/v2/api/network/v1api20240301/arm/network_security_group_spec_types_gen.go
@@ -46,6 +46,7 @@ type NetworkSecurityGroupPropertiesFormat struct {
 
 // Network security rule.
 type SecurityRule struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 
 	// Name: The name of the resource that is unique within a resource group. This name can be used to access the resource.
@@ -114,5 +115,6 @@ type SecurityRulePropertiesFormat_NetworkSecurityGroup_SubResourceEmbedded struc
 
 // An application security group in a resource group.
 type ApplicationSecurityGroupSpec_NetworkSecurityGroup_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }

--- a/v2/api/network/v1api20240301/arm/network_security_groups_security_rule_spec_types_gen.go
+++ b/v2/api/network/v1api20240301/arm/network_security_groups_security_rule_spec_types_gen.go
@@ -86,6 +86,7 @@ type SecurityRulePropertiesFormat_NetworkSecurityGroups_SecurityRule_SubResource
 
 // An application security group in a resource group.
 type ApplicationSecurityGroupSpec_NetworkSecurityGroups_SecurityRule_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 

--- a/v2/api/network/v1api20240301/arm/private_endpoint_spec_types_gen.go
+++ b/v2/api/network/v1api20240301/arm/private_endpoint_spec_types_gen.go
@@ -62,6 +62,7 @@ type PrivateEndpointProperties struct {
 
 // An application security group in a resource group.
 type ApplicationSecurityGroupSpec_PrivateEndpoint_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
@@ -85,6 +86,7 @@ type PrivateLinkServiceConnection struct {
 
 // Subnet in a virtual network resource.
 type Subnet_PrivateEndpoint_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
@@ -108,7 +110,9 @@ type PrivateLinkServiceConnectionProperties struct {
 	// PrivateLinkServiceConnectionState: A collection of read-only information about the state of the connection to the remote
 	// resource.
 	PrivateLinkServiceConnectionState *PrivateLinkServiceConnectionState `json:"privateLinkServiceConnectionState,omitempty"`
-	PrivateLinkServiceId              *string                            `json:"privateLinkServiceId,omitempty"`
+
+	// PrivateLinkServiceId: The resource id of private link service.
+	PrivateLinkServiceId *string `json:"privateLinkServiceId,omitempty"`
 
 	// RequestMessage: A message passed to the owner of the remote resource with this connection request. Restricted to 140
 	// chars.

--- a/v2/api/network/v1api20240301/arm/private_endpoints_private_dns_zone_group_spec_types_gen.go
+++ b/v2/api/network/v1api20240301/arm/private_endpoints_private_dns_zone_group_spec_types_gen.go
@@ -47,5 +47,6 @@ type PrivateDnsZoneConfig struct {
 
 // Properties of the private dns zone configuration resource.
 type PrivateDnsZonePropertiesFormat struct {
+	// PrivateDnsZoneId: The resource id of the private dns zone.
 	PrivateDnsZoneId *string `json:"privateDnsZoneId,omitempty"`
 }

--- a/v2/api/network/v1api20240301/arm/private_link_service_spec_types_gen.go
+++ b/v2/api/network/v1api20240301/arm/private_link_service_spec_types_gen.go
@@ -63,6 +63,7 @@ type PrivateLinkServiceProperties struct {
 
 // Frontend IP address of the load balancer.
 type FrontendIPConfiguration_PrivateLinkService_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
@@ -101,5 +102,6 @@ type PrivateLinkServiceIpConfigurationProperties struct {
 
 // Subnet in a virtual network resource.
 type Subnet_PrivateLinkService_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }

--- a/v2/api/network/v1api20240301/arm/public_ip_address_spec_types_gen.go
+++ b/v2/api/network/v1api20240301/arm/public_ip_address_spec_types_gen.go
@@ -141,6 +141,7 @@ var iPVersion_Values = map[string]IPVersion{
 
 // Nat Gateway resource.
 type NatGatewaySpec_PublicIPAddress_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
@@ -209,6 +210,7 @@ var publicIPAddressSku_Tier_Values = map[string]PublicIPAddressSku_Tier{
 
 // Public IP address resource.
 type PublicIPAddressSpec_PublicIPAddress_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 

--- a/v2/api/network/v1api20240301/arm/public_ip_prefix_spec_types_gen.go
+++ b/v2/api/network/v1api20240301/arm/public_ip_prefix_spec_types_gen.go
@@ -72,6 +72,7 @@ type PublicIPPrefixSku struct {
 
 // Nat Gateway resource.
 type NatGatewaySpec_PublicIPPrefix_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 

--- a/v2/api/network/v1api20240301/arm/route_table_spec_types_gen.go
+++ b/v2/api/network/v1api20240301/arm/route_table_spec_types_gen.go
@@ -45,6 +45,7 @@ type RouteTablePropertiesFormat struct {
 
 // Route resource.
 type Route struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 
 	// Name: The name of the resource that is unique within a resource group. This name can be used to access the resource.

--- a/v2/api/network/v1api20240301/arm/virtual_network_gateway_spec_types_gen.go
+++ b/v2/api/network/v1api20240301/arm/virtual_network_gateway_spec_types_gen.go
@@ -99,8 +99,11 @@ type VirtualNetworkGatewayPropertiesFormat struct {
 
 	// Sku: The reference to the VirtualNetworkGatewaySku resource which represents the SKU selected for Virtual network
 	// gateway.
-	Sku                            *VirtualNetworkGatewaySku `json:"sku,omitempty"`
-	VNetExtendedLocationResourceId *string                   `json:"vNetExtendedLocationResourceId,omitempty"`
+	Sku *VirtualNetworkGatewaySku `json:"sku,omitempty"`
+
+	// VNetExtendedLocationResourceId: Customer vnet resource id. VirtualNetworkGateway of type local gateway is associated
+	// with the customer vnet.
+	VNetExtendedLocationResourceId *string `json:"vNetExtendedLocationResourceId,omitempty"`
 
 	// VirtualNetworkGatewayPolicyGroups: The reference to the VirtualNetworkGatewayPolicyGroup resource which represents the
 	// available VirtualNetworkGatewayPolicyGroup for the gateway.
@@ -493,6 +496,7 @@ var virtualNetworkGatewaySku_Tier_Values = map[string]VirtualNetworkGatewaySku_T
 
 // A vpn client connection configuration for client connection configuration.
 type VngClientConnectionConfiguration struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 

--- a/v2/api/network/v1api20240301/arm/virtual_network_spec_types_gen.go
+++ b/v2/api/network/v1api20240301/arm/virtual_network_spec_types_gen.go
@@ -102,6 +102,7 @@ var privateEndpointVNetPolicies_Values = map[string]PrivateEndpointVNetPolicies{
 
 // Subnet in a virtual network resource.
 type Subnet_VirtualNetwork_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 
 	// Name: The name of the resource that is unique within a resource group. This name can be used to access the resource.
@@ -132,6 +133,7 @@ type VirtualNetworkEncryption struct {
 
 // Peerings in a virtual network resource.
 type VirtualNetworkPeering struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 
 	// Name: The name of the resource that is unique within a resource group. This name can be used to access the resource.
@@ -207,20 +209,24 @@ var virtualNetworkEncryption_Enforcement_Values = map[string]VirtualNetworkEncry
 
 // IP configuration of an application gateway. Currently 1 public and 1 private IP configuration is allowed.
 type ApplicationGatewayIPConfiguration_VirtualNetwork_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
 // NetworkSecurityGroup resource.
 type NetworkSecurityGroupSpec_VirtualNetwork_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
 // Route table resource.
 type RouteTableSpec_VirtualNetwork_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
 // Service End point policy resource.
 type ServiceEndpointPolicySpec_VirtualNetwork_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }

--- a/v2/api/network/v1api20240301/arm/virtual_networks_subnet_spec_types_gen.go
+++ b/v2/api/network/v1api20240301/arm/virtual_networks_subnet_spec_types_gen.go
@@ -79,6 +79,7 @@ type SubnetPropertiesFormat_VirtualNetworks_Subnet_SubResourceEmbedded struct {
 
 // IP configuration of an application gateway. Currently 1 public and 1 private IP configuration is allowed.
 type ApplicationGatewayIPConfiguration_VirtualNetworks_Subnet_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
@@ -93,16 +94,19 @@ type Delegation struct {
 
 // NetworkSecurityGroup resource.
 type NetworkSecurityGroupSpec_VirtualNetworks_Subnet_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
 // Route table resource.
 type RouteTableSpec_VirtualNetworks_Subnet_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
 // Service End point policy resource.
 type ServiceEndpointPolicySpec_VirtualNetworks_Subnet_SubResourceEmbedded struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 

--- a/v2/api/network/v1api20240601/arm/private_dns_zones_virtual_network_link_spec_types_gen.go
+++ b/v2/api/network/v1api20240601/arm/private_dns_zones_virtual_network_link_spec_types_gen.go
@@ -54,6 +54,7 @@ type VirtualNetworkLinkProperties struct {
 
 // Reference to another subresource.
 type SubResource struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 

--- a/v2/api/operationalinsights/v1api20210601/arm/workspace_spec_types_gen.go
+++ b/v2/api/operationalinsights/v1api20210601/arm/workspace_spec_types_gen.go
@@ -88,6 +88,7 @@ type WorkspaceCapping struct {
 
 // Workspace features.
 type WorkspaceFeatures struct {
+	// ClusterResourceId: Dedicated LA cluster resourceId that is linked to the workspaces.
 	ClusterResourceId *string `json:"clusterResourceId,omitempty"`
 
 	// DisableLocalAuth: Disable Non-AAD based Auth.

--- a/v2/api/redhatopenshift/v1api20231122/arm/open_shift_cluster_spec_types_gen.go
+++ b/v2/api/redhatopenshift/v1api20231122/arm/open_shift_cluster_spec_types_gen.go
@@ -93,11 +93,14 @@ type IngressProfile struct {
 
 // MasterProfile represents a master profile.
 type MasterProfile struct {
+	// DiskEncryptionSetId: The resource ID of an associated DiskEncryptionSet, if applicable.
 	DiskEncryptionSetId *string `json:"diskEncryptionSetId,omitempty"`
 
 	// EncryptionAtHost: Whether master virtual machines are encrypted at host.
 	EncryptionAtHost *EncryptionAtHost `json:"encryptionAtHost,omitempty"`
-	SubnetId         *string           `json:"subnetId,omitempty"`
+
+	// SubnetId: The Azure resource ID of the master subnet.
+	SubnetId *string `json:"subnetId,omitempty"`
 
 	// VmSize: The size of the master VMs.
 	VmSize *string `json:"vmSize,omitempty"`
@@ -133,7 +136,9 @@ type ServicePrincipalProfile struct {
 // WorkerProfile represents a worker profile.
 type WorkerProfile struct {
 	// Count: The number of worker VMs.
-	Count               *int    `json:"count,omitempty"`
+	Count *int `json:"count,omitempty"`
+
+	// DiskEncryptionSetId: The resource ID of an associated DiskEncryptionSet, if applicable.
 	DiskEncryptionSetId *string `json:"diskEncryptionSetId,omitempty"`
 
 	// DiskSizeGB: The disk size of the worker VMs.
@@ -143,7 +148,9 @@ type WorkerProfile struct {
 	EncryptionAtHost *EncryptionAtHost `json:"encryptionAtHost,omitempty"`
 
 	// Name: The worker profile name.
-	Name     *string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
+
+	// SubnetId: The Azure resource ID of the worker subnet.
 	SubnetId *string `json:"subnetId,omitempty"`
 
 	// VmSize: The size of the worker VMs.

--- a/v2/api/servicebus/v1api20210101preview/arm/namespace_spec_types_gen.go
+++ b/v2/api/servicebus/v1api20210101preview/arm/namespace_spec_types_gen.go
@@ -159,5 +159,6 @@ type KeyVaultProperties struct {
 }
 
 type UserAssignedIdentityProperties struct {
+	// UserAssignedIdentity: ARM ID of user Identity selected for encryption
 	UserAssignedIdentity *string `json:"userAssignedIdentity,omitempty"`
 }

--- a/v2/api/servicebus/v1api20211101/arm/namespace_spec_types_gen.go
+++ b/v2/api/servicebus/v1api20211101/arm/namespace_spec_types_gen.go
@@ -165,5 +165,6 @@ type KeyVaultProperties struct {
 }
 
 type UserAssignedIdentityProperties struct {
+	// UserAssignedIdentity: ARM ID of user Identity selected for encryption
 	UserAssignedIdentity *string `json:"userAssignedIdentity,omitempty"`
 }

--- a/v2/api/servicebus/v1api20221001preview/arm/namespace_spec_types_gen.go
+++ b/v2/api/servicebus/v1api20221001preview/arm/namespace_spec_types_gen.go
@@ -210,5 +210,6 @@ type KeyVaultProperties struct {
 }
 
 type UserAssignedIdentityProperties struct {
+	// UserAssignedIdentity: ARM ID of user Identity selected for encryption
 	UserAssignedIdentity *string `json:"userAssignedIdentity,omitempty"`
 }

--- a/v2/api/servicebus/v1api20240101/arm/namespace_spec_types_gen.go
+++ b/v2/api/servicebus/v1api20240101/arm/namespace_spec_types_gen.go
@@ -210,5 +210,6 @@ type KeyVaultProperties struct {
 }
 
 type UserAssignedIdentityProperties struct {
+	// UserAssignedIdentity: ARM ID of user Identity selected for encryption
 	UserAssignedIdentity *string `json:"userAssignedIdentity,omitempty"`
 }

--- a/v2/api/signalrservice/v1api20240301/arm/custom_domain_spec_types_gen.go
+++ b/v2/api/signalrservice/v1api20240301/arm/custom_domain_spec_types_gen.go
@@ -40,5 +40,6 @@ type CustomDomainProperties struct {
 
 // Reference to a resource.
 type ResourceReference struct {
+	// Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }

--- a/v2/api/sql/v1api20211101/arm/server_spec_types_gen.go
+++ b/v2/api/sql/v1api20211101/arm/server_spec_types_gen.go
@@ -63,7 +63,9 @@ type ServerProperties struct {
 	KeyId *string `json:"keyId,omitempty"`
 
 	// MinimalTlsVersion: Minimal TLS version. Allowed values: '1.0', '1.1', '1.2'
-	MinimalTlsVersion             *string `json:"minimalTlsVersion,omitempty"`
+	MinimalTlsVersion *string `json:"minimalTlsVersion,omitempty"`
+
+	// PrimaryUserAssignedIdentityId: The resource id of a user assigned identity to be used by default.
 	PrimaryUserAssignedIdentityId *string `json:"primaryUserAssignedIdentityId,omitempty"`
 
 	// PublicNetworkAccess: Whether or not public endpoint access is allowed for this server.  Value is optional but if passed

--- a/v2/api/sql/v1api20211101/arm/servers_database_spec_types_gen.go
+++ b/v2/api/sql/v1api20211101/arm/servers_database_spec_types_gen.go
@@ -85,8 +85,10 @@ type DatabaseProperties struct {
 	// RestoreLongTermRetentionBackup: Creates a database by restoring from a long term retention vault.
 	// recoveryServicesRecoveryPointResourceId must be specified as the recovery point resource ID.
 	// Copy, Secondary, and RestoreLongTermRetentionBackup are not supported for DataWarehouse edition.
-	CreateMode    *DatabaseProperties_CreateMode `json:"createMode,omitempty"`
-	ElasticPoolId *string                        `json:"elasticPoolId,omitempty"`
+	CreateMode *DatabaseProperties_CreateMode `json:"createMode,omitempty"`
+
+	// ElasticPoolId: The resource identifier of the elastic pool containing this database.
+	ElasticPoolId *string `json:"elasticPoolId,omitempty"`
 
 	// FederatedClientId: The Client id used for cross tenant per database CMK scenario
 	FederatedClientId *string `json:"federatedClientId,omitempty"`
@@ -101,8 +103,11 @@ type DatabaseProperties struct {
 
 	// LicenseType: The license type to apply for this database. `LicenseIncluded` if you need a license, or `BasePrice` if you
 	// have a license and are eligible for the Azure Hybrid Benefit.
-	LicenseType                       *DatabaseProperties_LicenseType `json:"licenseType,omitempty"`
-	LongTermRetentionBackupResourceId *string                         `json:"longTermRetentionBackupResourceId,omitempty"`
+	LicenseType *DatabaseProperties_LicenseType `json:"licenseType,omitempty"`
+
+	// LongTermRetentionBackupResourceId: The resource identifier of the long term retention backup associated with create
+	// operation of this database.
+	LongTermRetentionBackupResourceId *string `json:"longTermRetentionBackupResourceId,omitempty"`
 
 	// MaintenanceConfigurationId: Maintenance configuration id assigned to the database. This configuration defines the period
 	// when the maintenance updates will occur.
@@ -117,13 +122,22 @@ type DatabaseProperties struct {
 	// ReadScale: The state of read-only routing. If enabled, connections that have application intent set to readonly in their
 	// connection string may be routed to a readonly secondary replica in the same region. Not applicable to a Hyperscale
 	// database within an elastic pool.
-	ReadScale                       *DatabaseProperties_ReadScale `json:"readScale,omitempty"`
-	RecoverableDatabaseId           *string                       `json:"recoverableDatabaseId,omitempty"`
-	RecoveryServicesRecoveryPointId *string                       `json:"recoveryServicesRecoveryPointId,omitempty"`
+	ReadScale *DatabaseProperties_ReadScale `json:"readScale,omitempty"`
+
+	// RecoverableDatabaseId: The resource identifier of the recoverable database associated with create operation of this
+	// database.
+	RecoverableDatabaseId *string `json:"recoverableDatabaseId,omitempty"`
+
+	// RecoveryServicesRecoveryPointId: The resource identifier of the recovery point associated with create operation of this
+	// database.
+	RecoveryServicesRecoveryPointId *string `json:"recoveryServicesRecoveryPointId,omitempty"`
 
 	// RequestedBackupStorageRedundancy: The storage account type to be used to store backups for this database.
 	RequestedBackupStorageRedundancy *DatabaseProperties_RequestedBackupStorageRedundancy `json:"requestedBackupStorageRedundancy,omitempty"`
-	RestorableDroppedDatabaseId      *string                                              `json:"restorableDroppedDatabaseId,omitempty"`
+
+	// RestorableDroppedDatabaseId: The resource identifier of the restorable dropped database associated with create operation
+	// of this database.
+	RestorableDroppedDatabaseId *string `json:"restorableDroppedDatabaseId,omitempty"`
 
 	// RestorePointInTime: Specifies the point in time (ISO8601 format) of the source database that will be restored to create
 	// the new database.
@@ -137,8 +151,24 @@ type DatabaseProperties struct {
 
 	// SourceDatabaseDeletionDate: Specifies the time that the database was deleted.
 	SourceDatabaseDeletionDate *string `json:"sourceDatabaseDeletionDate,omitempty"`
-	SourceDatabaseId           *string `json:"sourceDatabaseId,omitempty"`
-	SourceResourceId           *string `json:"sourceResourceId,omitempty"`
+
+	// SourceDatabaseId: The resource identifier of the source database associated with create operation of this database.
+	SourceDatabaseId *string `json:"sourceDatabaseId,omitempty"`
+
+	// SourceResourceId: The resource identifier of the source associated with the create operation of this database.
+	// This property is only supported for DataWarehouse edition and allows to restore across subscriptions.
+	// When sourceResourceId is specified, sourceDatabaseId, recoverableDatabaseId, restorableDroppedDatabaseId and
+	// sourceDatabaseDeletionDate must not be specified and CreateMode must be PointInTimeRestore, Restore or Recover.
+	// When createMode is PointInTimeRestore, sourceResourceId must be the resource ID of the existing database or existing sql
+	// pool, and restorePointInTime must be specified.
+	// When createMode is Restore, sourceResourceId must be the resource ID of restorable dropped database or restorable
+	// dropped sql pool.
+	// When createMode is Recover, sourceResourceId must be the resource ID of recoverable database or recoverable sql pool.
+	// When source subscription belongs to a different tenant than target subscription, “x-ms-authorization-auxiliary”
+	// header must contain authentication token for the source tenant. For more details about
+	// “x-ms-authorization-auxiliary” header see
+	// https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/authenticate-multi-tenant
+	SourceResourceId *string `json:"sourceResourceId,omitempty"`
 
 	// ZoneRedundant: Whether or not this database is zone redundant, which means the replicas of this database will be spread
 	// across multiple availability zones.

--- a/v2/api/sql/v1api20211101/arm/servers_failover_group_spec_types_gen.go
+++ b/v2/api/sql/v1api20211101/arm/servers_failover_group_spec_types_gen.go
@@ -34,6 +34,7 @@ func (group *ServersFailoverGroup_Spec) GetType() string {
 
 // Properties of a failover group.
 type FailoverGroupProperties struct {
+	// Databases: List of databases in the failover group.
 	Databases []string `json:"databases,omitempty"`
 
 	// PartnerServers: List of partner server information for the failover group.
@@ -65,6 +66,7 @@ type FailoverGroupReadWriteEndpoint struct {
 
 // Partner server information for the failover group.
 type PartnerInfo struct {
+	// Id: Resource identifier of the partner server.
 	Id *string `json:"id,omitempty"`
 }
 

--- a/v2/api/sql/v1api20211101/arm/servers_virtual_network_rule_spec_types_gen.go
+++ b/v2/api/sql/v1api20211101/arm/servers_virtual_network_rule_spec_types_gen.go
@@ -32,6 +32,8 @@ func (rule *ServersVirtualNetworkRule_Spec) GetType() string {
 // Properties of a virtual network rule.
 type VirtualNetworkRuleProperties struct {
 	// IgnoreMissingVnetServiceEndpoint: Create firewall rule before the virtual network has vnet service endpoint enabled.
-	IgnoreMissingVnetServiceEndpoint *bool   `json:"ignoreMissingVnetServiceEndpoint,omitempty"`
-	VirtualNetworkSubnetId           *string `json:"virtualNetworkSubnetId,omitempty"`
+	IgnoreMissingVnetServiceEndpoint *bool `json:"ignoreMissingVnetServiceEndpoint,omitempty"`
+
+	// VirtualNetworkSubnetId: The ARM resource id of the virtual network subnet.
+	VirtualNetworkSubnetId *string `json:"virtualNetworkSubnetId,omitempty"`
 }

--- a/v2/api/storage/v1api20210401/arm/storage_account_spec_types_gen.go
+++ b/v2/api/storage/v1api20210401/arm/storage_account_spec_types_gen.go
@@ -438,6 +438,8 @@ var encryption_KeySource_Values = map[string]Encryption_KeySource{
 
 // Encryption identity for the storage account.
 type EncryptionIdentity struct {
+	// UserAssignedIdentity: Resource identifier of the UserAssigned identity to be associated with server-side encryption on
+	// the storage account.
 	UserAssignedIdentity *string `json:"userAssignedIdentity,omitempty"`
 }
 
@@ -493,6 +495,7 @@ var networkRuleSet_DefaultAction_Values = map[string]NetworkRuleSet_DefaultActio
 
 // Resource Access Rule.
 type ResourceAccessRule struct {
+	// ResourceId: Resource Id
 	ResourceId *string `json:"resourceId,omitempty"`
 
 	// TenantId: Tenant Id
@@ -527,7 +530,10 @@ var sasPolicy_ExpirationAction_Values = map[string]SasPolicy_ExpirationAction{
 type VirtualNetworkRule struct {
 	// Action: The action of virtual network rule.
 	Action *VirtualNetworkRule_Action `json:"action,omitempty"`
-	Id     *string                    `json:"id,omitempty"`
+
+	// Id: Resource ID of a subnet, for example:
+	// /subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Network/virtualNetworks/{vnetName}/subnets/{subnetName}.
+	Id *string `json:"id,omitempty"`
 
 	// State: Gets the state of virtual network rule.
 	State *VirtualNetworkRule_State `json:"state,omitempty"`

--- a/v2/api/storage/v1api20220901/arm/storage_account_spec_types_gen.go
+++ b/v2/api/storage/v1api20220901/arm/storage_account_spec_types_gen.go
@@ -551,7 +551,10 @@ type EncryptionIdentity struct {
 	// FederatedIdentityClientId: ClientId of the multi-tenant application to be used in conjunction with the user-assigned
 	// identity for cross-tenant customer-managed-keys server-side encryption on the storage account.
 	FederatedIdentityClientId *string `json:"federatedIdentityClientId,omitempty"`
-	UserAssignedIdentity      *string `json:"userAssignedIdentity,omitempty"`
+
+	// UserAssignedIdentity: Resource identifier of the UserAssigned identity to be associated with server-side encryption on
+	// the storage account.
+	UserAssignedIdentity *string `json:"userAssignedIdentity,omitempty"`
 }
 
 // A list of services that support encryption.
@@ -606,6 +609,7 @@ var networkRuleSet_DefaultAction_Values = map[string]NetworkRuleSet_DefaultActio
 
 // Resource Access Rule.
 type ResourceAccessRule struct {
+	// ResourceId: Resource Id
 	ResourceId *string `json:"resourceId,omitempty"`
 
 	// TenantId: Tenant Id
@@ -640,7 +644,10 @@ var sasPolicy_ExpirationAction_Values = map[string]SasPolicy_ExpirationAction{
 type VirtualNetworkRule struct {
 	// Action: The action of virtual network rule.
 	Action *VirtualNetworkRule_Action `json:"action,omitempty"`
-	Id     *string                    `json:"id,omitempty"`
+
+	// Id: Resource ID of a subnet, for example:
+	// /subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Network/virtualNetworks/{vnetName}/subnets/{subnetName}.
+	Id *string `json:"id,omitempty"`
 
 	// State: Gets the state of virtual network rule.
 	State *VirtualNetworkRule_State `json:"state,omitempty"`

--- a/v2/api/storage/v1api20220901/arm/storage_accounts_file_services_share_spec_types_gen.go
+++ b/v2/api/storage/v1api20220901/arm/storage_accounts_file_services_share_spec_types_gen.go
@@ -104,7 +104,9 @@ var fileShareProperties_RootSquash_Values = map[string]FileShareProperties_RootS
 type SignedIdentifier struct {
 	// AccessPolicy: Access policy
 	AccessPolicy *AccessPolicy `json:"accessPolicy,omitempty"`
-	Id           *string       `json:"id,omitempty"`
+
+	// Id: An unique identifier of the stored access policy.
+	Id *string `json:"id,omitempty"`
 }
 
 type AccessPolicy struct {

--- a/v2/api/storage/v1api20220901/arm/storage_accounts_table_services_table_spec_types_gen.go
+++ b/v2/api/storage/v1api20220901/arm/storage_accounts_table_services_table_spec_types_gen.go
@@ -38,7 +38,9 @@ type TableProperties struct {
 type TableSignedIdentifier struct {
 	// AccessPolicy: Access policy
 	AccessPolicy *TableAccessPolicy `json:"accessPolicy,omitempty"`
-	Id           *string            `json:"id,omitempty"`
+
+	// Id: unique-64-character-value of the stored access policy.
+	Id *string `json:"id,omitempty"`
 }
 
 // Table Access Policy Properties Object.

--- a/v2/api/storage/v1api20230101/arm/storage_account_spec_types_gen.go
+++ b/v2/api/storage/v1api20230101/arm/storage_account_spec_types_gen.go
@@ -552,7 +552,10 @@ type EncryptionIdentity struct {
 	// FederatedIdentityClientId: ClientId of the multi-tenant application to be used in conjunction with the user-assigned
 	// identity for cross-tenant customer-managed-keys server-side encryption on the storage account.
 	FederatedIdentityClientId *string `json:"federatedIdentityClientId,omitempty"`
-	UserAssignedIdentity      *string `json:"userAssignedIdentity,omitempty"`
+
+	// UserAssignedIdentity: Resource identifier of the UserAssigned identity to be associated with server-side encryption on
+	// the storage account.
+	UserAssignedIdentity *string `json:"userAssignedIdentity,omitempty"`
 }
 
 // A list of services that support encryption.
@@ -607,6 +610,7 @@ var networkRuleSet_DefaultAction_Values = map[string]NetworkRuleSet_DefaultActio
 
 // Resource Access Rule.
 type ResourceAccessRule struct {
+	// ResourceId: Resource Id
 	ResourceId *string `json:"resourceId,omitempty"`
 
 	// TenantId: Tenant Id
@@ -641,7 +645,10 @@ var sasPolicy_ExpirationAction_Values = map[string]SasPolicy_ExpirationAction{
 type VirtualNetworkRule struct {
 	// Action: The action of virtual network rule.
 	Action *VirtualNetworkRule_Action `json:"action,omitempty"`
-	Id     *string                    `json:"id,omitempty"`
+
+	// Id: Resource ID of a subnet, for example:
+	// /subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Network/virtualNetworks/{vnetName}/subnets/{subnetName}.
+	Id *string `json:"id,omitempty"`
 
 	// State: Gets the state of virtual network rule.
 	State *VirtualNetworkRule_State `json:"state,omitempty"`

--- a/v2/api/storage/v1api20230101/arm/storage_accounts_file_services_share_spec_types_gen.go
+++ b/v2/api/storage/v1api20230101/arm/storage_accounts_file_services_share_spec_types_gen.go
@@ -104,7 +104,9 @@ var fileShareProperties_RootSquash_Values = map[string]FileShareProperties_RootS
 type SignedIdentifier struct {
 	// AccessPolicy: Access policy
 	AccessPolicy *AccessPolicy `json:"accessPolicy,omitempty"`
-	Id           *string       `json:"id,omitempty"`
+
+	// Id: An unique identifier of the stored access policy.
+	Id *string `json:"id,omitempty"`
 }
 
 type AccessPolicy struct {

--- a/v2/api/storage/v1api20230101/arm/storage_accounts_table_services_table_spec_types_gen.go
+++ b/v2/api/storage/v1api20230101/arm/storage_accounts_table_services_table_spec_types_gen.go
@@ -38,7 +38,9 @@ type TableProperties struct {
 type TableSignedIdentifier struct {
 	// AccessPolicy: Access policy
 	AccessPolicy *TableAccessPolicy `json:"accessPolicy,omitempty"`
-	Id           *string            `json:"id,omitempty"`
+
+	// Id: unique-64-character-value of the stored access policy.
+	Id *string `json:"id,omitempty"`
 }
 
 // Table Access Policy Properties Object.

--- a/v2/api/synapse/v1api20210601/arm/workspace_spec_types_gen.go
+++ b/v2/api/synapse/v1api20210601/arm/workspace_spec_types_gen.go
@@ -111,6 +111,8 @@ type DataLakeStorageAccountDetails struct {
 
 	// Filesystem: Filesystem name
 	Filesystem *string `json:"filesystem,omitempty"`
+
+	// ResourceId: ARM resource Id of this storage account
 	ResourceId *string `json:"resourceId,omitempty"`
 }
 
@@ -150,6 +152,7 @@ type ManagedVirtualNetworkSettings struct {
 
 // Purview Configuration
 type PurviewConfiguration struct {
+	// PurviewResourceId: Purview Resource ID
 	PurviewResourceId *string `json:"purviewResourceId,omitempty"`
 }
 
@@ -220,7 +223,9 @@ type CustomerManagedKeyDetails struct {
 type KekIdentityProperties struct {
 	// UseSystemAssignedIdentity: Boolean specifying whether to use system assigned identity or not
 	UseSystemAssignedIdentity *v1.JSON `json:"useSystemAssignedIdentity,omitempty"`
-	UserAssignedIdentity      *string  `json:"userAssignedIdentity,omitempty"`
+
+	// UserAssignedIdentity: User assigned identity resource Id
+	UserAssignedIdentity *string `json:"userAssignedIdentity,omitempty"`
 }
 
 // Details of the customer managed key associated with the workspace

--- a/v2/api/web/v1api20220301/arm/server_farm_spec_types_gen.go
+++ b/v2/api/web/v1api20220301/arm/server_farm_spec_types_gen.go
@@ -140,11 +140,13 @@ type Capability struct {
 
 // Specification for an App Service Environment to use for this resource.
 type HostingEnvironmentProfile struct {
+	// Id: Resource ID of the App Service Environment.
 	Id *string `json:"id,omitempty"`
 }
 
 // Specification for a Kubernetes Environment to use for this resource.
 type KubeEnvironmentProfile struct {
+	// Id: Resource ID of the Kubernetes Environment.
 	Id *string `json:"id,omitempty"`
 }
 

--- a/v2/api/web/v1api20220301/arm/site_spec_types_gen.go
+++ b/v2/api/web/v1api20220301/arm/site_spec_types_gen.go
@@ -120,14 +120,22 @@ type Site_Properties_Spec struct {
 
 	// ScmSiteAlsoStopped: <code>true</code> to stop SCM (KUDU) site when the app is stopped; otherwise, <code>false</code>.
 	// The default is <code>false</code>.
-	ScmSiteAlsoStopped *bool   `json:"scmSiteAlsoStopped,omitempty"`
-	ServerFarmId       *string `json:"serverFarmId,omitempty"`
+	ScmSiteAlsoStopped *bool `json:"scmSiteAlsoStopped,omitempty"`
+
+	// ServerFarmId: Resource ID of the associated App Service plan, formatted as:
+	// "/subscriptions/{subscriptionID}/resourceGroups/{groupName}/providers/Microsoft.Web/serverfarms/{appServicePlanName}".
+	ServerFarmId *string `json:"serverFarmId,omitempty"`
 
 	// SiteConfig: Configuration of the app.
 	SiteConfig *SiteConfig `json:"siteConfig,omitempty"`
 
 	// StorageAccountRequired: Checks if Customer provided storage account is required
-	StorageAccountRequired *bool   `json:"storageAccountRequired,omitempty"`
+	StorageAccountRequired *bool `json:"storageAccountRequired,omitempty"`
+
+	// VirtualNetworkSubnetId: Azure Resource Manager ID of the Virtual network and subnet to be joined by Regional VNET
+	// Integration.
+	// This must be of the form
+	// /subscriptions/{subscriptionName}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{vnetName}/subnets/{subnetName}
 	VirtualNetworkSubnetId *string `json:"virtualNetworkSubnetId,omitempty"`
 
 	// VnetContentShareEnabled: To enable accessing content over virtual network
@@ -165,11 +173,21 @@ type CloningInfo struct {
 	HostingEnvironment *string `json:"hostingEnvironment,omitempty"`
 
 	// Overwrite: <code>true</code> to overwrite destination app; otherwise, <code>false</code>.
-	Overwrite      *bool   `json:"overwrite,omitempty"`
+	Overwrite *bool `json:"overwrite,omitempty"`
+
+	// SourceWebAppId: ARM resource ID of the source app. App resource ID is of the form
+	// /subscriptions/{subId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{siteName} for production slots
+	// and
+	// /subscriptions/{subId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{siteName}/slots/{slotName} for
+	// other slots.
 	SourceWebAppId *string `json:"sourceWebAppId,omitempty"`
 
 	// SourceWebAppLocation: Location of source app ex: West US or North Europe
-	SourceWebAppLocation    *string `json:"sourceWebAppLocation,omitempty"`
+	SourceWebAppLocation *string `json:"sourceWebAppLocation,omitempty"`
+
+	// TrafficManagerProfileId: ARM resource ID of the Traffic Manager profile to use, if it exists. Traffic Manager resource
+	// ID is of the form
+	// /subscriptions/{subId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficManagerProfiles/{profileName}.
 	TrafficManagerProfileId *string `json:"trafficManagerProfileId,omitempty"`
 
 	// TrafficManagerProfileName: Name of Traffic Manager profile to create. This is only needed if Traffic Manager profile
@@ -476,6 +494,7 @@ type ApiDefinitionInfo struct {
 
 // Azure API management (APIM) configuration linked to the app.
 type ApiManagementConfig struct {
+	// Id: APIM-Api Identifier.
 	Id *string `json:"id,omitempty"`
 }
 
@@ -624,8 +643,10 @@ type IpSecurityRestriction struct {
 	SubnetTrafficTag *int `json:"subnetTrafficTag,omitempty"`
 
 	// Tag: Defines what this IP filter will be used for. This is to support IP filtering on proxies.
-	Tag                  *IpSecurityRestriction_Tag `json:"tag,omitempty"`
-	VnetSubnetResourceId *string                    `json:"vnetSubnetResourceId,omitempty"`
+	Tag *IpSecurityRestriction_Tag `json:"tag,omitempty"`
+
+	// VnetSubnetResourceId: Virtual network resource id
+	VnetSubnetResourceId *string `json:"vnetSubnetResourceId,omitempty"`
 
 	// VnetTrafficTag: (internal) Vnet traffic tag
 	VnetTrafficTag *int `json:"vnetTrafficTag,omitempty"`

--- a/v2/tools/generator/internal/codegen/pipeline/create_arm_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_arm_types.go
@@ -486,7 +486,9 @@ func (c *armTypeCreator) createResourceReferenceProperty(
 	newProp := astmodel.NewPropertyDefinition(
 		c.idFactory.CreatePropertyName(armPropName, astmodel.Exported),
 		c.idFactory.CreateStringIdentifier(armPropName, astmodel.NotExported),
-		newPropType).MakeTypeOptional()
+		newPropType).
+		MakeTypeOptional().
+		WithDescription(prop.Description())
 
 	return newProp, nil
 }

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestCreateFlattenedARMTypeWithResourceRef_CreatesExpectedConversions/person-v20200101-arm.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestCreateFlattenedARMTypeWithResourceRef_CreatesExpectedConversions/person-v20200101-arm.golden
@@ -34,6 +34,7 @@ type Person_STATUS struct {
 }
 
 type PersonProperties struct {
+	// FamilyName: Shared name of the family
 	FamilyName *string `json:"familyName,omitempty"`
 
 	// FullName: As would be used to address mail

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_id_resource_reference_azure_arm.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_id_resource_reference_azure_arm.golden
@@ -53,8 +53,19 @@ var fakeResource_Type_Spec_Values = map[string]FakeResource_Type_Spec{
 
 // Generated from: https://test.test/schemas/2020-01-01/test.json#/definitions/FakeResourceProperties
 type FakeResourceProperties struct {
-	Id       *string           `json:"id,omitempty"`
-	NsgIds   []string          `json:"nsgIds,omitempty"`
-	NsgMap   map[string]string `json:"nsgMap,omitempty"`
-	SubnetId *string           `json:"subnetId,omitempty"`
+	// Id: A string of the form
+	// /subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Network/virtualNetworks/{vnetName}/subnets/{subnetName}
+	Id *string `json:"id,omitempty"`
+
+	// NsgIds: A collection of NSG IDs of the form
+	// /subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Network/networkSecurityGroups/{nsgName}
+	NsgIds []string `json:"nsgIds,omitempty"`
+
+	// NsgMap: A map of NSG IDs of the form
+	// /subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Network/networkSecurityGroups/{nsgName}
+	NsgMap map[string]string `json:"nsgMap,omitempty"`
+
+	// SubnetId: A string of the form
+	// /SUBSCRIPTIONS/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Network/virtualNetworks/{vnetName}/subnets/{subnetName}
+	SubnetId *string `json:"subnetId,omitempty"`
 }

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_required_and_optional_resource_references_azure_arm.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_required_and_optional_resource_references_azure_arm.golden
@@ -53,6 +53,11 @@ var fakeResource_Type_Spec_Values = map[string]FakeResource_Type_Spec{
 
 // Generated from: https://test.test/schemas/2020-01-01/test.json#/definitions/FakeResourceProperties
 type FakeResourceProperties struct {
+	// OptionalVNet: A string of the form
+	// /subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Network/virtualNetworks/{vnetName}/subnets/{subnetName}
 	OptionalVNet *string `json:"optionalVNet,omitempty"`
+
+	// RequiredVNet: A string of the form
+	// /subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Network/virtualNetworks/{vnetName}/subnets/{subnetName}
 	RequiredVNet *string `json:"requiredVNet,omitempty"`
 }


### PR DESCRIPTION
## What this PR does

When creating reference properties on ARM types, we were inadvertently dropping the documentation comments from the field.

This PR restores those comments, which will be useful if/when we need to troubleshoot ARM payloads.

### Special notes

One commit to make the change, one to update the golden files, and one to update the generated files.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExeDJmY2hxdnZncDVvMGdjZ2s4MTFhbXN5M2g0N3ZoMjExbHN2NnJ3ZCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/BemKqR9RDK4V2/giphy.gif)
