### PR TITLE
Fix header-check script

### DIFF
--- a/scripts/v2/check_headers.py
+++ b/scripts/v2/check_headers.py
@@ -40,11 +40,11 @@ def is_file_compliant(regex, path):
 
 
 if __name__ == '__main__':
-    msftRegex = 'Copyright \(c\) Microsoft Corporation\.(\s)*(.){0,7}Licensed under the MIT License\.'
+    msftRegex = r'Copyright \(c\) Microsoft Corporation\.(\s)*(.){0,7}Licensed under the MIT License\.'
 
     # We have a few files that were copied from CAPI and modified some. We need to maintain attribution and leave
     # their license as is. See <> for an issue discussing if they could be moved into a place we could depend on.
-    capiRegex = 'Copyright \d{4} The Kubernetes Authors\.(\s)*(.){0,7}Licensed under the Apache License, Version 2\.0'
+    capiRegex = r'Copyright \d{4} The Kubernetes Authors\.(\s)*(.){0,7}Licensed under the Apache License, Version 2\.0'
     regex = re.compile('({}|{})'.format(msftRegex, capiRegex), re.MULTILINE | re.IGNORECASE)
     failed_files = []
 


### PR DESCRIPTION
## What this PR does

Fixes a problem in our `check_headers.py` script that was triggered by a recent update to the version of Python.

We started seeing errors like this in our CI logs:

```
task: [header-check] /workspaces/azure-service-operator-2/scripts/v2/check_headers.py
[header-check] /workspaces/azure-service-operator-2/scripts/v2/check_headers.py:43: SyntaxWarning: invalid escape sequence '\('
[header-check]   msftRegex = 'Copyright \(c\) Microsoft Corporation\.(\s)*(.){0,7}Licensed under the MIT License\.'
[header-check] /workspaces/azure-service-operator-2/scripts/v2/check_headers.py:47: SyntaxWarning: invalid escape sequence '\d'
[header-check]   capiRegex = 'Copyright \d{4} The Kubernetes Authors\.(\s)*(.){0,7}Licensed under the Apache License, Version 2\.0'
[header-check] ==> Checking copyright headers <==
[header-check] Done checking copyright headers
```

Turns out that putting a regex into a normal string in Python has issues because sequences like `\d` that are intended for the regex engine are seen as invalid escape sequences by recent versions of Python. Fix is to use raw strings.