### PR TITLE
Add "UnsupportedResourceType" to asoctl exclusions for extension resources

### DIFF
--- a/v2/cmd/asoctl/pkg/importresources/importable_arm_resource.go
+++ b/v2/cmd/asoctl/pkg/importresources/importable_arm_resource.go
@@ -372,6 +372,7 @@ var skipCodes = set.Make(
 	"ValidationFailed",
 	"NoRegisteredProviderFound",
 	"ResourceTypeNotSupported",
+	"UnsupportedResourceType",
 )
 
 func (*importableARMResource) classifyError(err error) (string, bool) {


### PR DESCRIPTION
## What this PR does

Unlike other resource providers, who use the error code `ResourceTypeNotSupported` when an extension resource is used with the wrong parent resource, `Microsoft.Insights` use `UnsupportedResourceType`.

We need to add `UnsupportedResourceType` to the list of error code we expect for extension resources as asoctl probes to find resources.

Closes #4919 

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdXowem1saGVqYWx0ZmxneWIzcTM4NjQxN3NpZ3I4aHZrdzBibWVoaCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/xTiN0DvoDyWQey2B8I/giphy.gif)
