### PR TITLE
Add blog post creation instructions for new releases

### DIFF
--- a/docs/hugo/content/contributing/create-a-new-release.md
+++ b/docs/hugo/content/contributing/create-a-new-release.md
@@ -171,7 +171,7 @@ If you earlier [catalogued breaking changes](#catalog-breaking-changes), or if t
 
 ## Create a blog post
 
-Publish a new blog post under `docs/hugo/content/blogs` covering changes in the new release. Publish the blog post alongside the corresponding ASO release.
+Publish a new blog post under `docs/hugo/content/blogs` covering changes in the new release. Aim to publish the blog post alongside the corresponding ASO version's release date.
 
 Sections to cover:
 


### PR DESCRIPTION
## What this PR does

This PR augments the [release instructions](https://github.com/Azure/azure-service-operator/blob/8398607e1f1cb1bf0beee4c6adeb13b5d9c70ad5/docs/hugo/content/contributing/create-a-new-release.md#L4) to include a step directing folks to create a new blog post alongside releases.

## How does this PR make you feel?

![gif](https://media1.tenor.com/m/T5M0K0SmjTkAAAAC/penguins-of-madagascar-skipper.gif)

## Checklist

- [X] this PR contains documentation
