### PR TITLE
Update some astmodel tests to new style

### DIFF
--- a/v2/tools/generator/internal/astmodel/local_package_reference_test.go
+++ b/v2/tools/generator/internal/astmodel/local_package_reference_test.go
@@ -24,20 +24,35 @@ func makeTestLocalPackageReference(group string, version string) LocalPackageRef
 func TestMakeLocalPackageReference_GivenGroupAndPackage_ReturnsInstanceWithProperties(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
-		name       string
+	cases := map[string]struct {
 		group      string
 		apiVersion string
 		pkg        string
 	}{
-		{"Networking", "network", "2020-09-01", "v20200901"},
-		{"Batch (new)", "batch", "2020-09-01", "v20200901"},
-		{"Batch (old)", "batch", "2015-01-01", "v20150101"},
-		{"Networking Frontdoor", "network.frontdoor", "2020-09-01", "v20200901"},
+		"Networking": {
+			group:      "network",
+			apiVersion: "2020-09-01",
+			pkg:        "v20200901",
+		},
+		"Batch (new)": {
+			group:      "batch",
+			apiVersion: "2020-09-01",
+			pkg:        "v20200901",
+		},
+		"Batch (old)": {
+			group:      "batch",
+			apiVersion: "2015-01-01",
+			pkg:        "v20150101",
+		},
+		"Networking Frontdoor": {
+			group:      "network.frontdoor",
+			apiVersion: "2020-09-01",
+			pkg:        "v20200901",
+		},
 	}
-	for _, c := range cases {
-		c := c
-		t.Run(c.name, func(t *testing.T) {
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
@@ -52,50 +67,45 @@ func TestMakeLocalPackageReference_GivenGroupAndPackage_ReturnsInstanceWithPrope
 func TestLocalPackageReferences_ReturnExpectedProperties(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
-		name        string
+	cases := map[string]struct {
 		group       string
 		version     string
 		pkg         string
 		packagePath string
 		folderPath  string
 	}{
-		{
-			"Network",
-			"network",
-			"2020-09-01",
-			"v20200901",
-			"github.com/Azure/azure-service-operator/v2/api/network/v20200901",
-			"network/v20200901",
+		"Network": {
+			group:       "network",
+			version:     "2020-09-01",
+			pkg:         "v20200901",
+			packagePath: "github.com/Azure/azure-service-operator/v2/api/network/v20200901",
+			folderPath:  "network/v20200901",
 		},
-		{
-			"Batch (new)",
-			"batch",
-			"2020-09-01",
-			"v20200901",
-			"github.com/Azure/azure-service-operator/v2/api/batch/v20200901",
-			"batch/v20200901",
+		"Batch (new)": {
+			group:       "batch",
+			version:     "2020-09-01",
+			pkg:         "v20200901",
+			packagePath: "github.com/Azure/azure-service-operator/v2/api/batch/v20200901",
+			folderPath:  "batch/v20200901",
 		},
-		{
-			"Batch (old)",
-			"batch",
-			"2015-01-01",
-			"v20150101",
-			"github.com/Azure/azure-service-operator/v2/api/batch/v20150101",
-			"batch/v20150101",
+		"Batch (old)": {
+			group:       "batch",
+			version:     "2015-01-01",
+			pkg:         "v20150101",
+			packagePath: "github.com/Azure/azure-service-operator/v2/api/batch/v20150101",
+			folderPath:  "batch/v20150101",
 		},
-		{
-			"Network Frontdoor",
-			"network.frontdoor",
-			"2020-09-01",
-			"v20200901",
-			"github.com/Azure/azure-service-operator/v2/api/network.frontdoor/v20200901",
-			"network.frontdoor/v20200901",
+		"Network Frontdoor": {
+			group:       "network.frontdoor",
+			version:     "2020-09-01",
+			pkg:         "v20200901",
+			packagePath: "github.com/Azure/azure-service-operator/v2/api/network.frontdoor/v20200901",
+			folderPath:  "network.frontdoor/v20200901",
 		},
 	}
-	for _, c := range cases {
-		c := c
-		t.Run(c.name, func(t *testing.T) {
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
@@ -117,25 +127,55 @@ func TestLocalPackageReferences_Equals_GivesExpectedResults(t *testing.T) {
 	networkRef := makeTestLocalPackageReference("network", "v20200901")
 	fmtRef := MakeExternalPackageReference("fmt")
 
-	cases := []struct {
-		name     string
+	cases := map[string]struct {
 		this     LocalPackageReference
 		other    PackageReference
 		areEqual bool
 	}{
-		{"Equal self", batchRef, batchRef, true},
-		{"Equal self", olderRef, olderRef, true},
-		{"Not equal other library name", batchRef, networkRef, false},
-		{"Not equal other library name", networkRef, batchRef, false},
-		{"Not equal other library version", batchRef, olderRef, false},
-		{"Not equal other library version", olderRef, batchRef, false},
-		{"Not equal other kind", batchRef, fmtRef, false},
-		{"Not equal other kind", networkRef, fmtRef, false},
+		"Equal self (batch)": {
+			this:     batchRef,
+			other:    batchRef,
+			areEqual: true,
+		},
+		"Equal self (older)": {
+			this:     olderRef,
+			other:    olderRef,
+			areEqual: true,
+		},
+		"Not equal other library name (batch vs network)": {
+			this:     batchRef,
+			other:    networkRef,
+			areEqual: false,
+		},
+		"Not equal other library name (network vs batch)": {
+			this:     networkRef,
+			other:    batchRef,
+			areEqual: false,
+		},
+		"Not equal other library version (batch vs older)": {
+			this:     batchRef,
+			other:    olderRef,
+			areEqual: false,
+		},
+		"Not equal other library version (older vs batch)": {
+			this:     olderRef,
+			other:    batchRef,
+			areEqual: false,
+		},
+		"Not equal other kind (batch vs fmt)": {
+			this:     batchRef,
+			other:    fmtRef,
+			areEqual: false,
+		},
+		"Not equal other kind (network vs fmt)": {
+			this:     networkRef,
+			other:    fmtRef,
+			areEqual: false,
+		},
 	}
 
-	for _, c := range cases {
-		c := c
-		t.Run(c.name, func(t *testing.T) {
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
@@ -148,21 +188,34 @@ func TestLocalPackageReferences_Equals_GivesExpectedResults(t *testing.T) {
 func TestLocalPackageReferenceIsPreview(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
-		name      string
+	cases := map[string]struct {
 		version   string
 		isPreview bool
 	}{
-		{"GA Release is not preview", "v20200901", false},
-		{"Preview release is preview", "v20200901preview", true},
-		{"Preview rerelease is preview", "v20200901preview2", true},
-		{"Alpha release is preview", "v20200901alpha", true},
-		{"Beta release is preview", "v20200901beta", true},
+		"GA Release is not preview": {
+			version:   "v20200901",
+			isPreview: false,
+		},
+		"Preview release is preview": {
+			version:   "v20200901preview",
+			isPreview: true,
+		},
+		"Preview rerelease is preview": {
+			version:   "v20200901preview2",
+			isPreview: true,
+		},
+		"Alpha release is preview": {
+			version:   "v20200901alpha",
+			isPreview: true,
+		},
+		"Beta release is preview": {
+			version:   "v20200901beta",
+			isPreview: true,
+		},
 	}
 
-	for _, c := range cases {
-		c := c
-		t.Run(c.name, func(t *testing.T) {
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 

--- a/v2/tools/generator/internal/astmodel/package_reference_test.go
+++ b/v2/tools/generator/internal/astmodel/package_reference_test.go
@@ -32,78 +32,146 @@ func TestSortPackageReferencesByPathAndVersion(t *testing.T) {
 func TestComparePackageReferencesByPathAndVersion(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
-		name     string
+	cases := map[string]struct {
 		left     string
 		right    string
 		expected int
 	}{
 		// Equality tests
-		{"grobo v1 is equal to self", "grobo/v1", "grobo/v1", 0},
-		{"grobo v2 is equal to self", "grobo/v2", "grobo/v2", 0},
+		"grobo v1 is equal to self": {
+			left:     "grobo/v1",
+			right:    "grobo/v1",
+			expected: 0,
+		},
+		"grobo v2 is equal to self": {
+			left:     "grobo/v2",
+			right:    "grobo/v2",
+			expected: 0,
+		},
 		// Different length tests
-		{"Shorter is less than longer", "abc", "abcdef", -1},
-		{"Longer is not less than shorter", "abcdef", "abc", 1},
+		"Shorter is less than longer": {
+			left:     "abc",
+			right:    "abcdef",
+			expected: -1,
+		},
+		"Longer is not less than shorter": {
+			left:     "abcdef",
+			right:    "abc",
+			expected: 1,
+		},
 		// Numeric tests
-		{"Number equal to self", "42", "42", 0},
-		{"grobo v1 is less than grobo v2", "grobo/v1", "grobo/v2", -1},
-		{"grobo v2 is not less than grobo v1", "grobo/v2", "grobo/v1", 1},
+		"Number equal to self": {
+			left:     "42",
+			right:    "42",
+			expected: 0,
+		},
+		"grobo v1 is less than grobo v2": {
+			left:     "grobo/v1",
+			right:    "grobo/v2",
+			expected: -1,
+		},
+		"grobo v2 is not less than grobo v1": {
+			left:     "grobo/v2",
+			right:    "grobo/v1",
+			expected: 1,
+		},
 		// Prerelease tests
-		{"Alpha comes before beta", "1alpha", "1beta", -1},
-		{"Alpha comes before aardvark", "1alpha", "1aardvark", -1},
-		{"Alpha comes before GA", "1alpha", "1", -1},
-		{"Beta comes before preview", "1beta", "1preview", -1},
-		{"Beta comes before baboon", "1beta", "1baboon", -1},
-		{"Beta comes before GA", "1beta", "1", -1},
-		{"Preview comes before storage", "1preview", "1storage", -1},
-		{"Preview comes before grape", "1preview", "1grape", -1},
-		{"Preview comes before GA", "1preview", "1", -1},
+		"Alpha comes before beta": {
+			left:     "1alpha",
+			right:    "1beta",
+			expected: -1,
+		},
+		"Alpha comes before aardvark": {
+			left:     "1alpha",
+			right:    "1aardvark",
+			expected: -1,
+		},
+		"Alpha comes before GA": {
+			left:     "1alpha",
+			right:    "1",
+			expected: -1,
+		},
+		"Beta comes before preview": {
+			left:     "1beta",
+			right:    "1preview",
+			expected: -1,
+		},
+		"Beta comes before baboon": {
+			left:     "1beta",
+			right:    "1baboon",
+			expected: -1,
+		},
+		"Beta comes before GA": {
+			left:     "1beta",
+			right:    "1",
+			expected: -1,
+		},
+		"Preview comes before storage": {
+			left:     "1preview",
+			right:    "1storage",
+			expected: -1,
+		},
+		"Preview comes before grape": {
+			left:     "1preview",
+			right:    "1grape",
+			expected: -1,
+		},
+		"Preview comes before GA": {
+			left:     "1preview",
+			right:    "1",
+			expected: -1,
+		},
 		// Version tests
-		{"v2.0.0 comes before v2.1.0", "v2.0.0", "v2.1.0", -1},
-		{"v2.1.0 comes before v2.9.0", "v2.1.0", "v2.9.0", -1},
-		{"v2.9.0 comes before v2.10.0", "v2.9.0", "v2.10.0", -1},
+		"v2.0.0 comes before v2.1.0": {
+			left:     "v2.0.0",
+			right:    "v2.1.0",
+			expected: -1,
+		},
+		"v2.1.0 comes before v2.9.0": {
+			left:     "v2.1.0",
+			right:    "v2.9.0",
+			expected: -1,
+		},
+		"v2.9.0 comes before v2.10.0": {
+			left:     "v2.9.0",
+			right:    "v2.10.0",
+			expected: -1,
+		},
 		// Consistency tests, based on observed weirdness
-		{
-			"Storage subpackage comes after base",
-			"github.com/Azure/azure-service-operator/testing/person/v20200101",
-			"github.com/Azure/azure-service-operator/testing/person/v20200101/storage",
-			-1,
+		"Storage subpackage comes after base": {
+			left:     "github.com/Azure/azure-service-operator/testing/person/v20200101",
+			right:    "github.com/Azure/azure-service-operator/testing/person/v20200101/storage",
+			expected: -1,
 		},
-		{
-			"Storage subpackage comes after base, reversed",
-			"github.com/Azure/azure-service-operator/testing/person/v20200101/storage",
-			"github.com/Azure/azure-service-operator/testing/person/v20200101",
-			1,
+		"Storage subpackage comes after base, reversed": {
+			left:     "github.com/Azure/azure-service-operator/testing/person/v20200101/storage",
+			right:    "github.com/Azure/azure-service-operator/testing/person/v20200101",
+			expected: 1,
 		},
-		{
-			"Storage subpackage comes after preview base",
-			"github.com/Azure/azure-service-operator/testing/person/v20211231preview",
-			"github.com/Azure/azure-service-operator/testing/person/v20211231preview/storage",
-			-1,
+		"Storage subpackage comes after preview base": {
+			left:     "github.com/Azure/azure-service-operator/testing/person/v20211231preview",
+			right:    "github.com/Azure/azure-service-operator/testing/person/v20211231preview/storage",
+			expected: -1,
 		},
-		{
-			"Storage subpackage comes after preview base, reversed",
-			"github.com/Azure/azure-service-operator/testing/person/v20211231preview/storage",
-			"github.com/Azure/azure-service-operator/testing/person/v20211231preview",
-			1,
+		"Storage subpackage comes after preview base, reversed": {
+			left:     "github.com/Azure/azure-service-operator/testing/person/v20211231preview/storage",
+			right:    "github.com/Azure/azure-service-operator/testing/person/v20211231preview",
+			expected: 1,
 		},
-		{
-			"Storage subpackage of non-preview comes after preview base",
-			"github.com/Azure/azure-service-operator/testing/person/v20211231/storage",
-			"github.com/Azure/azure-service-operator/testing/person/v20211231preview",
-			1,
+		"Storage subpackage of non-preview comes after preview base": {
+			left:     "github.com/Azure/azure-service-operator/testing/person/v20211231/storage",
+			right:    "github.com/Azure/azure-service-operator/testing/person/v20211231preview",
+			expected: 1,
 		},
-		{
-			"Storage subpackage of non-preview comes after preview base, reversed",
-			"github.com/Azure/azure-service-operator/testing/person/v20211231preview",
-			"github.com/Azure/azure-service-operator/testing/person/v20211231/storage",
-			-1,
+		"Storage subpackage of non-preview comes after preview base, reversed": {
+			left:     "github.com/Azure/azure-service-operator/testing/person/v20211231preview",
+			right:    "github.com/Azure/azure-service-operator/testing/person/v20211231/storage",
+			expected: -1,
 		},
 	}
 
-	for _, c := range cases {
-		c := c
-		t.Run(c.name, func(t *testing.T) {
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
@@ -120,24 +188,50 @@ func TestComparePackageReferencesByPathAndVersion(t *testing.T) {
 func TestVersionComparerCompareNumeric(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
-		name     string
+	cases := map[string]struct {
 		left     string
 		right    string
 		expected int
 	}{
-		{"Number equal to self", "42", "42", 0},
-		{"Leading zeros on left-hand value don't matter", "042", "42", 0},
-		{"Leading zeros on right-hand value don't matter", "42", "042", 0},
-		{"Longer numbers are greater", "142", "42", 1},
-		{"Shorter numbers are lesser", "42", "942", -1},
-		{"Really really long equal numbers are equal", "1099511627776", "1099511627776", 0},
-		{"Really really long non-equal numbers are comparable", "10995116277763", "10995116277769", -1},
+		"Number equal to self": {
+			left:     "42",
+			right:    "42",
+			expected: 0,
+		},
+		"Leading zeros on left-hand value don't matter": {
+			left:     "042",
+			right:    "42",
+			expected: 0,
+		},
+		"Leading zeros on right-hand value don't matter": {
+			left:     "42",
+			right:    "042",
+			expected: 0,
+		},
+		"Longer numbers are greater": {
+			left:     "142",
+			right:    "42",
+			expected: 1,
+		},
+		"Shorter numbers are lesser": {
+			left:     "42",
+			right:    "942",
+			expected: -1,
+		},
+		"Really really long equal numbers are equal": {
+			left:     "1099511627776",
+			right:    "1099511627776",
+			expected: 0,
+		},
+		"Really really long non-equal numbers are comparable": {
+			left:     "10995116277763",
+			right:    "10995116277769",
+			expected: -1,
+		},
 	}
 
-	for _, c := range cases {
-		c := c
-		t.Run(c.name, func(t *testing.T) {
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
@@ -154,20 +248,30 @@ func TestVersionComparerCompareNumeric(t *testing.T) {
 func TestContainsPreviewVersionLabel(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
-		name     string
+	cases := map[string]struct {
 		version  string
 		expected bool
 	}{
-		{"Non-preview", "v20200201", false},
-		{"Alpha", "v20200201alpha", true},
-		{"Beta", "v20200201beta", true},
-		{"Preview", "v20200201preview", true},
+		"Non-preview": {
+			version:  "v20200201",
+			expected: false,
+		},
+		"Alpha": {
+			version:  "v20200201alpha",
+			expected: true,
+		},
+		"Beta": {
+			version:  "v20200201beta",
+			expected: true,
+		},
+		"Preview": {
+			version:  "v20200201preview",
+			expected: true,
+		},
 	}
 
-	for _, c := range cases {
-		c := c
-		t.Run(c.name, func(t *testing.T) {
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 

--- a/v2/tools/generator/internal/astmodel/storage_package_reference_test.go
+++ b/v2/tools/generator/internal/astmodel/storage_package_reference_test.go
@@ -14,18 +14,25 @@ import (
 func TestMakeStoragePackageReference(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
+	cases := map[string]struct {
 		group           string
 		version         string
 		expectedVersion string
 	}{
-		{"group", "1", "storage"},
-		{"microsoft.network", "2018-05-01", "storage"},
+		"group": {
+			group:           "group",
+			version:         "1",
+			expectedVersion: "storage",
+		},
+		"microsoft.network": {
+			group:           "microsoft.network",
+			version:         "2018-05-01",
+			expectedVersion: "storage",
+		},
 	}
 
-	for _, c := range cases {
-		c := c
-		t.Run(c.group, func(t *testing.T) {
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
@@ -45,21 +52,35 @@ func TestStoragePackageReferenceEquals(t *testing.T) {
 	storageRef := MakeStoragePackageReference(localRef)
 	otherRef := MakeStoragePackageReference(localRef)
 
-	cases := []struct {
-		name          string
+	cases := map[string]struct {
 		storageRef    InternalPackageReference
 		otherRef      InternalPackageReference
 		expectedEqual bool
 	}{
-		{"Equal to self", storageRef, storageRef, true},
-		{"Equal to other", storageRef, otherRef, true},
-		{"Equal to other (reversed)", otherRef, storageRef, true},
-		{"Not equal to local", storageRef, localRef, false},
+		"Equal to self": {
+			storageRef:    storageRef,
+			otherRef:      storageRef,
+			expectedEqual: true,
+		},
+		"Equal to other": {
+			storageRef:    storageRef,
+			otherRef:      otherRef,
+			expectedEqual: true,
+		},
+		"Equal to other (reversed)": {
+			storageRef:    otherRef,
+			otherRef:      storageRef,
+			expectedEqual: true,
+		},
+		"Not equal to local": {
+			storageRef:    storageRef,
+			otherRef:      localRef,
+			expectedEqual: false,
+		},
 	}
 
-	for _, c := range cases {
-		c := c
-		t.Run(c.name, func(t *testing.T) {
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
@@ -73,21 +94,34 @@ func TestStoragePackageReferenceEquals(t *testing.T) {
 func TestStoragePackageReferenceIsPreview(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
-		name      string
+	cases := map[string]struct {
 		version   string
 		isPreview bool
 	}{
-		{"GA storage Release is not preview", "v20200901", false},
-		{"Preview storage release is preview", "v20200901preview", true},
-		{"Preview storage re-release is preview", "v20200901preview2", true},
-		{"Alpha storage release is preview", "v20200901alpha", true},
-		{"Beta storage release is preview", "v20200901betas", true},
+		"GA storage Release is not preview": {
+			version:   "v20200901",
+			isPreview: false,
+		},
+		"Preview storage release is preview": {
+			version:   "v20200901preview",
+			isPreview: true,
+		},
+		"Preview storage re-release is preview": {
+			version:   "v20200901preview2",
+			isPreview: true,
+		},
+		"Alpha storage release is preview": {
+			version:   "v20200901alpha",
+			isPreview: true,
+		},
+		"Beta storage release is preview": {
+			version:   "v20200901betas",
+			isPreview: true,
+		},
 	}
 
-	for _, c := range cases {
-		c := c
-		t.Run(c.name, func(t *testing.T) {
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 

--- a/v2/tools/generator/internal/astmodel/sub_package_reference_test.go
+++ b/v2/tools/generator/internal/astmodel/sub_package_reference_test.go
@@ -17,29 +17,28 @@ func Test_NewSubPackageReference_GivenParentAndName_ReturnsExpectedProperties(t 
 	parent := makeTestLocalPackageReference("group", "version")
 	batch := makeTestLocalPackageReference("microsoft.batch", "2020-09-01")
 
-	cases := []struct {
+	cases := map[string]struct {
 		name                string
 		parent              InternalPackageReference
 		expectedPackageName string
 		expectedPackagePath string
 	}{
-		{
-			"simple",
-			parent,
-			"simple",
-			"github.com/Azure/azure-service-operator/v2/api/group/version/simple",
+		"simple parent returns expected package path": {
+			name:                "simple",
+			parent:              parent,
+			expectedPackageName: "simple",
+			expectedPackagePath: "github.com/Azure/azure-service-operator/v2/api/group/version/simple",
 		},
-		{
-			"sub",
-			batch,
-			"sub",
-			"github.com/Azure/azure-service-operator/v2/api/microsoft.batch/v20200901/sub",
+		"versioned parent returns expected package path": {
+			name:                "sub",
+			parent:              batch,
+			expectedPackageName: "sub",
+			expectedPackagePath: "github.com/Azure/azure-service-operator/v2/api/microsoft.batch/v20200901/sub",
 		},
 	}
 
-	for _, c := range cases {
-		c := c
-		t.Run(c.name, func(t *testing.T) {
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
@@ -59,33 +58,28 @@ func Test_SubPackageReference_GivenParent_InheritsParentsProperties(t *testing.T
 	network := makeTestLocalPackageReference("microsoft.network", "2023-07-01")
 	networkPreview := makeTestLocalPackageReference("microsoft.network", "2023-07-01-preview")
 
-	cases := []struct {
-		name      string
+	cases := map[string]struct {
 		parent    InternalPackageReference
 		group     string
 		version   string
 		isPreview bool
 	}{
-		{
-			"Network",
-			network,
-			"microsoft.network",
-			"v20230701",
-			false,
+		"GA parent is not preview": {
+			parent:    network,
+			group:     "microsoft.network",
+			version:   "v20230701",
+			isPreview: false,
 		},
-		{
-			"NetworkPreview",
-			networkPreview,
-			"microsoft.network",
-			"v20230701preview",
-			true,
+		"preview parent is preview": {
+			parent:    networkPreview,
+			group:     "microsoft.network",
+			version:   "v20230701preview",
+			isPreview: true,
 		},
 	}
 
-	for _, c := range cases {
-		c := c
-
-		t.Run(c.name, func(t *testing.T) {
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 


### PR DESCRIPTION
## What this PR does

Since starting ASO, we've evolved our style for table tests to use `map[string]struct{}` as that's clearer. This AI assisted PR changes a few of our tests in the astmodel package to the new style.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExOGloYW56dm5scWR0NXc5bWo3endzampiMHQxZ3RwcHpwOXM4MHg1ZiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/eoVusT7Pi9ODe/giphy.gif)

## Checklist

- [x] this PR contains tests

