### PR TITLE
feat(chart): Enhance CRD pattern configuration to support list variable

### DIFF
--- a/docs/hugo/content/getting-started/_index.md
+++ b/docs/hugo/content/getting-started/_index.md
@@ -70,6 +70,16 @@ C:\> helm upgrade --install aso2 aso2/azure-service-operator ^
 {{% /tab %}}
 {{< /tabpane >}}
 
+If you are using a values file, you can set the `crdPattern` variable as follows:
+``` yaml
+crdPattern: 
+  - resources.azure.com/*
+  - containerservice.azure.com/*
+  - keyvault.azure.com/*
+  - managedidentity.azure.com/*
+  - eventhub.azure.com/*
+```
+
 {{% alert title="Warning" color="warning" %}}
 Make sure to set the `crdPattern` variable to include the CRDs you are interested in using.
 You can use `--set crdPattern=*` to install all the CRDs, but be aware of the

--- a/v2/charts/azure-service-operator/templates/apps_v1_deployment_azureserviceoperator-controller-manager.yaml
+++ b/v2/charts/azure-service-operator/templates/apps_v1_deployment_azureserviceoperator-controller-manager.yaml
@@ -60,7 +60,7 @@ spec:
         - --enable-leader-election
         - --v=2
         {{- if and (eq .Values.installCRDs true) (or (eq .Values.multitenant.enable false) (eq .Values.azureOperatorMode "webhooks")) }}
-        - --crd-pattern={{ .Values.crdPattern }}
+        - --crd-pattern={{ if kindIs "slice" .Values.crdPattern }}{{ join ";" .Values.crdPattern }}{{ else }}{{ .Values.crdPattern }}{{ end }}
         {{- end }}
         - --webhook-port={{ .Values.webhook.port }}
         {{- if or (eq .Values.multitenant.enable false) (eq .Values.azureOperatorMode "webhooks") }}

--- a/v2/charts/azure-service-operator/values.yaml
+++ b/v2/charts/azure-service-operator/values.yaml
@@ -122,7 +122,7 @@ metrics:
 # the operator will only reconcile that subset if those are the only CRDs it finds when the pod starts.
 installCRDs: true
 
-# crdPattern is a semicolon delimited string containing the CRD patterns for the operator to install.
+# crdPattern is a semicolon delimited string or a list of strings containing the CRD patterns for the operator to install.
 # Setting this has no effect if installCRDs is false.
 # This defines what new CRDs will be installed by ASO. Will always upgrade any existing CRDs even if no
 # crdPattern is defined. Leaving this field unspecified for a fresh install of ASO will result in the operator pod


### PR DESCRIPTION
## What this PR does
Improves the configuration flexibility for specifying CRD patterns in Azure Service Operator deployments. It allows users to define the `crdPattern` as either a semicolon-delimited string or a list of strings, making it easier to manage and document CRD selection.

## How does this PR make you feel?

![gif](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExenQ1aHZmbjVlYWdsd2JjbjB2MTA1ZmV3Y3cwaHJ4cTNvcWoyNXk5cSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/8lgqAbycBjosxjfi9k/giphy.gif)

## Checklist

- [x] this PR contains documentation
- [x] this PR contains YAML Samples
