### PR TITLE
Fix bug preventing resource reconciliation due to "Secret not cached"

### DIFF
--- a/v2/cmd/controller/app/setup.go
+++ b/v2/cmd/controller/app/setup.go
@@ -416,7 +416,6 @@ func initializeClients(cfg config.Values, mgr ctrl.Manager) (*clients, error) {
 
 	armClientCache := armreconciler.NewARMClientCache(
 		credentialProvider,
-		kubeClient,
 		cfg.Cloud(),
 		nil,
 		armMetrics)

--- a/v2/internal/reconcilers/arm/arm_client_cache.go
+++ b/v2/internal/reconcilers/arm/arm_client_cache.go
@@ -15,7 +15,6 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
 	"github.com/Azure/azure-service-operator/v2/internal/identity"
 	"github.com/Azure/azure-service-operator/v2/internal/metrics"
-	"github.com/Azure/azure-service-operator/v2/internal/util/kubeclient"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 )
 
@@ -26,14 +25,12 @@ type ARMClientCache struct {
 	clients            map[string]*armClient
 	cloudConfig        cloud.Configuration
 	credentialProvider identity.CredentialProvider
-	kubeClient         kubeclient.Client
 	httpClient         *http.Client
 	armMetrics         *metrics.ARMClientMetrics
 }
 
 func NewARMClientCache(
 	credentialProvider identity.CredentialProvider,
-	kubeClient kubeclient.Client,
 	configuration cloud.Configuration,
 	httpClient *http.Client,
 	armMetrics *metrics.ARMClientMetrics,
@@ -42,7 +39,6 @@ func NewARMClientCache(
 		lock:               sync.Mutex{},
 		clients:            make(map[string]*armClient),
 		cloudConfig:        configuration,
-		kubeClient:         kubeClient,
 		credentialProvider: credentialProvider,
 		httpClient:         httpClient,
 		armMetrics:         armMetrics,

--- a/v2/internal/reconcilers/arm/arm_client_cache_test.go
+++ b/v2/internal/reconcilers/arm/arm_client_cache_test.go
@@ -69,7 +69,7 @@ func NewTestARMClientCache(client kubeclient.Client) (*ARMClientCache, error) {
 		return nil, err
 	}
 
-	return NewARMClientCache(credentialProvider, client, cfg.Cloud(), nil, metrics.NewARMClientMetrics()), nil
+	return NewARMClientCache(credentialProvider, cfg.Cloud(), nil, metrics.NewARMClientMetrics()), nil
 }
 
 type testResources struct {
@@ -113,7 +113,7 @@ func Test_DefaultCredential_NotSet_ReturnsErrorWhenTryToUseGlobalCredential(t *t
 	g.Expect(err).To(BeNil())
 
 	providerWithNoDefaultCred := identity.NewCredentialProvider(nil, kubeClient, nil)
-	clientWithNoDefaultCred := NewARMClientCache(providerWithNoDefaultCred, kubeClient, cfg.Cloud(), nil, metrics.NewARMClientMetrics())
+	clientWithNoDefaultCred := NewARMClientCache(providerWithNoDefaultCred, cfg.Cloud(), nil, metrics.NewARMClientMetrics())
 
 	rg := newResourceGroup("")
 

--- a/v2/internal/reconcilers/generic/register.go
+++ b/v2/internal/reconcilers/generic/register.go
@@ -22,6 +22,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -98,6 +99,21 @@ func RegisterAll(
 				return eris.Wrapf(err, "failed to register indexer for %T, Key: %q", obj.Obj, indexer.Key)
 			}
 		}
+	}
+
+	// Start informer for secrets. Not all ASO resources have registered for events from secrets, but we always need the ability
+	// to read secrets as at the very least we need to check for the aso-credential secret at the root of the resource namespace.
+	// This ensures the cache is populated since ReaderFailOnMissingInformer is true.
+	secretGVK := schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "Secret",
+	}
+	mgr.GetLogger().V(Info).Info("Registering informer for type", "type", secretGVK.String())
+	// We don't need to block until synced, we just want to make sure the informer is going to start
+	_, err := mgr.GetCache().GetInformerForKind(context.Background(), secretGVK, cache.BlockUntilSynced(false))
+	if err != nil {
+		return eris.Wrapf(err, "failed to start informer for secrets")
 	}
 
 	var errs []error

--- a/v2/internal/testcommon/kube_test_context_envtest.go
+++ b/v2/internal/testcommon/kube_test_context_envtest.go
@@ -543,7 +543,6 @@ func createEnvtestContext() (BaseTestContextFactory, context.CancelFunc) {
 			// register resources needed by controller for namespace
 			armClientCache := arm.NewARMClientCache(
 				credentialProvider,
-				envtest.KubeClient,
 				cfg.Cloud(),
 				perTestContext.HTTPClient,
 				metrics.NewARMClientMetrics())


### PR DESCRIPTION
This was caused by PR #4857 setting ReaderFailOnMissingInformer. It happens only if the CRDs installed via crdPattern do not include a resource which requires a Secret informer.

This issue was missed in our testing because we generally run with a full (or close to full) set of CRDs installed, but the problem only appears with a minimal subset installed.

Fixes #4926.

## Checklist

- [ ] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
