### PR TITLE
Fix panic in mangle-test-json tool

### DIFF
--- a/v2/tools/mangle-test-json/main.go
+++ b/v2/tools/mangle-test-json/main.go
@@ -374,6 +374,10 @@ func commonPrefix(
 
 // findCommonPackagePrefix finds the common prefix of all package names, to shorten display
 func findCommonPackagePrefix(packages []string) string {
+	if len(packages) == 0 {
+		return ""
+	}
+
 	prefix := packages[0]
 	for _, pkg := range packages {
 		prefix = commonPrefix(prefix, pkg)


### PR DESCRIPTION
## What this PR does

@matthchr observed the following panic in one of our builds where no testing was run.

``` bash
[produce-markdown-summary] panic: runtime error: index out of range [0] with length 0
[produce-markdown-summary] 
[produce-markdown-summary] goroutine 1 [running]:
[produce-markdown-summary] main.findCommonPackagePrefix({0xc0000bfe40?, 0xc00009c020?, 0x53f085?})
[produce-markdown-summary]  /workspace/v2/tools/mangle-test-json/main.go:377 +0x9f
[produce-markdown-summary] main.printSummary({0xc0000bfe40, 0x0, 0x0}, 0xc0000a2e70)
[produce-markdown-summary]  /workspace/v2/tools/mangle-test-json/main.go:156 +0x85
[produce-markdown-summary] main.main()
[produce-markdown-summary]  /workspace/v2/tools/mangle-test-json/main.go:55 +0xbe
task: Failed to run task "ci": exit status 1
```

This points to an edge case that's easily addressed.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExYndheG1wbWR1MXc4NTBxc2dpMHVhejdtMm8zb2FqMjNza3RvZW94NSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/skbgJvxjGfqoZ7Ue72/giphy.gif)
