### PR TITLE
Allow specifying `system` for Identity references in `app` resources

### DIFF
--- a/v2/api/app/v1api20240301/container_app_types_gen.go
+++ b/v2/api/app/v1api20240301/container_app_types_gen.go
@@ -6271,7 +6271,7 @@ var managedServiceIdentityType_STATUS_Values = map[string]ManagedServiceIdentity
 type RegistryCredentials struct {
 	// IdentityReference: A Managed Identity to use to authenticate with Azure Container Registry. For user-assigned
 	// identities, use the full user-assigned identity Resource ID. For system-assigned identities, use 'system'
-	IdentityReference *genruntime.ResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
+	IdentityReference *genruntime.WellknownResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
 
 	// PasswordSecretRef: The name of the Secret that contains the registry login password
 	PasswordSecretRef *string `json:"passwordSecretRef,omitempty"`
@@ -6294,11 +6294,19 @@ func (credentials *RegistryCredentials) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "Identity":
 	if credentials.IdentityReference != nil {
-		identityReferenceARMID, err := resolved.ResolvedReferences.Lookup(*credentials.IdentityReference)
-		if err != nil {
-			return nil, err
+		var identityReferenceTemp string
+		if credentials.IdentityReference.WellknownName != "" {
+			identityReferenceTemp = credentials.IdentityReference.WellknownName
+		} else {
+			armID, err := resolved.ResolvedReferences.Lookup(credentials.IdentityReference.ResourceReference)
+			if err != nil {
+				return nil, err
+			}
+
+			identityReferenceTemp = armID
 		}
-		identityReference := identityReferenceARMID
+
+		identityReference := identityReferenceTemp
 		result.Identity = &identityReference
 	}
 
@@ -6800,7 +6808,7 @@ func (scale *Scale_STATUS) AssignProperties_To_Scale_STATUS(destination *storage
 type Secret struct {
 	// IdentityReference: Resource ID of a managed identity to authenticate with Azure Key Vault, or System to use a
 	// system-assigned identity.
-	IdentityReference *genruntime.ResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
+	IdentityReference *genruntime.WellknownResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
 
 	// KeyVaultUrl: Azure Key Vault URL pointing to the secret referenced by the container app.
 	KeyVaultUrl *string `json:"keyVaultUrl,omitempty"`
@@ -6823,11 +6831,19 @@ func (secret *Secret) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 
 	// Set property "Identity":
 	if secret.IdentityReference != nil {
-		identityReferenceARMID, err := resolved.ResolvedReferences.Lookup(*secret.IdentityReference)
-		if err != nil {
-			return nil, err
+		var identityReferenceTemp string
+		if secret.IdentityReference.WellknownName != "" {
+			identityReferenceTemp = secret.IdentityReference.WellknownName
+		} else {
+			armID, err := resolved.ResolvedReferences.Lookup(secret.IdentityReference.ResourceReference)
+			if err != nil {
+				return nil, err
+			}
+
+			identityReferenceTemp = armID
 		}
-		identityReference := identityReferenceARMID
+
+		identityReference := identityReferenceTemp
 		result.Identity = &identityReference
 	}
 

--- a/v2/api/app/v1api20240301/storage/container_app_types_gen.go
+++ b/v2/api/app/v1api20240301/storage/container_app_types_gen.go
@@ -4380,11 +4380,11 @@ func (ingress *Ingress_STATUS) AssignProperties_To_Ingress_STATUS(destination *s
 type RegistryCredentials struct {
 	// IdentityReference: A Managed Identity to use to authenticate with Azure Container Registry. For user-assigned
 	// identities, use the full user-assigned identity Resource ID. For system-assigned identities, use 'system'
-	IdentityReference *genruntime.ResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
-	PasswordSecretRef *string                       `json:"passwordSecretRef,omitempty"`
-	PropertyBag       genruntime.PropertyBag        `json:"$propertyBag,omitempty"`
-	Server            *string                       `json:"server,omitempty"`
-	Username          *string                       `json:"username,omitempty"`
+	IdentityReference *genruntime.WellknownResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
+	PasswordSecretRef *string                                `json:"passwordSecretRef,omitempty"`
+	PropertyBag       genruntime.PropertyBag                 `json:"$propertyBag,omitempty"`
+	Server            *string                                `json:"server,omitempty"`
+	Username          *string                                `json:"username,omitempty"`
 }
 
 // AssignProperties_From_RegistryCredentials populates our RegistryCredentials from the provided source RegistryCredentials
@@ -4854,11 +4854,11 @@ func (scale *Scale_STATUS) AssignProperties_To_Scale_STATUS(destination *storage
 type Secret struct {
 	// IdentityReference: Resource ID of a managed identity to authenticate with Azure Key Vault, or System to use a
 	// system-assigned identity.
-	IdentityReference *genruntime.ResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
-	KeyVaultUrl       *string                       `json:"keyVaultUrl,omitempty"`
-	Name              *string                       `json:"name,omitempty"`
-	PropertyBag       genruntime.PropertyBag        `json:"$propertyBag,omitempty"`
-	Value             *genruntime.SecretReference   `json:"value,omitempty"`
+	IdentityReference *genruntime.WellknownResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
+	KeyVaultUrl       *string                                `json:"keyVaultUrl,omitempty"`
+	Name              *string                                `json:"name,omitempty"`
+	PropertyBag       genruntime.PropertyBag                 `json:"$propertyBag,omitempty"`
+	Value             *genruntime.SecretReference            `json:"value,omitempty"`
 }
 
 // AssignProperties_From_Secret populates our Secret from the provided source Secret
@@ -8677,7 +8677,7 @@ func (rule *CustomScaleRule) AssignProperties_To_CustomScaleRule(destination *st
 
 	// IdentityReference
 	if propertyBag.Contains("IdentityReference") {
-		var identityReference genruntime.ResourceReference
+		var identityReference genruntime.WellknownResourceReference
 		err := propertyBag.Pull("IdentityReference", &identityReference)
 		if err != nil {
 			return eris.Wrap(err, "pulling 'IdentityReference' from propertyBag")
@@ -8927,7 +8927,7 @@ func (rule *HttpScaleRule) AssignProperties_To_HttpScaleRule(destination *storag
 
 	// IdentityReference
 	if propertyBag.Contains("IdentityReference") {
-		var identityReference genruntime.ResourceReference
+		var identityReference genruntime.WellknownResourceReference
 		err := propertyBag.Pull("IdentityReference", &identityReference)
 		if err != nil {
 			return eris.Wrap(err, "pulling 'IdentityReference' from propertyBag")
@@ -9191,7 +9191,7 @@ func (rule *QueueScaleRule) AssignProperties_To_QueueScaleRule(destination *stor
 
 	// IdentityReference
 	if propertyBag.Contains("IdentityReference") {
-		var identityReference genruntime.ResourceReference
+		var identityReference genruntime.WellknownResourceReference
 		err := propertyBag.Pull("IdentityReference", &identityReference)
 		if err != nil {
 			return eris.Wrap(err, "pulling 'IdentityReference' from propertyBag")
@@ -9461,7 +9461,7 @@ func (rule *TcpScaleRule) AssignProperties_To_TcpScaleRule(destination *storage.
 
 	// IdentityReference
 	if propertyBag.Contains("IdentityReference") {
-		var identityReference genruntime.ResourceReference
+		var identityReference genruntime.WellknownResourceReference
 		err := propertyBag.Pull("IdentityReference", &identityReference)
 		if err != nil {
 			return eris.Wrap(err, "pulling 'IdentityReference' from propertyBag")

--- a/v2/api/app/v1api20240301/storage/job_types_gen.go
+++ b/v2/api/app/v1api20240301/storage/job_types_gen.go
@@ -2667,7 +2667,7 @@ func (rule *JobScaleRule) AssignProperties_To_JobScaleRule(destination *storage.
 
 	// IdentityReference
 	if propertyBag.Contains("IdentityReference") {
-		var identityReference genruntime.ResourceReference
+		var identityReference genruntime.WellknownResourceReference
 		err := propertyBag.Pull("IdentityReference", &identityReference)
 		if err != nil {
 			return eris.Wrap(err, "pulling 'IdentityReference' from propertyBag")

--- a/v2/api/app/v1api20240301/storage/structure.txt
+++ b/v2/api/app/v1api20240301/storage/structure.txt
@@ -402,13 +402,13 @@ ContainerApp: Resource
 │   │   ├── MaxInactiveRevisions: *int
 │   │   ├── PropertyBag: genruntime.PropertyBag
 │   │   ├── Registries: Object (5 properties)[]
-│   │   │   ├── IdentityReference: *genruntime.ResourceReference
+│   │   │   ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │   ├── PasswordSecretRef: *string
 │   │   │   ├── PropertyBag: genruntime.PropertyBag
 │   │   │   ├── Server: *string
 │   │   │   └── Username: *string
 │   │   ├── Secrets: Object (5 properties)[]
-│   │   │   ├── IdentityReference: *genruntime.ResourceReference
+│   │   │   ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │   ├── KeyVaultUrl: *string
 │   │   │   ├── Name: *string
 │   │   │   ├── PropertyBag: genruntime.PropertyBag
@@ -821,7 +821,7 @@ Job: Resource
 │   │   │   └── ReplicaCompletionCount: *int
 │   │   ├── PropertyBag: genruntime.PropertyBag
 │   │   ├── Registries: Object (5 properties)[]
-│   │   │   ├── IdentityReference: *genruntime.ResourceReference
+│   │   │   ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │   ├── PasswordSecretRef: *string
 │   │   │   ├── PropertyBag: genruntime.PropertyBag
 │   │   │   ├── Server: *string
@@ -834,7 +834,7 @@ Job: Resource
 │   │   │   ├── PropertyBag: genruntime.PropertyBag
 │   │   │   └── ReplicaCompletionCount: *int
 │   │   ├── Secrets: Object (5 properties)[]
-│   │   │   ├── IdentityReference: *genruntime.ResourceReference
+│   │   │   ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │   ├── KeyVaultUrl: *string
 │   │   │   ├── Name: *string
 │   │   │   ├── PropertyBag: genruntime.PropertyBag

--- a/v2/api/app/v1api20240301/storage/zz_generated.deepcopy.go
+++ b/v2/api/app/v1api20240301/storage/zz_generated.deepcopy.go
@@ -6793,7 +6793,7 @@ func (in *RegistryCredentials) DeepCopyInto(out *RegistryCredentials) {
 	*out = *in
 	if in.IdentityReference != nil {
 		in, out := &in.IdentityReference, &out.IdentityReference
-		*out = new(genruntime.ResourceReference)
+		*out = new(genruntime.WellknownResourceReference)
 		**out = **in
 	}
 	if in.PasswordSecretRef != nil {
@@ -7113,7 +7113,7 @@ func (in *Secret) DeepCopyInto(out *Secret) {
 	*out = *in
 	if in.IdentityReference != nil {
 		in, out := &in.IdentityReference, &out.IdentityReference
-		*out = new(genruntime.ResourceReference)
+		*out = new(genruntime.WellknownResourceReference)
 		**out = **in
 	}
 	if in.KeyVaultUrl != nil {

--- a/v2/api/app/v1api20240301/structure.txt
+++ b/v2/api/app/v1api20240301/structure.txt
@@ -353,12 +353,12 @@ ContainerApp: Resource
 │   │   │       └── "tcp"
 │   │   ├── MaxInactiveRevisions: *int
 │   │   ├── Registries: Object (4 properties)[]
-│   │   │   ├── IdentityReference: *genruntime.ResourceReference
+│   │   │   ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │   ├── PasswordSecretRef: *string
 │   │   │   ├── Server: *string
 │   │   │   └── Username: *string
 │   │   ├── Secrets: Object (4 properties)[]
-│   │   │   ├── IdentityReference: *genruntime.ResourceReference
+│   │   │   ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │   ├── KeyVaultUrl: *string
 │   │   │   ├── Name: *string
 │   │   │   └── Value: *genruntime.SecretReference
@@ -748,7 +748,7 @@ Job: Resource
 │   │   │   ├── Parallelism: *int
 │   │   │   └── ReplicaCompletionCount: *int
 │   │   ├── Registries: Object (4 properties)[]
-│   │   │   ├── IdentityReference: *genruntime.ResourceReference
+│   │   │   ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │   ├── PasswordSecretRef: *string
 │   │   │   ├── Server: *string
 │   │   │   └── Username: *string
@@ -759,7 +759,7 @@ Job: Resource
 │   │   │   ├── Parallelism: *int
 │   │   │   └── ReplicaCompletionCount: *int
 │   │   ├── Secrets: Object (4 properties)[]
-│   │   │   ├── IdentityReference: *genruntime.ResourceReference
+│   │   │   ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │   ├── KeyVaultUrl: *string
 │   │   │   ├── Name: *string
 │   │   │   └── Value: *genruntime.SecretReference

--- a/v2/api/app/v1api20240301/zz_generated.deepcopy.go
+++ b/v2/api/app/v1api20240301/zz_generated.deepcopy.go
@@ -5706,7 +5706,7 @@ func (in *RegistryCredentials) DeepCopyInto(out *RegistryCredentials) {
 	*out = *in
 	if in.IdentityReference != nil {
 		in, out := &in.IdentityReference, &out.IdentityReference
-		*out = new(genruntime.ResourceReference)
+		*out = new(genruntime.WellknownResourceReference)
 		**out = **in
 	}
 	if in.PasswordSecretRef != nil {
@@ -5970,7 +5970,7 @@ func (in *Secret) DeepCopyInto(out *Secret) {
 	*out = *in
 	if in.IdentityReference != nil {
 		in, out := &in.IdentityReference, &out.IdentityReference
-		*out = new(genruntime.ResourceReference)
+		*out = new(genruntime.WellknownResourceReference)
 		**out = **in
 	}
 	if in.KeyVaultUrl != nil {

--- a/v2/api/app/v1api20250101/container_app_types_gen.go
+++ b/v2/api/app/v1api20250101/container_app_types_gen.go
@@ -5992,7 +5992,7 @@ type IdentitySettings struct {
 	// +kubebuilder:validation:Required
 	// IdentityReference: The resource ID of a user-assigned managed identity that is assigned to the Container App, or
 	// 'system' for system-assigned identity.
-	IdentityReference *genruntime.ResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
+	IdentityReference *genruntime.WellknownResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
 
 	// Lifecycle: Use to select the lifecycle stages of a Container App during which the Managed Identity should be available.
 	Lifecycle *IdentitySettings_Lifecycle `json:"lifecycle,omitempty"`
@@ -6009,11 +6009,19 @@ func (settings *IdentitySettings) ConvertToARM(resolved genruntime.ConvertToARMR
 
 	// Set property "Identity":
 	if settings.IdentityReference != nil {
-		identityReferenceARMID, err := resolved.ResolvedReferences.Lookup(*settings.IdentityReference)
-		if err != nil {
-			return nil, err
+		var identityReferenceTemp string
+		if settings.IdentityReference.WellknownName != "" {
+			identityReferenceTemp = settings.IdentityReference.WellknownName
+		} else {
+			armID, err := resolved.ResolvedReferences.Lookup(settings.IdentityReference.ResourceReference)
+			if err != nil {
+				return nil, err
+			}
+
+			identityReferenceTemp = armID
 		}
-		identityReference := identityReferenceARMID
+
+		identityReference := identityReferenceTemp
 		result.Identity = &identityReference
 	}
 
@@ -7424,7 +7432,7 @@ var managedServiceIdentityType_STATUS_Values = map[string]ManagedServiceIdentity
 type RegistryCredentials struct {
 	// IdentityReference: A Managed Identity to use to authenticate with Azure Container Registry. For user-assigned
 	// identities, use the full user-assigned identity Resource ID. For system-assigned identities, use 'system'
-	IdentityReference *genruntime.ResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
+	IdentityReference *genruntime.WellknownResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
 
 	// PasswordSecretRef: The name of the Secret that contains the registry login password
 	PasswordSecretRef *string `json:"passwordSecretRef,omitempty"`
@@ -7447,11 +7455,19 @@ func (credentials *RegistryCredentials) ConvertToARM(resolved genruntime.Convert
 
 	// Set property "Identity":
 	if credentials.IdentityReference != nil {
-		identityReferenceARMID, err := resolved.ResolvedReferences.Lookup(*credentials.IdentityReference)
-		if err != nil {
-			return nil, err
+		var identityReferenceTemp string
+		if credentials.IdentityReference.WellknownName != "" {
+			identityReferenceTemp = credentials.IdentityReference.WellknownName
+		} else {
+			armID, err := resolved.ResolvedReferences.Lookup(credentials.IdentityReference.ResourceReference)
+			if err != nil {
+				return nil, err
+			}
+
+			identityReferenceTemp = armID
 		}
-		identityReference := identityReferenceARMID
+
+		identityReference := identityReferenceTemp
 		result.Identity = &identityReference
 	}
 
@@ -8280,7 +8296,7 @@ func (scale *Scale_STATUS) AssignProperties_To_Scale_STATUS(destination *storage
 type Secret struct {
 	// IdentityReference: Resource ID of a managed identity to authenticate with Azure Key Vault, or System to use a
 	// system-assigned identity.
-	IdentityReference *genruntime.ResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
+	IdentityReference *genruntime.WellknownResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
 
 	// KeyVaultUrl: Azure Key Vault URL pointing to the secret referenced by the container app.
 	KeyVaultUrl *string `json:"keyVaultUrl,omitempty"`
@@ -8303,11 +8319,19 @@ func (secret *Secret) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 
 	// Set property "Identity":
 	if secret.IdentityReference != nil {
-		identityReferenceARMID, err := resolved.ResolvedReferences.Lookup(*secret.IdentityReference)
-		if err != nil {
-			return nil, err
+		var identityReferenceTemp string
+		if secret.IdentityReference.WellknownName != "" {
+			identityReferenceTemp = secret.IdentityReference.WellknownName
+		} else {
+			armID, err := resolved.ResolvedReferences.Lookup(secret.IdentityReference.ResourceReference)
+			if err != nil {
+				return nil, err
+			}
+
+			identityReferenceTemp = armID
 		}
-		identityReference := identityReferenceARMID
+
+		identityReference := identityReferenceTemp
 		result.Identity = &identityReference
 	}
 
@@ -14075,7 +14099,7 @@ type CustomScaleRule struct {
 
 	// IdentityReference: The resource ID of a user-assigned managed identity that is assigned to the Container App, or
 	// 'system' for system-assigned identity.
-	IdentityReference *genruntime.ResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
+	IdentityReference *genruntime.WellknownResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
 
 	// Metadata: Metadata properties to describe custom scale rule.
 	Metadata map[string]string `json:"metadata,omitempty"`
@@ -14105,11 +14129,19 @@ func (rule *CustomScaleRule) ConvertToARM(resolved genruntime.ConvertToARMResolv
 
 	// Set property "Identity":
 	if rule.IdentityReference != nil {
-		identityReferenceARMID, err := resolved.ResolvedReferences.Lookup(*rule.IdentityReference)
-		if err != nil {
-			return nil, err
+		var identityReferenceTemp string
+		if rule.IdentityReference.WellknownName != "" {
+			identityReferenceTemp = rule.IdentityReference.WellknownName
+		} else {
+			armID, err := resolved.ResolvedReferences.Lookup(rule.IdentityReference.ResourceReference)
+			if err != nil {
+				return nil, err
+			}
+
+			identityReferenceTemp = armID
 		}
-		identityReference := identityReferenceARMID
+
+		identityReference := identityReferenceTemp
 		result.Identity = &identityReference
 	}
 
@@ -14438,7 +14470,7 @@ type HttpScaleRule struct {
 
 	// IdentityReference: The resource ID of a user-assigned managed identity that is assigned to the Container App, or
 	// 'system' for system-assigned identity.
-	IdentityReference *genruntime.ResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
+	IdentityReference *genruntime.WellknownResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
 
 	// Metadata: Metadata properties to describe http scale rule.
 	Metadata map[string]string `json:"metadata,omitempty"`
@@ -14464,11 +14496,19 @@ func (rule *HttpScaleRule) ConvertToARM(resolved genruntime.ConvertToARMResolved
 
 	// Set property "Identity":
 	if rule.IdentityReference != nil {
-		identityReferenceARMID, err := resolved.ResolvedReferences.Lookup(*rule.IdentityReference)
-		if err != nil {
-			return nil, err
+		var identityReferenceTemp string
+		if rule.IdentityReference.WellknownName != "" {
+			identityReferenceTemp = rule.IdentityReference.WellknownName
+		} else {
+			armID, err := resolved.ResolvedReferences.Lookup(rule.IdentityReference.ResourceReference)
+			if err != nil {
+				return nil, err
+			}
+
+			identityReferenceTemp = armID
 		}
-		identityReference := identityReferenceARMID
+
+		identityReference := identityReferenceTemp
 		result.Identity = &identityReference
 	}
 
@@ -14817,7 +14857,7 @@ type QueueScaleRule struct {
 
 	// IdentityReference: The resource ID of a user-assigned managed identity that is assigned to the Container App, or
 	// 'system' for system-assigned identity.
-	IdentityReference *genruntime.ResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
+	IdentityReference *genruntime.WellknownResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
 
 	// QueueLength: Queue length.
 	QueueLength *int `json:"queueLength,omitempty"`
@@ -14852,11 +14892,19 @@ func (rule *QueueScaleRule) ConvertToARM(resolved genruntime.ConvertToARMResolve
 
 	// Set property "Identity":
 	if rule.IdentityReference != nil {
-		identityReferenceARMID, err := resolved.ResolvedReferences.Lookup(*rule.IdentityReference)
-		if err != nil {
-			return nil, err
+		var identityReferenceTemp string
+		if rule.IdentityReference.WellknownName != "" {
+			identityReferenceTemp = rule.IdentityReference.WellknownName
+		} else {
+			armID, err := resolved.ResolvedReferences.Lookup(rule.IdentityReference.ResourceReference)
+			if err != nil {
+				return nil, err
+			}
+
+			identityReferenceTemp = armID
 		}
-		identityReference := identityReferenceARMID
+
+		identityReference := identityReferenceTemp
 		result.Identity = &identityReference
 	}
 
@@ -15208,7 +15256,7 @@ type TcpScaleRule struct {
 
 	// IdentityReference: The resource ID of a user-assigned managed identity that is assigned to the Container App, or
 	// 'system' for system-assigned identity.
-	IdentityReference *genruntime.ResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
+	IdentityReference *genruntime.WellknownResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
 
 	// Metadata: Metadata properties to describe tcp scale rule.
 	Metadata map[string]string `json:"metadata,omitempty"`
@@ -15234,11 +15282,19 @@ func (rule *TcpScaleRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "Identity":
 	if rule.IdentityReference != nil {
-		identityReferenceARMID, err := resolved.ResolvedReferences.Lookup(*rule.IdentityReference)
-		if err != nil {
-			return nil, err
+		var identityReferenceTemp string
+		if rule.IdentityReference.WellknownName != "" {
+			identityReferenceTemp = rule.IdentityReference.WellknownName
+		} else {
+			armID, err := resolved.ResolvedReferences.Lookup(rule.IdentityReference.ResourceReference)
+			if err != nil {
+				return nil, err
+			}
+
+			identityReferenceTemp = armID
 		}
-		identityReference := identityReferenceARMID
+
+		identityReference := identityReferenceTemp
 		result.Identity = &identityReference
 	}
 

--- a/v2/api/app/v1api20250101/job_types_gen.go
+++ b/v2/api/app/v1api20250101/job_types_gen.go
@@ -3763,7 +3763,7 @@ type JobScaleRule struct {
 
 	// IdentityReference: The resource ID of a user-assigned managed identity that is assigned to the Container App, or
 	// 'system' for system-assigned identity.
-	IdentityReference *genruntime.ResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
+	IdentityReference *genruntime.WellknownResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
 
 	// Metadata: Metadata properties to describe the scale rule.
 	Metadata map[string]v1.JSON `json:"metadata,omitempty"`
@@ -3796,11 +3796,19 @@ func (rule *JobScaleRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 
 	// Set property "Identity":
 	if rule.IdentityReference != nil {
-		identityReferenceARMID, err := resolved.ResolvedReferences.Lookup(*rule.IdentityReference)
-		if err != nil {
-			return nil, err
+		var identityReferenceTemp string
+		if rule.IdentityReference.WellknownName != "" {
+			identityReferenceTemp = rule.IdentityReference.WellknownName
+		} else {
+			armID, err := resolved.ResolvedReferences.Lookup(rule.IdentityReference.ResourceReference)
+			if err != nil {
+				return nil, err
+			}
+
+			identityReferenceTemp = armID
 		}
-		identityReference := identityReferenceARMID
+
+		identityReference := identityReferenceTemp
 		result.Identity = &identityReference
 	}
 

--- a/v2/api/app/v1api20250101/managed_environment_types_gen.go
+++ b/v2/api/app/v1api20250101/managed_environment_types_gen.go
@@ -3740,7 +3740,7 @@ func (profile *WorkloadProfile_STATUS) AssignProperties_To_WorkloadProfile_STATU
 type CertificateKeyVaultProperties struct {
 	// IdentityReference: Resource ID of a managed identity to authenticate with Azure Key Vault, or System to use a
 	// system-assigned identity.
-	IdentityReference *genruntime.ResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
+	IdentityReference *genruntime.WellknownResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
 
 	// +kubebuilder:validation:Pattern="^[a-zA-Z][a-zA-Z0-9+-.]*:[^\\s]*$"
 	// KeyVaultUrl: URL pointing to the Azure Key Vault secret that holds the certificate.
@@ -3758,11 +3758,19 @@ func (properties *CertificateKeyVaultProperties) ConvertToARM(resolved genruntim
 
 	// Set property "Identity":
 	if properties.IdentityReference != nil {
-		identityReferenceARMID, err := resolved.ResolvedReferences.Lookup(*properties.IdentityReference)
-		if err != nil {
-			return nil, err
+		var identityReferenceTemp string
+		if properties.IdentityReference.WellknownName != "" {
+			identityReferenceTemp = properties.IdentityReference.WellknownName
+		} else {
+			armID, err := resolved.ResolvedReferences.Lookup(properties.IdentityReference.ResourceReference)
+			if err != nil {
+				return nil, err
+			}
+
+			identityReferenceTemp = armID
 		}
-		identityReference := identityReferenceARMID
+
+		identityReference := identityReferenceTemp
 		result.Identity = &identityReference
 	}
 

--- a/v2/api/app/v1api20250101/storage/container_app_types_gen.go
+++ b/v2/api/app/v1api20250101/storage/container_app_types_gen.go
@@ -495,9 +495,9 @@ type IdentitySettings struct {
 	// +kubebuilder:validation:Required
 	// IdentityReference: The resource ID of a user-assigned managed identity that is assigned to the Container App, or
 	// 'system' for system-assigned identity.
-	IdentityReference *genruntime.ResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
-	Lifecycle         *string                       `json:"lifecycle,omitempty"`
-	PropertyBag       genruntime.PropertyBag        `json:"$propertyBag,omitempty"`
+	IdentityReference *genruntime.WellknownResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
+	Lifecycle         *string                                `json:"lifecycle,omitempty"`
+	PropertyBag       genruntime.PropertyBag                 `json:"$propertyBag,omitempty"`
 }
 
 // Storage version of v1api20250101.IdentitySettings_STATUS
@@ -550,11 +550,11 @@ type Ingress_STATUS struct {
 type RegistryCredentials struct {
 	// IdentityReference: A Managed Identity to use to authenticate with Azure Container Registry. For user-assigned
 	// identities, use the full user-assigned identity Resource ID. For system-assigned identities, use 'system'
-	IdentityReference *genruntime.ResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
-	PasswordSecretRef *string                       `json:"passwordSecretRef,omitempty"`
-	PropertyBag       genruntime.PropertyBag        `json:"$propertyBag,omitempty"`
-	Server            *string                       `json:"server,omitempty"`
-	Username          *string                       `json:"username,omitempty"`
+	IdentityReference *genruntime.WellknownResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
+	PasswordSecretRef *string                                `json:"passwordSecretRef,omitempty"`
+	PropertyBag       genruntime.PropertyBag                 `json:"$propertyBag,omitempty"`
+	Server            *string                                `json:"server,omitempty"`
+	Username          *string                                `json:"username,omitempty"`
 }
 
 // Storage version of v1api20250101.RegistryCredentials_STATUS
@@ -608,11 +608,11 @@ type Scale_STATUS struct {
 type Secret struct {
 	// IdentityReference: Resource ID of a managed identity to authenticate with Azure Key Vault, or System to use a
 	// system-assigned identity.
-	IdentityReference *genruntime.ResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
-	KeyVaultUrl       *string                       `json:"keyVaultUrl,omitempty"`
-	Name              *string                       `json:"name,omitempty"`
-	PropertyBag       genruntime.PropertyBag        `json:"$propertyBag,omitempty"`
-	Value             *genruntime.SecretReference   `json:"value,omitempty"`
+	IdentityReference *genruntime.WellknownResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
+	KeyVaultUrl       *string                                `json:"keyVaultUrl,omitempty"`
+	Name              *string                                `json:"name,omitempty"`
+	PropertyBag       genruntime.PropertyBag                 `json:"$propertyBag,omitempty"`
+	Value             *genruntime.SecretReference            `json:"value,omitempty"`
 }
 
 // Storage version of v1api20250101.Secret_STATUS
@@ -983,10 +983,10 @@ type CustomScaleRule struct {
 
 	// IdentityReference: The resource ID of a user-assigned managed identity that is assigned to the Container App, or
 	// 'system' for system-assigned identity.
-	IdentityReference *genruntime.ResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
-	Metadata          map[string]string             `json:"metadata,omitempty"`
-	PropertyBag       genruntime.PropertyBag        `json:"$propertyBag,omitempty"`
-	Type              *string                       `json:"type,omitempty"`
+	IdentityReference *genruntime.WellknownResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
+	Metadata          map[string]string                      `json:"metadata,omitempty"`
+	PropertyBag       genruntime.PropertyBag                 `json:"$propertyBag,omitempty"`
+	Type              *string                                `json:"type,omitempty"`
 }
 
 // Storage version of v1api20250101.CustomScaleRule_STATUS
@@ -1006,9 +1006,9 @@ type HttpScaleRule struct {
 
 	// IdentityReference: The resource ID of a user-assigned managed identity that is assigned to the Container App, or
 	// 'system' for system-assigned identity.
-	IdentityReference *genruntime.ResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
-	Metadata          map[string]string             `json:"metadata,omitempty"`
-	PropertyBag       genruntime.PropertyBag        `json:"$propertyBag,omitempty"`
+	IdentityReference *genruntime.WellknownResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
+	Metadata          map[string]string                      `json:"metadata,omitempty"`
+	PropertyBag       genruntime.PropertyBag                 `json:"$propertyBag,omitempty"`
 }
 
 // Storage version of v1api20250101.HttpScaleRule_STATUS
@@ -1028,10 +1028,10 @@ type QueueScaleRule struct {
 
 	// IdentityReference: The resource ID of a user-assigned managed identity that is assigned to the Container App, or
 	// 'system' for system-assigned identity.
-	IdentityReference *genruntime.ResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
-	PropertyBag       genruntime.PropertyBag        `json:"$propertyBag,omitempty"`
-	QueueLength       *int                          `json:"queueLength,omitempty"`
-	QueueName         *string                       `json:"queueName,omitempty"`
+	IdentityReference *genruntime.WellknownResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
+	PropertyBag       genruntime.PropertyBag                 `json:"$propertyBag,omitempty"`
+	QueueLength       *int                                   `json:"queueLength,omitempty"`
+	QueueName         *string                                `json:"queueName,omitempty"`
 }
 
 // Storage version of v1api20250101.QueueScaleRule_STATUS
@@ -1052,9 +1052,9 @@ type TcpScaleRule struct {
 
 	// IdentityReference: The resource ID of a user-assigned managed identity that is assigned to the Container App, or
 	// 'system' for system-assigned identity.
-	IdentityReference *genruntime.ResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
-	Metadata          map[string]string             `json:"metadata,omitempty"`
-	PropertyBag       genruntime.PropertyBag        `json:"$propertyBag,omitempty"`
+	IdentityReference *genruntime.WellknownResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
+	Metadata          map[string]string                      `json:"metadata,omitempty"`
+	PropertyBag       genruntime.PropertyBag                 `json:"$propertyBag,omitempty"`
 }
 
 // Storage version of v1api20250101.TcpScaleRule_STATUS

--- a/v2/api/app/v1api20250101/storage/job_types_gen.go
+++ b/v2/api/app/v1api20250101/storage/job_types_gen.go
@@ -382,11 +382,11 @@ type JobScaleRule struct {
 
 	// IdentityReference: The resource ID of a user-assigned managed identity that is assigned to the Container App, or
 	// 'system' for system-assigned identity.
-	IdentityReference *genruntime.ResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
-	Metadata          map[string]v1.JSON            `json:"metadata,omitempty"`
-	Name              *string                       `json:"name,omitempty"`
-	PropertyBag       genruntime.PropertyBag        `json:"$propertyBag,omitempty"`
-	Type              *string                       `json:"type,omitempty"`
+	IdentityReference *genruntime.WellknownResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
+	Metadata          map[string]v1.JSON                     `json:"metadata,omitempty"`
+	Name              *string                                `json:"name,omitempty"`
+	PropertyBag       genruntime.PropertyBag                 `json:"$propertyBag,omitempty"`
+	Type              *string                                `json:"type,omitempty"`
 }
 
 // Storage version of v1api20250101.JobScaleRule_STATUS

--- a/v2/api/app/v1api20250101/storage/managed_environment_types_gen.go
+++ b/v2/api/app/v1api20250101/storage/managed_environment_types_gen.go
@@ -401,9 +401,9 @@ type WorkloadProfile_STATUS struct {
 type CertificateKeyVaultProperties struct {
 	// IdentityReference: Resource ID of a managed identity to authenticate with Azure Key Vault, or System to use a
 	// system-assigned identity.
-	IdentityReference *genruntime.ResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
-	KeyVaultUrl       *string                       `json:"keyVaultUrl,omitempty"`
-	PropertyBag       genruntime.PropertyBag        `json:"$propertyBag,omitempty"`
+	IdentityReference *genruntime.WellknownResourceReference `armReference:"Identity" json:"identityReference,omitempty"`
+	KeyVaultUrl       *string                                `json:"keyVaultUrl,omitempty"`
+	PropertyBag       genruntime.PropertyBag                 `json:"$propertyBag,omitempty"`
 }
 
 // Storage version of v1api20250101.CertificateKeyVaultProperties_STATUS

--- a/v2/api/app/v1api20250101/storage/structure.txt
+++ b/v2/api/app/v1api20250101/storage/structure.txt
@@ -359,7 +359,7 @@ ContainerApp: Resource
 │   │   │   ├── LogLevel: *string
 │   │   │   └── PropertyBag: genruntime.PropertyBag
 │   │   ├── IdentitySettings: Object (3 properties)[]
-│   │   │   ├── IdentityReference: *genruntime.ResourceReference
+│   │   │   ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │   ├── Lifecycle: *string
 │   │   │   └── PropertyBag: genruntime.PropertyBag
 │   │   ├── Ingress: *Object (13 properties)
@@ -406,7 +406,7 @@ ContainerApp: Resource
 │   │   ├── MaxInactiveRevisions: *int
 │   │   ├── PropertyBag: genruntime.PropertyBag
 │   │   ├── Registries: Object (5 properties)[]
-│   │   │   ├── IdentityReference: *genruntime.ResourceReference
+│   │   │   ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │   ├── PasswordSecretRef: *string
 │   │   │   ├── PropertyBag: genruntime.PropertyBag
 │   │   │   ├── Server: *string
@@ -417,7 +417,7 @@ ContainerApp: Resource
 │   │   │   │   └── PropertyBag: genruntime.PropertyBag
 │   │   │   └── PropertyBag: genruntime.PropertyBag
 │   │   ├── Secrets: Object (5 properties)[]
-│   │   │   ├── IdentityReference: *genruntime.ResourceReference
+│   │   │   ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │   ├── KeyVaultUrl: *string
 │   │   │   ├── Name: *string
 │   │   │   ├── PropertyBag: genruntime.PropertyBag
@@ -530,7 +530,7 @@ ContainerApp: Resource
 │   │   │       │   │   ├── PropertyBag: genruntime.PropertyBag
 │   │   │       │   │   ├── SecretRef: *string
 │   │   │       │   │   └── TriggerParameter: *string
-│   │   │       │   ├── IdentityReference: *genruntime.ResourceReference
+│   │   │       │   ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │       │   ├── PropertyBag: genruntime.PropertyBag
 │   │   │       │   ├── QueueLength: *int
 │   │   │       │   └── QueueName: *string
@@ -539,7 +539,7 @@ ContainerApp: Resource
 │   │   │       │   │   ├── PropertyBag: genruntime.PropertyBag
 │   │   │       │   │   ├── SecretRef: *string
 │   │   │       │   │   └── TriggerParameter: *string
-│   │   │       │   ├── IdentityReference: *genruntime.ResourceReference
+│   │   │       │   ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │       │   ├── Metadata: map[string]string
 │   │   │       │   ├── PropertyBag: genruntime.PropertyBag
 │   │   │       │   └── Type: *string
@@ -548,7 +548,7 @@ ContainerApp: Resource
 │   │   │       │   │   ├── PropertyBag: genruntime.PropertyBag
 │   │   │       │   │   ├── SecretRef: *string
 │   │   │       │   │   └── TriggerParameter: *string
-│   │   │       │   ├── IdentityReference: *genruntime.ResourceReference
+│   │   │       │   ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │       │   ├── Metadata: map[string]string
 │   │   │       │   └── PropertyBag: genruntime.PropertyBag
 │   │   │       ├── Name: *string
@@ -558,7 +558,7 @@ ContainerApp: Resource
 │   │   │           │   ├── PropertyBag: genruntime.PropertyBag
 │   │   │           │   ├── SecretRef: *string
 │   │   │           │   └── TriggerParameter: *string
-│   │   │           ├── IdentityReference: *genruntime.ResourceReference
+│   │   │           ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │           ├── Metadata: map[string]string
 │   │   │           └── PropertyBag: genruntime.PropertyBag
 │   │   ├── ServiceBinds: Object (3 properties)[]
@@ -844,13 +844,13 @@ Job: Resource
 │   │   │           │   ├── PropertyBag: genruntime.PropertyBag
 │   │   │           │   ├── SecretRef: *string
 │   │   │           │   └── TriggerParameter: *string
-│   │   │           ├── IdentityReference: *genruntime.ResourceReference
+│   │   │           ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │           ├── Metadata: map[string]v1.JSON
 │   │   │           ├── Name: *string
 │   │   │           ├── PropertyBag: genruntime.PropertyBag
 │   │   │           └── Type: *string
 │   │   ├── IdentitySettings: Object (3 properties)[]
-│   │   │   ├── IdentityReference: *genruntime.ResourceReference
+│   │   │   ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │   ├── Lifecycle: *string
 │   │   │   └── PropertyBag: genruntime.PropertyBag
 │   │   ├── ManualTriggerConfig: *Object (3 properties)
@@ -859,7 +859,7 @@ Job: Resource
 │   │   │   └── ReplicaCompletionCount: *int
 │   │   ├── PropertyBag: genruntime.PropertyBag
 │   │   ├── Registries: Object (5 properties)[]
-│   │   │   ├── IdentityReference: *genruntime.ResourceReference
+│   │   │   ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │   ├── PasswordSecretRef: *string
 │   │   │   ├── PropertyBag: genruntime.PropertyBag
 │   │   │   ├── Server: *string
@@ -872,7 +872,7 @@ Job: Resource
 │   │   │   ├── PropertyBag: genruntime.PropertyBag
 │   │   │   └── ReplicaCompletionCount: *int
 │   │   ├── Secrets: Object (5 properties)[]
-│   │   │   ├── IdentityReference: *genruntime.ResourceReference
+│   │   │   ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │   ├── KeyVaultUrl: *string
 │   │   │   ├── Name: *string
 │   │   │   ├── PropertyBag: genruntime.PropertyBag
@@ -1139,7 +1139,7 @@ ManagedEnvironment: Resource
 │   ├── AzureName: string
 │   ├── CustomDomainConfiguration: *Object (5 properties)
 │   │   ├── CertificateKeyVaultProperties: *Object (3 properties)
-│   │   │   ├── IdentityReference: *genruntime.ResourceReference
+│   │   │   ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │   ├── KeyVaultUrl: *string
 │   │   │   └── PropertyBag: genruntime.PropertyBag
 │   │   ├── CertificatePassword: *genruntime.SecretReference

--- a/v2/api/app/v1api20250101/storage/zz_generated.deepcopy.go
+++ b/v2/api/app/v1api20250101/storage/zz_generated.deepcopy.go
@@ -1344,7 +1344,7 @@ func (in *CertificateKeyVaultProperties) DeepCopyInto(out *CertificateKeyVaultPr
 	*out = *in
 	if in.IdentityReference != nil {
 		in, out := &in.IdentityReference, &out.IdentityReference
-		*out = new(genruntime.ResourceReference)
+		*out = new(genruntime.WellknownResourceReference)
 		**out = **in
 	}
 	if in.KeyVaultUrl != nil {
@@ -2965,7 +2965,7 @@ func (in *CustomScaleRule) DeepCopyInto(out *CustomScaleRule) {
 	}
 	if in.IdentityReference != nil {
 		in, out := &in.IdentityReference, &out.IdentityReference
-		*out = new(genruntime.ResourceReference)
+		*out = new(genruntime.WellknownResourceReference)
 		**out = **in
 	}
 	if in.Metadata != nil {
@@ -3864,7 +3864,7 @@ func (in *HttpScaleRule) DeepCopyInto(out *HttpScaleRule) {
 	}
 	if in.IdentityReference != nil {
 		in, out := &in.IdentityReference, &out.IdentityReference
-		*out = new(genruntime.ResourceReference)
+		*out = new(genruntime.WellknownResourceReference)
 		**out = **in
 	}
 	if in.Metadata != nil {
@@ -4195,7 +4195,7 @@ func (in *IdentitySettings) DeepCopyInto(out *IdentitySettings) {
 	*out = *in
 	if in.IdentityReference != nil {
 		in, out := &in.IdentityReference, &out.IdentityReference
-		*out = new(genruntime.ResourceReference)
+		*out = new(genruntime.WellknownResourceReference)
 		**out = **in
 	}
 	if in.Lifecycle != nil {
@@ -5168,7 +5168,7 @@ func (in *JobScaleRule) DeepCopyInto(out *JobScaleRule) {
 	}
 	if in.IdentityReference != nil {
 		in, out := &in.IdentityReference, &out.IdentityReference
-		*out = new(genruntime.ResourceReference)
+		*out = new(genruntime.WellknownResourceReference)
 		**out = **in
 	}
 	if in.Metadata != nil {
@@ -6948,7 +6948,7 @@ func (in *QueueScaleRule) DeepCopyInto(out *QueueScaleRule) {
 	}
 	if in.IdentityReference != nil {
 		in, out := &in.IdentityReference, &out.IdentityReference
-		*out = new(genruntime.ResourceReference)
+		*out = new(genruntime.WellknownResourceReference)
 		**out = **in
 	}
 	if in.PropertyBag != nil {
@@ -7034,7 +7034,7 @@ func (in *RegistryCredentials) DeepCopyInto(out *RegistryCredentials) {
 	*out = *in
 	if in.IdentityReference != nil {
 		in, out := &in.IdentityReference, &out.IdentityReference
-		*out = new(genruntime.ResourceReference)
+		*out = new(genruntime.WellknownResourceReference)
 		**out = **in
 	}
 	if in.PasswordSecretRef != nil {
@@ -7482,7 +7482,7 @@ func (in *Secret) DeepCopyInto(out *Secret) {
 	*out = *in
 	if in.IdentityReference != nil {
 		in, out := &in.IdentityReference, &out.IdentityReference
-		*out = new(genruntime.ResourceReference)
+		*out = new(genruntime.WellknownResourceReference)
 		**out = **in
 	}
 	if in.KeyVaultUrl != nil {
@@ -7802,7 +7802,7 @@ func (in *TcpScaleRule) DeepCopyInto(out *TcpScaleRule) {
 	}
 	if in.IdentityReference != nil {
 		in, out := &in.IdentityReference, &out.IdentityReference
-		*out = new(genruntime.ResourceReference)
+		*out = new(genruntime.WellknownResourceReference)
 		**out = **in
 	}
 	if in.Metadata != nil {

--- a/v2/api/app/v1api20250101/structure.txt
+++ b/v2/api/app/v1api20250101/structure.txt
@@ -305,7 +305,7 @@ ContainerApp: Resource
 │   │   │       ├── "info"
 │   │   │       └── "warn"
 │   │   ├── IdentitySettings: Object (2 properties)[]
-│   │   │   ├── IdentityReference: *genruntime.ResourceReference
+│   │   │   ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │   └── Lifecycle: *Enum (4 values)
 │   │   │       ├── "All"
 │   │   │       ├── "Init"
@@ -360,7 +360,7 @@ ContainerApp: Resource
 │   │   │       └── "tcp"
 │   │   ├── MaxInactiveRevisions: *int
 │   │   ├── Registries: Object (4 properties)[]
-│   │   │   ├── IdentityReference: *genruntime.ResourceReference
+│   │   │   ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │   ├── PasswordSecretRef: *string
 │   │   │   ├── Server: *string
 │   │   │   └── Username: *string
@@ -368,7 +368,7 @@ ContainerApp: Resource
 │   │   │   └── Java: *Object (1 property)
 │   │   │       └── EnableMetrics: *bool
 │   │   ├── Secrets: Object (4 properties)[]
-│   │   │   ├── IdentityReference: *genruntime.ResourceReference
+│   │   │   ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │   ├── KeyVaultUrl: *string
 │   │   │   ├── Name: *string
 │   │   │   └── Value: *genruntime.SecretReference
@@ -467,28 +467,28 @@ ContainerApp: Resource
 │   │   │       │   ├── Auth: Object (2 properties)[]
 │   │   │       │   │   ├── SecretRef: *string
 │   │   │       │   │   └── TriggerParameter: *string
-│   │   │       │   ├── IdentityReference: *genruntime.ResourceReference
+│   │   │       │   ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │       │   ├── QueueLength: *int
 │   │   │       │   └── QueueName: *string
 │   │   │       ├── Custom: *Object (4 properties)
 │   │   │       │   ├── Auth: Object (2 properties)[]
 │   │   │       │   │   ├── SecretRef: *string
 │   │   │       │   │   └── TriggerParameter: *string
-│   │   │       │   ├── IdentityReference: *genruntime.ResourceReference
+│   │   │       │   ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │       │   ├── Metadata: map[string]string
 │   │   │       │   └── Type: *string
 │   │   │       ├── Http: *Object (3 properties)
 │   │   │       │   ├── Auth: Object (2 properties)[]
 │   │   │       │   │   ├── SecretRef: *string
 │   │   │       │   │   └── TriggerParameter: *string
-│   │   │       │   ├── IdentityReference: *genruntime.ResourceReference
+│   │   │       │   ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │       │   └── Metadata: map[string]string
 │   │   │       ├── Name: *string
 │   │   │       └── Tcp: *Object (3 properties)
 │   │   │           ├── Auth: Object (2 properties)[]
 │   │   │           │   ├── SecretRef: *string
 │   │   │           │   └── TriggerParameter: *string
-│   │   │           ├── IdentityReference: *genruntime.ResourceReference
+│   │   │           ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │           └── Metadata: map[string]string
 │   │   ├── ServiceBinds: Object (2 properties)[]
 │   │   │   ├── Name: *string
@@ -783,12 +783,12 @@ Job: Resource
 │   │   │           ├── Auth: Object (2 properties)[]
 │   │   │           │   ├── SecretRef: *string
 │   │   │           │   └── TriggerParameter: *string
-│   │   │           ├── IdentityReference: *genruntime.ResourceReference
+│   │   │           ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │           ├── Metadata: map[string]v1.JSON
 │   │   │           ├── Name: *string
 │   │   │           └── Type: *string
 │   │   ├── IdentitySettings: Object (2 properties)[]
-│   │   │   ├── IdentityReference: *genruntime.ResourceReference
+│   │   │   ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │   └── Lifecycle: *Enum (4 values)
 │   │   │       ├── "All"
 │   │   │       ├── "Init"
@@ -798,7 +798,7 @@ Job: Resource
 │   │   │   ├── Parallelism: *int
 │   │   │   └── ReplicaCompletionCount: *int
 │   │   ├── Registries: Object (4 properties)[]
-│   │   │   ├── IdentityReference: *genruntime.ResourceReference
+│   │   │   ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │   ├── PasswordSecretRef: *string
 │   │   │   ├── Server: *string
 │   │   │   └── Username: *string
@@ -809,7 +809,7 @@ Job: Resource
 │   │   │   ├── Parallelism: *int
 │   │   │   └── ReplicaCompletionCount: *int
 │   │   ├── Secrets: Object (4 properties)[]
-│   │   │   ├── IdentityReference: *genruntime.ResourceReference
+│   │   │   ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │   ├── KeyVaultUrl: *string
 │   │   │   ├── Name: *string
 │   │   │   └── Value: *genruntime.SecretReference
@@ -1073,7 +1073,7 @@ ManagedEnvironment: Resource
 │   ├── AzureName: string
 │   ├── CustomDomainConfiguration: *Object (4 properties)
 │   │   ├── CertificateKeyVaultProperties: *Object (2 properties)
-│   │   │   ├── IdentityReference: *genruntime.ResourceReference
+│   │   │   ├── IdentityReference: *genruntime.WellknownResourceReference
 │   │   │   └── KeyVaultUrl: Validated<*string> (1 rule)
 │   │   │       └── Rule 0: Pattern: "^[a-zA-Z][a-zA-Z0-9+-.]*:[^\\s]*$"
 │   │   ├── CertificatePassword: *genruntime.SecretReference

--- a/v2/api/app/v1api20250101/zz_generated.deepcopy.go
+++ b/v2/api/app/v1api20250101/zz_generated.deepcopy.go
@@ -1113,7 +1113,7 @@ func (in *CertificateKeyVaultProperties) DeepCopyInto(out *CertificateKeyVaultPr
 	*out = *in
 	if in.IdentityReference != nil {
 		in, out := &in.IdentityReference, &out.IdentityReference
-		*out = new(genruntime.ResourceReference)
+		*out = new(genruntime.WellknownResourceReference)
 		**out = **in
 	}
 	if in.KeyVaultUrl != nil {
@@ -2510,7 +2510,7 @@ func (in *CustomScaleRule) DeepCopyInto(out *CustomScaleRule) {
 	}
 	if in.IdentityReference != nil {
 		in, out := &in.IdentityReference, &out.IdentityReference
-		*out = new(genruntime.ResourceReference)
+		*out = new(genruntime.WellknownResourceReference)
 		**out = **in
 	}
 	if in.Metadata != nil {
@@ -3248,7 +3248,7 @@ func (in *HttpScaleRule) DeepCopyInto(out *HttpScaleRule) {
 	}
 	if in.IdentityReference != nil {
 		in, out := &in.IdentityReference, &out.IdentityReference
-		*out = new(genruntime.ResourceReference)
+		*out = new(genruntime.WellknownResourceReference)
 		**out = **in
 	}
 	if in.Metadata != nil {
@@ -3523,7 +3523,7 @@ func (in *IdentitySettings) DeepCopyInto(out *IdentitySettings) {
 	*out = *in
 	if in.IdentityReference != nil {
 		in, out := &in.IdentityReference, &out.IdentityReference
-		*out = new(genruntime.ResourceReference)
+		*out = new(genruntime.WellknownResourceReference)
 		**out = **in
 	}
 	if in.Lifecycle != nil {
@@ -4356,7 +4356,7 @@ func (in *JobScaleRule) DeepCopyInto(out *JobScaleRule) {
 	}
 	if in.IdentityReference != nil {
 		in, out := &in.IdentityReference, &out.IdentityReference
-		*out = new(genruntime.ResourceReference)
+		*out = new(genruntime.WellknownResourceReference)
 		**out = **in
 	}
 	if in.Metadata != nil {
@@ -5847,7 +5847,7 @@ func (in *QueueScaleRule) DeepCopyInto(out *QueueScaleRule) {
 	}
 	if in.IdentityReference != nil {
 		in, out := &in.IdentityReference, &out.IdentityReference
-		*out = new(genruntime.ResourceReference)
+		*out = new(genruntime.WellknownResourceReference)
 		**out = **in
 	}
 	if in.QueueLength != nil {
@@ -5919,7 +5919,7 @@ func (in *RegistryCredentials) DeepCopyInto(out *RegistryCredentials) {
 	*out = *in
 	if in.IdentityReference != nil {
 		in, out := &in.IdentityReference, &out.IdentityReference
-		*out = new(genruntime.ResourceReference)
+		*out = new(genruntime.WellknownResourceReference)
 		**out = **in
 	}
 	if in.PasswordSecretRef != nil {
@@ -6283,7 +6283,7 @@ func (in *Secret) DeepCopyInto(out *Secret) {
 	*out = *in
 	if in.IdentityReference != nil {
 		in, out := &in.IdentityReference, &out.IdentityReference
-		*out = new(genruntime.ResourceReference)
+		*out = new(genruntime.WellknownResourceReference)
 		**out = **in
 	}
 	if in.KeyVaultUrl != nil {
@@ -6540,7 +6540,7 @@ func (in *TcpScaleRule) DeepCopyInto(out *TcpScaleRule) {
 	}
 	if in.IdentityReference != nil {
 		in, out := &in.IdentityReference, &out.IdentityReference
-		*out = new(genruntime.ResourceReference)
+		*out = new(genruntime.WellknownResourceReference)
 		**out = **in
 	}
 	if in.Metadata != nil {

--- a/v2/azure-arm.yaml
+++ b/v2/azure-arm.yaml
@@ -1241,13 +1241,13 @@ objectModelConfiguration:
         passwordSecretRef:
           $isSecret: false
         Identity:
-          $referenceType: arm
+          $referenceType: arm+wellknown
       ServiceBind:
         ServiceId:
           $referenceType: arm
       Secret:
         Identity:
-          $referenceType: arm
+          $referenceType: arm+wellknown
       ContainerApp_Spec:
         ManagedBy:
           $referenceType: arm
@@ -1276,25 +1276,25 @@ objectModelConfiguration:
           $referenceType: arm
       IdentitySettings:
         Identity:
-          $referenceType: arm
+          $referenceType: arm+wellknown
       HttpScaleRule:
         Identity:
-          $referenceType: arm
+          $referenceType: arm+wellknown
       TcpScaleRule:
         Identity:
-          $referenceType: arm
+          $referenceType: arm+wellknown
       CustomScaleRule:
         Identity:
-          $referenceType: arm
+          $referenceType: arm+wellknown
       JobScaleRule:
         Identity:
-          $referenceType: arm
+          $referenceType: arm+wellknown
       QueueScaleRule:
         Identity:
-          $referenceType: arm
+          $referenceType: arm+wellknown
       CertificateKeyVaultProperties:
         Identity:
-          $referenceType: arm
+          $referenceType: arm+wellknown
     2024-03-01:
       ContainerApp:
         $exportAs: ContainerApp
@@ -1309,13 +1309,13 @@ objectModelConfiguration:
         passwordSecretRef:
           $isSecret: false
         Identity:
-          $referenceType: arm
+          $referenceType: arm+wellknown
       ServiceBind:
         ServiceId:
           $referenceType: arm
       Secret:
         Identity:
-          $referenceType: arm
+          $referenceType: arm+wellknown
       ContainerApp_Spec:
         ManagedBy:
           $referenceType: arm


### PR DESCRIPTION
## What this PR does

A number of the Identity references used in the `app` group permit specifying `system` to use a system assigned identity instead of an explicit one. 

Previously ASO had no support for these, but with the completion of #4922 we'll have full support via the `wellKnownName` property.

### Prerequisites

- [ ] #4922 

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcWYwejBhcW00b2p1eGV4MWU4ejBqYmMxbjNvcmpuZ2o5MzJ6a25kMiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/mhIk0lHu6jJ3jUuZIH/giphy.gif)
