### PR TITLE
Fix subtle startup bug

### DIFF
--- a/v2/cmd/controller/app/setup.go
+++ b/v2/cmd/controller/app/setup.go
@@ -214,7 +214,7 @@ func SetupControllerManager(ctx context.Context, setupLog logr.Logger, flgs *Fla
 			os.Exit(1)
 		}
 
-		if errs := generic.RegisterWebhooks(mgr, objs); errs != nil {
+		if err = generic.RegisterWebhooks(mgr, objs); err != nil {
 			setupLog.Error(err, "failed to register webhook for gvks")
 			os.Exit(1)
 		}


### PR DESCRIPTION
## What this PR does

An update to golangci-lint caught a subtle bug in our startup that would have resulted in a panic.

```
[controller:lint] v2/cmd/controller/app/setup.go:218:18: call function with a nil value error after check error (nilnesserr)
[controller:lint] 			setupLog.Error(err, "failed to register webhook for gvks")
```

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExam5vN3c5emhvcjF4M3c2ZmpwMncxcDZ4NWc4MTduaWd3dm40YWZtZiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/n8SkNR77udWlG/giphy.gif)