### PR TITLE
Add tutorial for creating deployment manifests

### DIFF
--- a/docs/hugo/content/tutorials/deployment_files.md
+++ b/docs/hugo/content/tutorials/deployment_files.md
@@ -1,0 +1,63 @@
+---
+title: Creating deployment manifests
+weight: 10
+type: docs
+---
+
+## Creating your own deployment files 
+
+Typially, a deployment of a specific type of Azure resource is its own CRD; you can tell what type of resource is deployed by looking at its `kind:`.
+
+The `spec:` field of the deployment file will typically be associated with the parameters you expect when creating the resource in Azure.
+
+### Example AKS Cluster
+
+Lets look at an AKS cluster as an example. The [latest sample](https://github.com/Azure/azure-service-operator/blob/main/v2/samples/containerservice/v1api20240901/v1api20240901_managedcluster.yaml) looks like so:
+
+```yaml
+apiVersion: containerservice.azure.com/v1api20240901
+kind: ManagedCluster
+metadata:
+  name: sample-managedcluster-20240901
+  namespace: default
+spec:
+  location: westus3
+  owner:
+    name: aso-sample-rg
+  dnsPrefix: aso
+  agentPoolProfiles:
+    - name: pool1
+      count: 1
+      vmSize: Standard_DS2_v2
+      osType: Linux
+      mode: System
+  identity:
+    type: SystemAssigned
+```
+
+If we wanted to specify our own deployment, we'd replace parameters as we typically fill in for creation in the CLI. Let's say I wanted to create `myAKSCluster` in `eastus`, for instance. It'd look like:
+
+```yaml
+apiVersion: containerservice.azure.com/v1api20240901
+kind: ManagedCluster
+metadata:
+  name: myAKSCluster
+  namespace: default
+spec:
+  location: eastus
+  owner:
+    name: <myResourceGroup>
+  dnsPrefix: aso
+  agentPoolProfiles:
+    - name: agentpool1
+      count: 1
+      vmSize: <my_vm_size>
+      osType: Linux
+      mode: System
+  identity:
+    type: SystemAssigned
+```
+
+## More Examples
+
+If you want to create your own deployment files, you can visit our [samples directory](https://github.com/Azure/azure-service-operator/tree/main/v2/samples) to see how different deployments are structured and alter the manifest according to your own specifications.


### PR DESCRIPTION
This document provides guidance on creating deployment manifests for Azure resources, including an example of an AKS cluster and instructions for customizing deployment files.


## What this PR does

Creates a new doc, `deployment_files.md` in "Tutorials" to showcase how users can create their own ASO deployment manifests for their desired resources.

<!--  

Here are some tips:

If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. 
Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.

Closes #[issue number]
-->

## How does this PR make you feel?

![gif](https://media.tenor.com/images/352d2ede7f4656431187642a0c85ed11/tenor.gif)

## Checklist

<!--
_Delete any that don't apply. For completed items, change [ ] to [x]._
-->

- [ ✅ ] this PR contains documentation
- [ ] this PR contains tests
- [ ✅ ] this PR contains YAML Samples
