### PR TITLE
fix delete-old-resourcegroups.sh flake

### DIFF
--- a/scripts/v2/delete-old-resourcegroups.sh
+++ b/scripts/v2/delete-old-resourcegroups.sh
@@ -49,6 +49,13 @@ else
 fi
 
 for rgname in ${RESOURCE_GROUPS[@]}; do
-  echo "$rgname will be deleted"; \
-  az group delete --name $rgname --no-wait --yes; \
+  echo "$rgname will be deleted"
+  output=$(az group delete --name "$rgname" --no-wait --yes 2>&1) || {
+    if echo "$output" | grep -q "ResourceGroupNotFound"; then
+      echo "$rgname was already deleted"
+    else
+      echo "$output" >&2
+      exit 1
+    fi
+  }
 done


### PR DESCRIPTION
## Checklist

<!--
_Delete any that don't apply. For completed items, change [ ] to [x]._
-->

- [ ] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
