### PR TITLE
Update samples to use well known names for global role definitions

### DIFF
--- a/v2/samples/authorization/v1api20200801preview/v1api20200801preview_roleassignment.yaml
+++ b/v2/samples/authorization/v1api20200801preview/v1api20200801preview_roleassignment.yaml
@@ -14,6 +14,6 @@ spec:
     name: identity-settings
     key: principalId
   roleDefinitionReference:
-    # ASO allows you to specify global roles by name instead of the published GUID
-    wellKnownName: contributor
+    # ASO allows you to specify global roles by name instead of the published GUID. Lookup is case insensitive.
+    wellKnownName: Contributor
 

--- a/v2/samples/authorization/v1api20220401/v1api20220401_roleassignment.yaml
+++ b/v2/samples/authorization/v1api20220401/v1api20220401_roleassignment.yaml
@@ -14,5 +14,5 @@ spec:
     name: identity-settings
     key: principalId
   roleDefinitionReference:
-    # ASO allows you to specify global roles by name instead of the published GUID
-    wellKnownName: contributor
+    # ASO allows you to specify global roles by name instead of the published GUID. Lookup is case insensitive.
+    wellKnownName: Contributor

--- a/v2/samples/insights/v1api20240101preview/refs/v1api20220401_roleassignment.yaml
+++ b/v2/samples/insights/v1api20240101preview/refs/v1api20220401_roleassignment.yaml
@@ -12,5 +12,5 @@ spec:
     name: admin-settings
     key: principalId
   roleDefinitionReference:
-    # ASO allows you to specify global roles by name instead of the published GUID
+    # ASO allows you to specify global roles by name instead of the published GUID. Lookup is case insensitive.
     wellKnownName: contributor

--- a/v2/samples/redhatopenshift/v1api/refs/v1api20220401_roleassignment_from_rp_to_vnet.yaml
+++ b/v2/samples/redhatopenshift/v1api/refs/v1api20220401_roleassignment_from_rp_to_vnet.yaml
@@ -13,5 +13,5 @@ spec:
   # This can be fetched by using `az ad sp list --display-name "Azure Red Hat OpenShift RP" --query "[0].id" -o tsv` command
   principalId: 00000000-0000-0000-0000-000000000000
   roleDefinitionReference:
-    # ASO allows you to specify global roles by name instead of the published GUID
+    # ASO allows you to specify global roles by name instead of the published GUID. Lookup is case insensitive.
     wellKnownName: contributor

--- a/v2/samples/redhatopenshift/v1api/refs/v1api20220401_roleassignment_from_sp_to_vnet.yaml
+++ b/v2/samples/redhatopenshift/v1api/refs/v1api20220401_roleassignment_from_sp_to_vnet.yaml
@@ -12,5 +12,5 @@ spec:
   # This is the Principal ID of the AAD identity to which the role will be assigned
   principalId: 00000000-0000-0000-0000-000000000000
   roleDefinitionReference:
-    # ASO allows you to specify global roles by name instead of the published GUID
+    # ASO allows you to specify global roles by name instead of the published GUID. Lookup is case insensitive.
     wellKnownName: contributor


### PR DESCRIPTION
## What this PR does

Thanks to #4923, we can create `RoleAssignment` resources using global role definitions by using their _name_ instead of the published _guid_. This is a quality-of-life improvement for ASO users.

In this PR, we update our samples to demonstrate this feature.
 
## Checklist

- [x] this PR contains YAML Samples
