### PR TITLE
Improve diagnostics from TypeTransformers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ hack/tools
 v2/controller
 v2/cmd/asoctl/asoctl
 v2/tools/generator/aso-gen
+v2/tools/generator/generator

--- a/v2/api/documentdb/v1api20210515/storage/database_account_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/storage/database_account_types_gen.go
@@ -481,13 +481,6 @@ func (account *DatabaseAccount_Spec) AssignProperties_From_DatabaseAccount_Spec(
 		propertyBag.Remove("CreateMode")
 	}
 
-	// CustomerManagedKeyStatus
-	if source.CustomerManagedKeyStatus != nil {
-		propertyBag.Add("CustomerManagedKeyStatus", *source.CustomerManagedKeyStatus)
-	} else {
-		propertyBag.Remove("CustomerManagedKeyStatus")
-	}
-
 	// DatabaseAccountOfferType
 	account.DatabaseAccountOfferType = genruntime.ClonePointerToString(source.DatabaseAccountOfferType)
 
@@ -851,19 +844,6 @@ func (account *DatabaseAccount_Spec) AssignProperties_To_DatabaseAccount_Spec(de
 		destination.CreateMode = &createMode
 	} else {
 		destination.CreateMode = nil
-	}
-
-	// CustomerManagedKeyStatus
-	if propertyBag.Contains("CustomerManagedKeyStatus") {
-		var customerManagedKeyStatus string
-		err := propertyBag.Pull("CustomerManagedKeyStatus", &customerManagedKeyStatus)
-		if err != nil {
-			return eris.Wrap(err, "pulling 'CustomerManagedKeyStatus' from propertyBag")
-		}
-
-		destination.CustomerManagedKeyStatus = &customerManagedKeyStatus
-	} else {
-		destination.CustomerManagedKeyStatus = nil
 	}
 
 	// DatabaseAccountOfferType

