### PR TITLE
Avoid crash if no tests included in output

### DIFF
--- a/v2/tools/mangle-test-json/main.go
+++ b/v2/tools/mangle-test-json/main.go
@@ -290,6 +290,11 @@ func printSlowTests(byPackage map[string][]TestRun) {
 		allTests = append(allTests, v[1:]...)
 	}
 
+	if len(allTests) == 0 {
+		fmt.Println("No tests found.")
+		return
+	}
+
 	sort.Slice(allTests, func(i, j int) bool {
 		return allTests[i].RunTime > allTests[j].RunTime
 	})


### PR DESCRIPTION
## What this PR does

Discovered while looking at the CI builds for #5130, our test reporting tool (`mangle-json`) crashes if no tests are present in the summary - this happens if something causes major build failures.

Adds a guard clause to prevent the crash.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExa2Y5Y2N2cnk5ejloeTRtYXBqM3hqYnFhZDJyN2lyY3B0aTR2cmRjMSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3osxY5pSBcc9ZfWN20/giphy.gif)
