### PR TITLE
Cache configmaps 

### DIFF
--- a/v2/internal/reconcilers/generic/register.go
+++ b/v2/internal/reconcilers/generic/register.go
@@ -111,9 +111,21 @@ func RegisterAll(
 	}
 	mgr.GetLogger().V(Info).Info("Registering informer for type", "type", secretGVK.String())
 	// We don't need to block until synced, we just want to make sure the informer is going to start
-	_, err := mgr.GetCache().GetInformerForKind(context.Background(), secretGVK, cache.BlockUntilSynced(false))
-	if err != nil {
+	if _, err := mgr.GetCache().GetInformerForKind(context.Background(), secretGVK, cache.BlockUntilSynced(false)); err != nil {
 		return eris.Wrapf(err, "failed to start informer for secrets")
+	}
+
+	// Start informer for configmaps. Not all ASO resources have registered for events from configmaps, but we always need the ability
+	// to read configmaps. This ensures the cache is populated since ReaderFailOnMissingInformer is true.
+	configMapGVK := schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "ConfigMap",
+	}
+	mgr.GetLogger().V(Info).Info("Registering informer for type", "type", configMapGVK.String())
+	// We don't need to block until synced, we just want to make sure the informer is going to start
+	if _, err := mgr.GetCache().GetInformerForKind(context.Background(), configMapGVK, cache.BlockUntilSynced(false)); err != nil {
+		return eris.Wrapf(err, "failed to start informer for configmaps")
 	}
 
 	var errs []error


### PR DESCRIPTION
## What this PR does

When crd-pattern is empty (because ASO is not managing CRD installation), we can end up in a situation where there's no watcher for config maps, leading to errors.

This fix applies the same approach as used in #4966 for secrets.

May resolve #5079

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExYjVuZGVzOHdhNW5zNTZmYjBsYW1wYWFsZ2JzbXVkNGFsNGRydWsyYSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/GuWSJPF6bEkKs/giphy.gif)