### PR TITLE
Create resources in parallel

### DIFF
--- a/v2/internal/controllers/networking_virtualnetwork_20201101_test.go
+++ b/v2/internal/controllers/networking_virtualnetwork_20201101_test.go
@@ -95,8 +95,7 @@ func Test_Networking_Subnet_CreatedThenVNETUpdated_20201101_SubnetStillExists(t 
 		},
 	}
 
-	tc.CreateResourceAndWait(vnet)
-	tc.CreateResourceAndWait(subnet)
+	tc.CreateResourcesAndWait(vnet, subnet)
 	tc.Expect(subnet.Status.Id).ToNot(BeNil())
 	armId := *subnet.Status.Id
 

--- a/v2/internal/controllers/networking_virtualnetwork_20240301_test.go
+++ b/v2/internal/controllers/networking_virtualnetwork_20240301_test.go
@@ -95,8 +95,7 @@ func Test_Networking_Subnet_CreatedThenVNETUpdated_20240301_SubnetStillExists(t 
 		},
 	}
 
-	tc.CreateResourceAndWait(vnet)
-	tc.CreateResourceAndWait(subnet)
+	tc.CreateResourcesAndWait(vnet, subnet)
 	tc.Expect(subnet.Status.Id).ToNot(BeNil())
 	armId := *subnet.Status.Id
 

--- a/v2/internal/controllers/owner_arm_id_test.go
+++ b/v2/internal/controllers/owner_arm_id_test.go
@@ -64,7 +64,6 @@ func Test_OwnerIsARMIDOfParent_ChildResourceSuccessfullyReconciled(t *testing.T)
 
 	// Now create a storage account
 	acct := newStorageAccount20230101(tc, rg)
-	tc.CreateResourceAndWait(acct)
 
 	// and a blob service
 	blobService := &storage.StorageAccountsBlobService{
@@ -78,7 +77,7 @@ func Test_OwnerIsARMIDOfParent_ChildResourceSuccessfullyReconciled(t *testing.T)
 	// We can delete it from the cluster by applying this annotation, but this won't change anything in Azure.
 	tc.AddAnnotation(&blobService.ObjectMeta, "serviceoperator.azure.com/reconcile-policy", "detach-on-delete")
 
-	tc.CreateResourceAndWait(blobService)
+	tc.CreateResourcesAndWait(acct, blobService)
 
 	tc.Expect(blobService.Status.Id).ToNot(BeNil())
 	armID := *blobService.Status.Id

--- a/v2/internal/controllers/sql_server_crud_v20211101_test.go
+++ b/v2/internal/controllers/sql_server_crud_v20211101_test.go
@@ -187,10 +187,6 @@ func SQL_Server_VulnerabilityAssessments_CRUD(tc *testcommon.KubePerTestContext,
 	// We can delete it from the cluster by applying this annotation, but this won't change anything in Azure.
 	tc.AddAnnotation(&alertPolicy.ObjectMeta, "serviceoperator.azure.com/reconcile-policy", "detach-on-delete")
 
-	tc.CreateResourceAndWait(alertPolicy)
-
-	tc.Expect(alertPolicy.Status.Id).ToNot(BeNil())
-
 	secret := tc.GetSecret(storageDetails.secretName)
 	blobEndpoint := string(secret.Data[storageDetails.blobEndpointSecretKey])
 
@@ -210,8 +206,9 @@ func SQL_Server_VulnerabilityAssessments_CRUD(tc *testcommon.KubePerTestContext,
 		},
 	}
 
-	tc.CreateResourceAndWait(vulnerabilityAssessment)
+	tc.CreateResourcesAndWait(alertPolicy, vulnerabilityAssessment)
 
+	tc.Expect(alertPolicy.Status.Id).ToNot(BeNil())
 	tc.Expect(vulnerabilityAssessment.Status.Id).ToNot(BeNil())
 
 	tc.DeleteResourceAndWait(vulnerabilityAssessment)
@@ -511,10 +508,6 @@ func SQL_Database_VulnerabilityAssessment_CRUD(tc *testcommon.KubePerTestContext
 	// We can delete it from the cluster by applying this annotation, but this won't change anything in Azure.
 	tc.AddAnnotation(&securityAlertPolicy.ObjectMeta, "serviceoperator.azure.com/reconcile-policy", "detach-on-delete")
 
-	tc.CreateResourceAndWait(securityAlertPolicy)
-
-	tc.Expect(securityAlertPolicy.Status.Id).ToNot(BeNil())
-
 	secret := tc.GetSecret(storageDetails.secretName)
 	blobEndpoint := string(secret.Data[storageDetails.blobEndpointSecretKey])
 
@@ -534,8 +527,9 @@ func SQL_Database_VulnerabilityAssessment_CRUD(tc *testcommon.KubePerTestContext
 		},
 	}
 
-	tc.CreateResourceAndWait(vulnerabilityAssessment)
+	tc.CreateResourcesAndWait(securityAlertPolicy, vulnerabilityAssessment)
 
+	tc.Expect(securityAlertPolicy.Status.Id).ToNot(BeNil())
 	tc.Expect(vulnerabilityAssessment.Status.Id).ToNot(BeNil())
 
 	// This is an odd case - the DELETE is accepted by the service, but isn't actually honoured: the resource still exists after deletion

--- a/v2/test/mysql_test.go
+++ b/v2/test/mysql_test.go
@@ -38,10 +38,9 @@ func Test_MySQL_Combined(t *testing.T) {
 	tc.CreateResource(secret)
 
 	flexibleServer := newMySQLServer(tc, rg, adminUsername, adminPasswordKey, secret.Name)
-	tc.CreateResourceAndWait(flexibleServer)
-
 	firewallRule := newMySQLServerOpenFirewallRule(tc, flexibleServer)
-	tc.CreateResourceAndWait(firewallRule)
+
+	tc.CreateResourcesAndWait(flexibleServer, firewallRule)
 
 	tc.Expect(flexibleServer.Status.FullyQualifiedDomainName).ToNot(BeNil())
 	fqdn := *flexibleServer.Status.FullyQualifiedDomainName

--- a/v2/test/postgresql_test.go
+++ b/v2/test/postgresql_test.go
@@ -41,10 +41,9 @@ func Test_PostgreSQL_Combined(t *testing.T) {
 	tc.CreateResource(secret)
 
 	flexibleServer := newPostgreSQLServer(tc, rg, adminUsername, adminPasswordKey, secret.Name)
-	tc.CreateResourceAndWait(flexibleServer)
-
 	firewallRule := newPostgreSQLServerOpenFirewallRule(tc, flexibleServer)
-	tc.CreateResourceAndWait(firewallRule)
+
+	tc.CreateResourcesAndWait(flexibleServer, firewallRule)
 
 	tc.Expect(flexibleServer.Status.FullyQualifiedDomainName).ToNot(BeNil())
 	fqdn := *flexibleServer.Status.FullyQualifiedDomainName


### PR DESCRIPTION
## What this PR does

Modifies a few of our coded tests to create resources in parallel instead of series. This extends the test coverage to also check whether ASO properly manages dependencies between resources. 

Followup to #5107 

Some tests (e.g. `Test_MachineLearning_Workspaces_CRUD`) don't pass when this change is made, those will be handled separately. Details are in #5105.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExYWJwcHRvZnZjbmNpcno2bXd2bG9pcng1MjYwdWhzbnVqODJicHZjbCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Ala8Pjo4RN9kY/giphy.gif)
