### PR TITLE
Fix devcontainer image caching

### DIFF
--- a/.github/workflows/build-devcontainer-image.yml
+++ b/.github/workflows/build-devcontainer-image.yml
@@ -43,8 +43,8 @@ jobs:
         with:
           context: .devcontainer
           push: true
-          # Build an image usable as cache-from, per: https://docs.docker.com/engine/reference/commandline/build/#specifying-external-cache-sources
-          build-args: BUILDKIT_INLINE_CACHE=1
+          # Embed inline cache metadata so consumers can use --cache-from
+          cache-to: type=inline
           tags: |
             docker.pkg.github.com/azure/azure-service-operator/aso-devcontainer:latest
             docker.pkg.github.com/azure/azure-service-operator/aso-devcontainer:${{ github.sha }}


### PR DESCRIPTION
## What this PR does

The devcontainer image wasn't being cached properly in PR validation workflows, causing [install-dependencies.sh](vscode-file://vscode-app/c:/Users/bearps/AppData/Local/Programs/Microsoft%20VS%20Code/bdd88df003/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to run every time (~3+ minutes).

Problem: The "Build Devcontainer image" workflow uses docker/build-push-action@v6, which defaults to Buildx. It was configured with build-args: BUILDKIT_INLINE_CACHE=1, which is the legacy Docker approach for embedding cache metadata. Buildx ignores this build-arg and requires cache-to: type=inline instead. Without proper cache metadata, the PR validation workflows couldn't match layers when using --cache-from.

Fix: Replace build-args: BUILDKIT_INLINE_CACHE=1 with cache-to: type=inline so Buildx correctly embeds the cache metadata into the pushed image.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExOWhwNmg5OHYwMzc5b2JnbnRjbzQ1cjlmb3pxaXo1cHg3eHh0NmhlaSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Lk023zZqHJ3Zz4rxtV/giphy.gif)