### PR TITLE
Default reconcile policy if unconfigured

### DIFF
--- a/v2/internal/reconcilers/generic/generic_reconciler.go
+++ b/v2/internal/reconcilers/generic/generic_reconciler.go
@@ -408,7 +408,13 @@ func (gr *GenericReconciler) mergeReconcilePolicy(ctx context.Context, log logr.
 		source = "object" // used to track where the policy was taken from for logging purposes
 	}
 
-	reconcilePolicy, err := reconcilers.ParseReconcilePolicy(policyStr, gr.Config.DefaultReconcilePolicy)
+	// If no configured default policy, we set it to 'manage'
+	defaultReconcilePolicy := gr.Config.DefaultReconcilePolicy
+	if defaultReconcilePolicy == "" {
+		defaultReconcilePolicy = annotations.ReconcilePolicyManage
+	}
+
+	reconcilePolicy, err := reconcilers.ParseReconcilePolicy(policyStr, defaultReconcilePolicy)
 	if err != nil {
 		log.Error(
 			err,


### PR DESCRIPTION
## What this PR does

If we haven't configured the default reconcile policy for ASO, the value `""` is interpreted as _don't manage_ which isn't what we want.

### Special notes

Identified during re-record of existing tests.

## How does this PR make you feel?

![giphy.com](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExYTBiZWxqZGIyN214Z3I4MTdkMXNtODJkcWptdmczMzZ1bHhzcGgxZCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Qd9ZfVqCvEqKrVSQEu/giphy.gif)