--- a/v2/api/documentdb/v1api20231115/arm/database_account_spec_types_gen.go
+++ b/v2/api/documentdb/v1api20231115/arm/database_account_spec_types_gen.go
@@ -86,10 +86,6 @@ type DatabaseAccountCreateUpdateProperties struct {
 	// CreateMode: Enum to indicate the mode of account creation.
 	CreateMode *CreateMode `json:"createMode,omitempty"`
 
-	// CustomerManagedKeyStatus: Indicates the status of the Customer Managed Key feature on the account. In case there are
-	// errors, the property provides troubleshooting guidance.
-	CustomerManagedKeyStatus *string `json:"customerManagedKeyStatus,omitempty"`
-
 	// DatabaseAccountOfferType: The offer type for the database
 	DatabaseAccountOfferType *DatabaseAccountOfferType `json:"databaseAccountOfferType,omitempty"`
 

--- a/v2/api/documentdb/v1api20231115/arm/database_account_spec_types_gen_test.go
+++ b/v2/api/documentdb/v1api20231115/arm/database_account_spec_types_gen_test.go
@@ -738,7 +738,6 @@ func DatabaseAccountCreateUpdatePropertiesGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForDatabaseAccountCreateUpdateProperties(gens map[string]gopter.Gen) {
 	gens["ConnectorOffer"] = gen.PtrOf(gen.OneConstOf(ConnectorOffer_Small))
 	gens["CreateMode"] = gen.PtrOf(gen.OneConstOf(CreateMode_Default, CreateMode_Restore))
-	gens["CustomerManagedKeyStatus"] = gen.PtrOf(gen.AlphaString())
 	gens["DatabaseAccountOfferType"] = gen.PtrOf(gen.OneConstOf(DatabaseAccountOfferType_Standard))
 	gens["DefaultIdentity"] = gen.PtrOf(gen.AlphaString())
 	gens["DisableKeyBasedMetadataWriteAccess"] = gen.PtrOf(gen.Bool())

--- a/v2/api/documentdb/v1api20231115/arm/structure.txt
+++ b/v2/api/documentdb/v1api20231115/arm/structure.txt
@@ -208,7 +208,7 @@ DatabaseAccount_Spec: Object (6 properties)
 │   └── "Parse"
 ├── Location: *string
 ├── Name: string
-├── Properties: *Object (31 properties)
+├── Properties: *Object (30 properties)
 │   ├── AnalyticalStorageConfiguration: *Object (1 property)
 │   │   └── SchemaType: *Enum (2 values)
 │   │       ├── "FullFidelity"
@@ -281,7 +281,6 @@ DatabaseAccount_Spec: Object (6 properties)
 │   ├── CreateMode: *Enum (2 values)
 │   │   ├── "Default"
 │   │   └── "Restore"
-│   ├── CustomerManagedKeyStatus: *string
 │   ├── DatabaseAccountOfferType: *Enum (1 value)
 │   │   └── "Standard"
 │   ├── DefaultIdentity: *string

--- a/v2/api/documentdb/v1api20231115/database_account_types_gen.go
+++ b/v2/api/documentdb/v1api20231115/database_account_types_gen.go
@@ -289,10 +289,6 @@ type DatabaseAccount_Spec struct {
 	// CreateMode: Enum to indicate the mode of account creation.
 	CreateMode *CreateMode `json:"createMode,omitempty"`
 
-	// CustomerManagedKeyStatus: Indicates the status of the Customer Managed Key feature on the account. In case there are
-	// errors, the property provides troubleshooting guidance.
-	CustomerManagedKeyStatus *string `json:"customerManagedKeyStatus,omitempty"`
-
 	// +kubebuilder:validation:Required
 	// DatabaseAccountOfferType: The offer type for the database
 	DatabaseAccountOfferType *DatabaseAccountOfferType `json:"databaseAccountOfferType,omitempty"`
@@ -431,7 +427,6 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		account.ConsistencyPolicy != nil ||
 		account.Cors != nil ||
 		account.CreateMode != nil ||
-		account.CustomerManagedKeyStatus != nil ||
 		account.DatabaseAccountOfferType != nil ||
 		account.DefaultIdentity != nil ||
 		account.DisableKeyBasedMetadataWriteAccess != nil ||
@@ -520,10 +515,6 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		temp = string(*account.CreateMode)
 		createMode := arm.CreateMode(temp)
 		result.Properties.CreateMode = &createMode
-	}
-	if account.CustomerManagedKeyStatus != nil {
-		customerManagedKeyStatus := *account.CustomerManagedKeyStatus
-		result.Properties.CustomerManagedKeyStatus = &customerManagedKeyStatus
 	}
 	if account.DatabaseAccountOfferType != nil {
 		var temp string
@@ -774,15 +765,6 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 			temp = string(*typedInput.Properties.CreateMode)
 			createMode := CreateMode(temp)
 			account.CreateMode = &createMode
-		}
-	}
-
-	// Set property "CustomerManagedKeyStatus":
-	// copying flattened property:
-	if typedInput.Properties != nil {
-		if typedInput.Properties.CustomerManagedKeyStatus != nil {
-			customerManagedKeyStatus := *typedInput.Properties.CustomerManagedKeyStatus
-			account.CustomerManagedKeyStatus = &customerManagedKeyStatus
 		}
 	}
 
@@ -1208,9 +1190,6 @@ func (account *DatabaseAccount_Spec) AssignProperties_From_DatabaseAccount_Spec(
 		account.CreateMode = nil
 	}
 
-	// CustomerManagedKeyStatus
-	account.CustomerManagedKeyStatus = genruntime.ClonePointerToString(source.CustomerManagedKeyStatus)
-
 	// DatabaseAccountOfferType
 	if source.DatabaseAccountOfferType != nil {
 		databaseAccountOfferType := *source.DatabaseAccountOfferType
@@ -1582,9 +1561,6 @@ func (account *DatabaseAccount_Spec) AssignProperties_To_DatabaseAccount_Spec(de
 	} else {
 		destination.CreateMode = nil
 	}
-
-	// CustomerManagedKeyStatus
-	destination.CustomerManagedKeyStatus = genruntime.ClonePointerToString(account.CustomerManagedKeyStatus)
 
 	// DatabaseAccountOfferType
 	if account.DatabaseAccountOfferType != nil {

--- a/v2/api/documentdb/v1api20231115/database_account_types_gen_test.go
+++ b/v2/api/documentdb/v1api20231115/database_account_types_gen_test.go
@@ -2997,7 +2997,6 @@ func AddIndependentPropertyGeneratorsForDatabaseAccount_Spec(gens map[string]gop
 	gens["AzureName"] = gen.AlphaString()
 	gens["ConnectorOffer"] = gen.PtrOf(gen.OneConstOf(ConnectorOffer_Small))
 	gens["CreateMode"] = gen.PtrOf(gen.OneConstOf(CreateMode_Default, CreateMode_Restore))
-	gens["CustomerManagedKeyStatus"] = gen.PtrOf(gen.AlphaString())
 	gens["DatabaseAccountOfferType"] = gen.PtrOf(gen.OneConstOf(DatabaseAccountOfferType_Standard))
 	gens["DefaultIdentity"] = gen.PtrOf(gen.AlphaString())
 	gens["DisableKeyBasedMetadataWriteAccess"] = gen.PtrOf(gen.Bool())

--- a/v2/api/documentdb/v1api20231115/storage/database_account_types_gen.go
+++ b/v2/api/documentdb/v1api20231115/storage/database_account_types_gen.go
@@ -281,7 +281,6 @@ type DatabaseAccount_Spec struct {
 	ConsistencyPolicy                  *ConsistencyPolicy             `json:"consistencyPolicy,omitempty"`
 	Cors                               []CorsPolicy                   `json:"cors,omitempty"`
 	CreateMode                         *string                        `json:"createMode,omitempty"`
-	CustomerManagedKeyStatus           *string                        `json:"customerManagedKeyStatus,omitempty"`
 	DatabaseAccountOfferType           *string                        `json:"databaseAccountOfferType,omitempty"`
 	DefaultIdentity                    *string                        `json:"defaultIdentity,omitempty"`
 	DisableKeyBasedMetadataWriteAccess *bool                          `json:"disableKeyBasedMetadataWriteAccess,omitempty"`
@@ -477,9 +476,6 @@ func (account *DatabaseAccount_Spec) AssignProperties_From_DatabaseAccount_Spec(
 
 	// CreateMode
 	account.CreateMode = genruntime.ClonePointerToString(source.CreateMode)
-
-	// CustomerManagedKeyStatus
-	account.CustomerManagedKeyStatus = genruntime.ClonePointerToString(source.CustomerManagedKeyStatus)
 
 	// DatabaseAccountOfferType
 	account.DatabaseAccountOfferType = genruntime.ClonePointerToString(source.DatabaseAccountOfferType)
@@ -831,9 +827,6 @@ func (account *DatabaseAccount_Spec) AssignProperties_To_DatabaseAccount_Spec(de
 
 	// CreateMode
 	destination.CreateMode = genruntime.ClonePointerToString(account.CreateMode)
-
-	// CustomerManagedKeyStatus
-	destination.CustomerManagedKeyStatus = genruntime.ClonePointerToString(account.CustomerManagedKeyStatus)
 
 	// DatabaseAccountOfferType
 	destination.DatabaseAccountOfferType = genruntime.ClonePointerToString(account.DatabaseAccountOfferType)

--- a/v2/api/documentdb/v1api20231115/storage/database_account_types_gen_test.go
+++ b/v2/api/documentdb/v1api20231115/storage/database_account_types_gen_test.go
@@ -2971,7 +2971,6 @@ func AddIndependentPropertyGeneratorsForDatabaseAccount_Spec(gens map[string]gop
 	gens["AzureName"] = gen.AlphaString()
 	gens["ConnectorOffer"] = gen.PtrOf(gen.AlphaString())
 	gens["CreateMode"] = gen.PtrOf(gen.AlphaString())
-	gens["CustomerManagedKeyStatus"] = gen.PtrOf(gen.AlphaString())
 	gens["DatabaseAccountOfferType"] = gen.PtrOf(gen.AlphaString())
 	gens["DefaultIdentity"] = gen.PtrOf(gen.AlphaString())
 	gens["DisableKeyBasedMetadataWriteAccess"] = gen.PtrOf(gen.Bool())

--- a/v2/api/documentdb/v1api20231115/storage/structure.txt
+++ b/v2/api/documentdb/v1api20231115/storage/structure.txt
@@ -6,7 +6,7 @@ APIVersion: Enum (1 value)
 
 DatabaseAccount: Resource
 ├── Owner: resources/v1apiv20191001.ResourceGroup
-├── Spec: Object (40 properties)
+├── Spec: Object (39 properties)
 │   ├── AnalyticalStorageConfiguration: *Object (2 properties)
 │   │   ├── PropertyBag: genruntime.PropertyBag
 │   │   └── SchemaType: *string
@@ -60,7 +60,6 @@ DatabaseAccount: Resource
 │   │   ├── MaxAgeInSeconds: *int
 │   │   └── PropertyBag: genruntime.PropertyBag
 │   ├── CreateMode: *string
-│   ├── CustomerManagedKeyStatus: *string
 │   ├── DatabaseAccountOfferType: *string
 │   ├── DefaultIdentity: *string
 │   ├── DisableKeyBasedMetadataWriteAccess: *bool

--- a/v2/api/documentdb/v1api20231115/storage/zz_generated.deepcopy.go
+++ b/v2/api/documentdb/v1api20231115/storage/zz_generated.deepcopy.go
@@ -1868,11 +1868,6 @@ func (in *DatabaseAccount_Spec) DeepCopyInto(out *DatabaseAccount_Spec) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.CustomerManagedKeyStatus != nil {
-		in, out := &in.CustomerManagedKeyStatus, &out.CustomerManagedKeyStatus
-		*out = new(string)
-		**out = **in
-	}
 	if in.DatabaseAccountOfferType != nil {
 		in, out := &in.DatabaseAccountOfferType, &out.DatabaseAccountOfferType
 		*out = new(string)

--- a/v2/api/documentdb/v1api20231115/structure.txt
+++ b/v2/api/documentdb/v1api20231115/structure.txt
@@ -6,7 +6,7 @@ APIVersion: Enum (1 value)
 
 DatabaseAccount: Resource
 ├── Owner: resources/v1apiv20191001.ResourceGroup
-├── Spec: Object (38 properties)
+├── Spec: Object (37 properties)
 │   ├── AnalyticalStorageConfiguration: *Object (1 property)
 │   │   └── SchemaType: *Enum (2 values)
 │   │       ├── "FullFidelity"
@@ -92,7 +92,6 @@ DatabaseAccount: Resource
 │   ├── CreateMode: *Enum (2 values)
 │   │   ├── "Default"
 │   │   └── "Restore"
-│   ├── CustomerManagedKeyStatus: *string
 │   ├── DatabaseAccountOfferType: *Enum (1 value)
 │   │   └── "Standard"
 │   ├── DefaultIdentity: *string

--- a/v2/api/documentdb/v1api20231115/zz_generated.deepcopy.go
+++ b/v2/api/documentdb/v1api20231115/zz_generated.deepcopy.go
@@ -1560,11 +1560,6 @@ func (in *DatabaseAccount_Spec) DeepCopyInto(out *DatabaseAccount_Spec) {
 		*out = new(CreateMode)
 		**out = **in
 	}
-	if in.CustomerManagedKeyStatus != nil {
-		in, out := &in.CustomerManagedKeyStatus, &out.CustomerManagedKeyStatus
-		*out = new(string)
-		**out = **in
-	}
 	if in.DatabaseAccountOfferType != nil {
 		in, out := &in.DatabaseAccountOfferType, &out.DatabaseAccountOfferType
 		*out = new(DatabaseAccountOfferType)

--- a/v2/api/documentdb/v1api20240815/arm/database_account_spec_types_gen.go
+++ b/v2/api/documentdb/v1api20240815/arm/database_account_spec_types_gen.go
@@ -86,10 +86,6 @@ type DatabaseAccountCreateUpdateProperties struct {
 	// CreateMode: Enum to indicate the mode of account creation.
 	CreateMode *CreateMode `json:"createMode,omitempty"`
 
-	// CustomerManagedKeyStatus: Indicates the status of the Customer Managed Key feature on the account. In case there are
-	// errors, the property provides troubleshooting guidance.
-	CustomerManagedKeyStatus *string `json:"customerManagedKeyStatus,omitempty"`
-
 	// DatabaseAccountOfferType: The offer type for the database
 	DatabaseAccountOfferType *DatabaseAccountOfferType `json:"databaseAccountOfferType,omitempty"`
 

--- a/v2/api/documentdb/v1api20240815/arm/database_account_spec_types_gen_test.go
+++ b/v2/api/documentdb/v1api20240815/arm/database_account_spec_types_gen_test.go
@@ -741,7 +741,6 @@ func DatabaseAccountCreateUpdatePropertiesGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForDatabaseAccountCreateUpdateProperties(gens map[string]gopter.Gen) {
 	gens["ConnectorOffer"] = gen.PtrOf(gen.OneConstOf(ConnectorOffer_Small))
 	gens["CreateMode"] = gen.PtrOf(gen.OneConstOf(CreateMode_Default, CreateMode_Restore))
-	gens["CustomerManagedKeyStatus"] = gen.PtrOf(gen.AlphaString())
 	gens["DatabaseAccountOfferType"] = gen.PtrOf(gen.OneConstOf(DatabaseAccountOfferType_Standard))
 	gens["DefaultIdentity"] = gen.PtrOf(gen.AlphaString())
 	gens["DisableKeyBasedMetadataWriteAccess"] = gen.PtrOf(gen.Bool())

--- a/v2/api/documentdb/v1api20240815/arm/structure.txt
+++ b/v2/api/documentdb/v1api20240815/arm/structure.txt
@@ -212,7 +212,7 @@ DatabaseAccount_Spec: Object (6 properties)
 │   └── "Parse"
 ├── Location: *string
 ├── Name: string
-├── Properties: *Object (31 properties)
+├── Properties: *Object (30 properties)
 │   ├── AnalyticalStorageConfiguration: *Object (1 property)
 │   │   └── SchemaType: *Enum (2 values)
 │   │       ├── "FullFidelity"
@@ -288,7 +288,6 @@ DatabaseAccount_Spec: Object (6 properties)
 │   ├── CreateMode: *Enum (2 values)
 │   │   ├── "Default"
 │   │   └── "Restore"
-│   ├── CustomerManagedKeyStatus: *string
 │   ├── DatabaseAccountOfferType: *Enum (1 value)
 │   │   └── "Standard"
 │   ├── DefaultIdentity: *string

--- a/v2/api/documentdb/v1api20240815/database_account_types_gen.go
+++ b/v2/api/documentdb/v1api20240815/database_account_types_gen.go
@@ -286,10 +286,6 @@ type DatabaseAccount_Spec struct {
 	// CreateMode: Enum to indicate the mode of account creation.
 	CreateMode *CreateMode `json:"createMode,omitempty"`
 
-	// CustomerManagedKeyStatus: Indicates the status of the Customer Managed Key feature on the account. In case there are
-	// errors, the property provides troubleshooting guidance.
-	CustomerManagedKeyStatus *string `json:"customerManagedKeyStatus,omitempty"`
-
 	// +kubebuilder:validation:Required
 	// DatabaseAccountOfferType: The offer type for the database
 	DatabaseAccountOfferType *DatabaseAccountOfferType `json:"databaseAccountOfferType,omitempty"`
@@ -428,7 +424,6 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		account.ConsistencyPolicy != nil ||
 		account.Cors != nil ||
 		account.CreateMode != nil ||
-		account.CustomerManagedKeyStatus != nil ||
 		account.DatabaseAccountOfferType != nil ||
 		account.DefaultIdentity != nil ||
 		account.DisableKeyBasedMetadataWriteAccess != nil ||
@@ -517,10 +512,6 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		temp = string(*account.CreateMode)
 		createMode := arm.CreateMode(temp)
 		result.Properties.CreateMode = &createMode
-	}
-	if account.CustomerManagedKeyStatus != nil {
-		customerManagedKeyStatus := *account.CustomerManagedKeyStatus
-		result.Properties.CustomerManagedKeyStatus = &customerManagedKeyStatus
 	}
 	if account.DatabaseAccountOfferType != nil {
 		var temp string
@@ -771,15 +762,6 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 			temp = string(*typedInput.Properties.CreateMode)
 			createMode := CreateMode(temp)
 			account.CreateMode = &createMode
-		}
-	}
-
-	// Set property "CustomerManagedKeyStatus":
-	// copying flattened property:
-	if typedInput.Properties != nil {
-		if typedInput.Properties.CustomerManagedKeyStatus != nil {
-			customerManagedKeyStatus := *typedInput.Properties.CustomerManagedKeyStatus
-			account.CustomerManagedKeyStatus = &customerManagedKeyStatus
 		}
 	}
 
@@ -1205,9 +1187,6 @@ func (account *DatabaseAccount_Spec) AssignProperties_From_DatabaseAccount_Spec(
 		account.CreateMode = nil
 	}
 
-	// CustomerManagedKeyStatus
-	account.CustomerManagedKeyStatus = genruntime.ClonePointerToString(source.CustomerManagedKeyStatus)
-
 	// DatabaseAccountOfferType
 	if source.DatabaseAccountOfferType != nil {
 		databaseAccountOfferType := *source.DatabaseAccountOfferType
@@ -1580,9 +1559,6 @@ func (account *DatabaseAccount_Spec) AssignProperties_To_DatabaseAccount_Spec(de
 		destination.CreateMode = nil
 	}
 
-	// CustomerManagedKeyStatus
-	destination.CustomerManagedKeyStatus = genruntime.ClonePointerToString(account.CustomerManagedKeyStatus)
-
 	// DatabaseAccountOfferType
 	if account.DatabaseAccountOfferType != nil {
 		databaseAccountOfferType := string(*account.DatabaseAccountOfferType)
@@ -1954,9 +1930,6 @@ func (account *DatabaseAccount_Spec) Initialize_From_DatabaseAccount_STATUS(sour
 	} else {
 		account.CreateMode = nil
 	}
-
-	// CustomerManagedKeyStatus
-	account.CustomerManagedKeyStatus = genruntime.ClonePointerToString(source.CustomerManagedKeyStatus)
 
 	// DatabaseAccountOfferType
 	if source.DatabaseAccountOfferType != nil {

--- a/v2/api/documentdb/v1api20240815/database_account_types_gen_test.go
+++ b/v2/api/documentdb/v1api20240815/database_account_types_gen_test.go
@@ -3002,7 +3002,6 @@ func AddIndependentPropertyGeneratorsForDatabaseAccount_Spec(gens map[string]gop
 	gens["AzureName"] = gen.AlphaString()
 	gens["ConnectorOffer"] = gen.PtrOf(gen.OneConstOf(ConnectorOffer_Small))
 	gens["CreateMode"] = gen.PtrOf(gen.OneConstOf(CreateMode_Default, CreateMode_Restore))
-	gens["CustomerManagedKeyStatus"] = gen.PtrOf(gen.AlphaString())
 	gens["DatabaseAccountOfferType"] = gen.PtrOf(gen.OneConstOf(DatabaseAccountOfferType_Standard))
 	gens["DefaultIdentity"] = gen.PtrOf(gen.AlphaString())
 	gens["DisableKeyBasedMetadataWriteAccess"] = gen.PtrOf(gen.Bool())

--- a/v2/api/documentdb/v1api20240815/storage/database_account_types_gen.go
+++ b/v2/api/documentdb/v1api20240815/storage/database_account_types_gen.go
@@ -187,7 +187,6 @@ type DatabaseAccount_Spec struct {
 	ConsistencyPolicy                  *ConsistencyPolicy             `json:"consistencyPolicy,omitempty"`
 	Cors                               []CorsPolicy                   `json:"cors,omitempty"`
 	CreateMode                         *string                        `json:"createMode,omitempty"`
-	CustomerManagedKeyStatus           *string                        `json:"customerManagedKeyStatus,omitempty"`
 	DatabaseAccountOfferType           *string                        `json:"databaseAccountOfferType,omitempty"`
 	DefaultIdentity                    *string                        `json:"defaultIdentity,omitempty"`
 	DisableKeyBasedMetadataWriteAccess *bool                          `json:"disableKeyBasedMetadataWriteAccess,omitempty"`

--- a/v2/api/documentdb/v1api20240815/storage/database_account_types_gen_test.go
+++ b/v2/api/documentdb/v1api20240815/storage/database_account_types_gen_test.go
@@ -1792,7 +1792,6 @@ func AddIndependentPropertyGeneratorsForDatabaseAccount_Spec(gens map[string]gop
 	gens["AzureName"] = gen.AlphaString()
 	gens["ConnectorOffer"] = gen.PtrOf(gen.AlphaString())
 	gens["CreateMode"] = gen.PtrOf(gen.AlphaString())
-	gens["CustomerManagedKeyStatus"] = gen.PtrOf(gen.AlphaString())
 	gens["DatabaseAccountOfferType"] = gen.PtrOf(gen.AlphaString())
 	gens["DefaultIdentity"] = gen.PtrOf(gen.AlphaString())
 	gens["DisableKeyBasedMetadataWriteAccess"] = gen.PtrOf(gen.Bool())

--- a/v2/api/documentdb/v1api20240815/storage/structure.txt
+++ b/v2/api/documentdb/v1api20240815/storage/structure.txt
@@ -6,7 +6,7 @@ APIVersion: Enum (1 value)
 
 DatabaseAccount: Resource
 ├── Owner: resources/v1apiv20191001.ResourceGroup
-├── Spec: Object (40 properties)
+├── Spec: Object (39 properties)
 │   ├── AnalyticalStorageConfiguration: *Object (2 properties)
 │   │   ├── PropertyBag: genruntime.PropertyBag
 │   │   └── SchemaType: *string
@@ -60,7 +60,6 @@ DatabaseAccount: Resource
 │   │   ├── MaxAgeInSeconds: *int
 │   │   └── PropertyBag: genruntime.PropertyBag
 │   ├── CreateMode: *string
-│   ├── CustomerManagedKeyStatus: *string
 │   ├── DatabaseAccountOfferType: *string
 │   ├── DefaultIdentity: *string
 │   ├── DisableKeyBasedMetadataWriteAccess: *bool

--- a/v2/api/documentdb/v1api20240815/storage/zz_generated.deepcopy.go
+++ b/v2/api/documentdb/v1api20240815/storage/zz_generated.deepcopy.go
@@ -1868,11 +1868,6 @@ func (in *DatabaseAccount_Spec) DeepCopyInto(out *DatabaseAccount_Spec) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.CustomerManagedKeyStatus != nil {
-		in, out := &in.CustomerManagedKeyStatus, &out.CustomerManagedKeyStatus
-		*out = new(string)
-		**out = **in
-	}
 	if in.DatabaseAccountOfferType != nil {
 		in, out := &in.DatabaseAccountOfferType, &out.DatabaseAccountOfferType
 		*out = new(string)

--- a/v2/api/documentdb/v1api20240815/structure.txt
+++ b/v2/api/documentdb/v1api20240815/structure.txt
@@ -6,7 +6,7 @@ APIVersion: Enum (1 value)
 
 DatabaseAccount: Resource
 ├── Owner: resources/v1apiv20191001.ResourceGroup
-├── Spec: Object (38 properties)
+├── Spec: Object (37 properties)
 │   ├── AnalyticalStorageConfiguration: *Object (1 property)
 │   │   └── SchemaType: *Enum (2 values)
 │   │       ├── "FullFidelity"
@@ -95,7 +95,6 @@ DatabaseAccount: Resource
 │   ├── CreateMode: *Enum (2 values)
 │   │   ├── "Default"
 │   │   └── "Restore"
-│   ├── CustomerManagedKeyStatus: *string
 │   ├── DatabaseAccountOfferType: *Enum (1 value)
 │   │   └── "Standard"
 │   ├── DefaultIdentity: *string

--- a/v2/api/documentdb/v1api20240815/zz_generated.deepcopy.go
+++ b/v2/api/documentdb/v1api20240815/zz_generated.deepcopy.go
@@ -1560,11 +1560,6 @@ func (in *DatabaseAccount_Spec) DeepCopyInto(out *DatabaseAccount_Spec) {
 		*out = new(CreateMode)
 		**out = **in
 	}
-	if in.CustomerManagedKeyStatus != nil {
-		in, out := &in.CustomerManagedKeyStatus, &out.CustomerManagedKeyStatus
-		*out = new(string)
-		**out = **in
-	}
 	if in.DatabaseAccountOfferType != nil {
 		in, out := &in.DatabaseAccountOfferType, &out.DatabaseAccountOfferType
 		*out = new(DatabaseAccountOfferType)

--- a/v2/azure-arm.yaml
+++ b/v2/azure-arm.yaml
@@ -577,7 +577,7 @@ typeTransformers:
     because: This property should have been marked readonly but wasn't.
 
   - group: documentdb
-    name: DatabaseAccount_Spec
+    name: DatabaseAccountCreateUpdateProperties
     property: CustomerManagedKeyStatus
     remove: true
     because: This property should have been marked readonly but wasn't.

--- a/v2/tools/generator/internal/config/configuration.go
+++ b/v2/tools/generator/internal/config/configuration.go
@@ -126,7 +126,7 @@ func (config *Configuration) GetTransformersError() error {
 		}
 
 		if filter.Property.IsRestrictive() {
-			if err := filter.RequiredTypesWereMatched(); err != nil {
+			if err := filter.RequiredPropertiesWereMatched(); err != nil {
 				return eris.Wrap(err, "type transformer property")
 			}
 		}

--- a/v2/tools/generator/internal/config/field_matcher.go
+++ b/v2/tools/generator/internal/config/field_matcher.go
@@ -63,7 +63,7 @@ func (dm *FieldMatcher) IsRestrictive() bool {
 }
 
 // UnmarshalYAML populates our instance from the YAML.
-// We expect just a single string, which we use create an actual StringMatcher
+// We expect just a single string, which we use to create an actual StringMatcher
 func (dm *FieldMatcher) UnmarshalYAML(value *yaml.Node) error {
 	if value.Kind != yaml.ScalarNode {
 		return eris.New("expected scalar value")

--- a/v2/tools/generator/internal/config/type_matcher.go
+++ b/v2/tools/generator/internal/config/type_matcher.go
@@ -19,8 +19,10 @@ type TypeMatcher struct {
 	Group   FieldMatcher `yaml:",omitempty"` // Filter matching types by group
 	Version FieldMatcher `yaml:",omitempty"` // Filter matching types by version
 	Name    FieldMatcher `yaml:",omitempty"` // Filter matching types by name
+
 	// Because is used to articulate why the filter applied to a type (used to generate explanatory logs in debug mode)
 	Because string
+
 	// MatchRequired indicates if an error will be raised if this TypeMatcher doesn't match at least one type.
 	// The default is true.
 	// Don't access directly, use the MustMatch() method instead.

--- a/v2/tools/generator/internal/config/type_transformer.go
+++ b/v2/tools/generator/internal/config/type_transformer.go
@@ -182,6 +182,7 @@ func (r PropertyTransformResult) String() string {
 			r.Because,
 		)
 	}
+
 	return fmt.Sprintf("%s.%s -> %s because %s",
 		r.TypeName,
 		r.Property,
@@ -210,18 +211,14 @@ func (r PropertyTransformResult) LogTo(log logr.Logger) {
 }
 
 func (transformer *TypeTransformer) RequiredPropertiesWereMatched() error {
-	// If this transformer applies to entire types (instead of just properties on types), we just defer to
-	// transformer.MatchedRequiredTypes
-	if !transformer.Property.IsRestrictive() {
-		return transformer.RequiredTypesWereMatched()
-	}
-
-	if !transformer.MustMatch() {
-		return nil
-	}
-
 	if err := transformer.RequiredTypesWereMatched(); err != nil {
 		return err
+	}
+
+	// If this transformer applies to entire types (instead of just properties on types),
+	// no further checks are needed
+	if !transformer.Property.IsRestrictive() {
+		return nil
 	}
 
 	if err := transformer.Property.WasMatched(); err != nil {

--- a/v2/tools/generator/internal/config/type_transformer_test.go
+++ b/v2/tools/generator/internal/config/type_transformer_test.go
@@ -802,15 +802,15 @@ func Test_TypeTransformer_RequiredTypesWereMatched_ReturnsExpectedResults(t *tes
 		},
 		"When no match on group": {
 			typeName:      differentGroup,
-			expectedError: "every group was excluded",
+			expectedError: "incomplete match for group",
 		},
 		"When no match on version": {
 			typeName:      differentVersion,
-			expectedError: "groups matched, but every version was excluded",
+			expectedError: "incomplete match for version",
 		},
 		"When no match on name": {
 			typeName:      differentName,
-			expectedError: "groups and versions matched, but every type was excluded",
+			expectedError: "incomplete match for name",
 		},
 	}
 
@@ -863,15 +863,15 @@ func Test_TypeTransformer_RequirePropertiesWereMatched_ReturnsExpectedResults(t 
 		},
 		"When no match on group": {
 			definition:    differentGroup,
-			expectedError: "every group was excluded",
+			expectedError: "incomplete match for group: no match for \"party\"",
 		},
 		"When no match on version": {
 			definition:    differentVersion,
-			expectedError: "groups matched, but every version was excluded",
+			expectedError: "incomplete match for version: no match for \"v2025\"",
 		},
 		"When no match on name": {
 			definition:    differentName,
-			expectedError: "groups and versions matched, but every type was excluded",
+			expectedError: "incomplete match for name: no match for \"person\"",
 		},
 		"When no match on property": {
 			definition:    differentProperty,


### PR DESCRIPTION
## What this PR does

Tightens our validation of TypeTransformer configuration to ensure that all parts of the TypeMatcher are used, and to leverage our `TypoAdvisor` to generate good error messages.

Also fixes ineffective removal of the property `CustomerManagedKeyStatus`, dating back to #3967

Closes #4867 

Sample error (line-breaks added):

```
ERR failed to execute root command error="
error generating code: 
failed to execute stage 9: 
Modify types using configured type transforms: 
type transformer: 
type matcher [Group: 'dataprotection'; Name: 'BackupVaults_BackupPolicySpec'; Because: 'This property should be marked readonly in Swagger'], incomplete match for name: 
no match for \"BackupVaults_BackupPolicySpec\" (did you mean BackupVaults_BackupPolicy_Spec?)"
```

### Special notes

Much of the infrastructure needed was already present, so this involved less work than expected.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPWVjZjA1ZTQ3NXViaTI3czZkZTFzbWtncDhsZXJmcGw3MHl6bHhxNXEwaW02bnkwdSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/26SSWjcPAKCyXdCXgh/giphy.gif)

## Checklist

- [x] this PR contains tests

