### PR TITLE
Remove very old prerelease warning

### DIFF
--- a/docs/hugo/content/reference/_index.md
+++ b/docs/hugo/content/reference/_index.md
@@ -928,8 +928,6 @@ These resource(s) are available for use in the current release of ASO. Different
 
 To install the CRDs for these resources, your ASO configuration must include `search.azure.com/*` as one of the configured CRD patterns. See [CRD Management in ASO](https://azure.github.io/azure-service-operator/guide/crd-management/) for details on doing this for both [Helm](https://azure.github.io/azure-service-operator/guide/crd-management/#helm) and [YAML](https://azure.github.io/azure-service-operator/guide/crd-management/#yaml) based installations.
 
-The `authOptions` and `operatorSpec` properties on [`SearchService`](https://azure.github.io/azure-service-operator/reference/search/v1api20220901/#search.azure.com/v1api20220901.SearchService) are not supported in ASO v2.1.0; they'll be included in the next release.
-
 ### Latest Released Versions
 
 These resource(s) are the latest versions available for use in the current release of ASO. Different versions of a given resource reflect different versions of the Azure ARM API.

--- a/docs/hugo/content/reference/search/_index.md
+++ b/docs/hugo/content/reference/search/_index.md
@@ -5,8 +5,6 @@ no_list: true
 ---
 To install the CRDs for these resources, your ASO configuration must include `search.azure.com/*` as one of the configured CRD patterns. See [CRD Management in ASO](https://azure.github.io/azure-service-operator/guide/crd-management/) for details on doing this for both [Helm](https://azure.github.io/azure-service-operator/guide/crd-management/#helm) and [YAML](https://azure.github.io/azure-service-operator/guide/crd-management/#yaml) based installations.
 
-The `authOptions` and `operatorSpec` properties on [`SearchService`](https://azure.github.io/azure-service-operator/reference/search/v1api20220901/#search.azure.com/v1api20220901.SearchService) are not supported in ASO v2.1.0; they'll be included in the next release.
-
 ### Latest Released Versions
 
 These resource(s) are the latest versions available for use in the current release of ASO. Different versions of a given resource reflect different versions of the Azure ARM API.

--- a/docs/v2/azure/supported-resources/search.md
+++ b/docs/v2/azure/supported-resources/search.md
@@ -1,2 +1,0 @@
-The `authOptions` and `operatorSpec` properties on [`SearchService`](https://azure.github.io/azure-service-operator/reference/search/v1api20220901/#search.azure.com/v1api20220901.SearchService) are not supported in ASO v2.1.0; they'll be included in the next release.
-


### PR DESCRIPTION
## What this PR does

Prior to the release of v2.2.0, we put in a documentation warning about some properties that wouldn't be available until that release was out. And then we promptly forgot to remove the warning.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExenEya3p5cml6am1rZXh5cmYzdThqYXN6dWpoMnlzNHc1amFwZWE0aCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/czTpnEaTz3rizw3I0f/giphy.gif)

## Checklist

- [x] this PR contains documentation
