### PR TITLE
Fix formatting of User Assigned Identity Credentials link

### DIFF
--- a/docs/hugo/content/guide/authentication/_index.md
+++ b/docs/hugo/content/guide/authentication/_index.md
@@ -18,7 +18,7 @@ Azure Service Operator supports five different styles of authentication today.
 2. [Service Principal using a Client Secret]( {{< relref "credential-format#service-principal-using-a-client-secret" >}} )
 3. [Service Principal using a Client Certificate]( {{< relref "credential-format#service-principal-using-a-client-certificate" >}} )
 4. [Deprecated] [aad-pod-identity authentication (Managed Identity)]( {{< relref "credential-format#deprecated-managed-identity-aad-pod-identity" >}} )
-5. [User Assigned Identity Credentials] ( {{< relref "credential-format#user-assigned-identity-credentials" >}} )
+5. [User Assigned Identity Credentials]( {{< relref "credential-format#user-assigned-identity-credentials" >}} )
 
 ## Credential scope
 


### PR DESCRIPTION
## What this PR does

<img width="716" height="106" alt="image" src="https://github.com/user-attachments/assets/7db72412-331c-4ab8-9b43-270f705f127b" />

This link is broken in the public doc side

<!--  

Here are some tips:

If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. 
Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.

Closes #[issue number]
-->

<!--
### Special notes

_If there's anything complex or unusual about this PR that would help us review it, let us know here. Otherwise delete this section._
-->

## How does this PR make you feel?

![gif](https://giphy.com/)

## Checklist

<!--
_Delete any that don't apply. For completed items, change [ ] to [x]._
-->

- [x] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
