### PR TITLE
Disable trivy install

### DIFF
--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -249,17 +249,17 @@ fi
 
 # Install Trivy
 #doc# | Trivy | v0.67.2 | https://trivy.dev/ |
-write-verbose "Checking for $TOOL_DEST/trivy"
-if should-install "$TOOL_DEST/trivy"; then
-    write-info "Installing trivy"
-    # This guys decided to use different naming conventions for os(go env GOOS) and arch(go env GOARCH) despite trivy is 98.6% written in Go
-    # This fixes macos arm64 architechture. Every other os/arch is named differently. Consider adding a workaround of your own ¯\_(ツ)_/¯
-    if [[ ${os} == "darwin" ]] && [[ ${arch} == "arm64" ]]; then
-        curl -sL "https://github.com/aquasecurity/trivy/releases/download/v0.67.2/trivy_0.67.2_macOS-ARM64.tar.gz" | tar xz -C "$TOOL_DEST" trivy
-    else
-        curl -sL "https://github.com/aquasecurity/trivy/releases/download/v0.67.2/trivy_0.67.2_Linux-64bit.tar.gz" | tar xz -C "$TOOL_DEST" trivy
-    fi
-fi
+# write-verbose "Checking for $TOOL_DEST/trivy"
+# if should-install "$TOOL_DEST/trivy"; then
+#     write-info "Installing trivy"
+#     # These guys decided to use different naming conventions for os(go env GOOS) and arch(go env GOARCH) despite trivy is 98.6% written in Go
+#     # This fixes macos arm64 architechture. Every other os/arch is named differently. Consider adding a workaround of your own ¯\_(ツ)_/¯
+#     if [[ ${os} == "darwin" ]] && [[ ${arch} == "arm64" ]]; then
+#         curl -sL "https://github.com/aquasecurity/trivy/releases/download/v0.67.2/trivy_0.67.2_macOS-ARM64.tar.gz" | tar xz -C "$TOOL_DEST" trivy
+#     else
+#         curl -sL "https://github.com/aquasecurity/trivy/releases/download/v0.67.2/trivy_0.67.2_Linux-64bit.tar.gz" | tar xz -C "$TOOL_DEST" trivy
+#     fi
+# fi
 
 # Install helm
 #doc# | Helm | v3.19.0 | https://helm.sh/ |


### PR DESCRIPTION
## What this PR does

Temporarily disable installation of trivy until we are confident it can be safely renabled.

### Special notes

See #5209 for our tracking issue for turning trivy back on again.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZTd2bnN6aWN5Ym40OXpqMTdreWpzbXFtMnRibnFldG9iMzI0dHZtMiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/2d400VBPJbxaU/giphy.gif)
