### PR TITLE
Remove usage of NewDefaultAzureCredential

### DIFF
--- a/v2/internal/identity/credential_provider.go
+++ b/v2/internal/identity/credential_provider.go
@@ -68,6 +68,8 @@ func (c *Credential) AdditionalTenants() []string {
 	return c.additionalTenants
 }
 
+// NewDefaultCredential creates a Credential representing the default/global credential
+// from aso-controller-settings.
 func NewDefaultCredential(
 	tokenCred azcore.TokenCredential,
 	namespace string,


### PR DESCRIPTION
Replaced with NewChainedTokenCredential and a more limited set of credentials.

For the ASO controller, this shouldn't have any impact on actual users, as we're still supporting the same authentication options that we supported before. The options that were removed were:
* NewWorkloadIdentityCredential - but we already take care of this up above via cfg.UseWorkloadIdentityAuth, and the workload identity option via DefaultCredential never worked because we don't set the AZURE_FEDERATED_TOKEN_FILE env variable.
* NewAzureCLICredential - which is obviously not recommended for running in production due to the need to constantly refresh the credentials, and we never supported as there is no way to mount the CLI credentials file into the pod.
* NewAzureDeveloperCLICredential - Same as above.
* NewAzurePowerShellCredential - Same as above.

For asoctl, there is a slight change in that we now do not support:
* NewAzureDeveloperCLICredential
* NewAzurePowerShellCredential

The correct way is to use Azure CLI credentials.


## Checklist

<!--
_Delete any that don't apply. For completed items, change [ ] to [x]._
-->

- [ ] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
