### PR TITLE
Fix go mod download cache permissions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -38,13 +38,12 @@ COPY v2/tools/generator/go.mod v2/tools/generator/go.sum /tmp/mod-download/v2/to
 # mangle-test-json (standalone, no replace directives)
 COPY v2/tools/mangle-test-json/go.mod v2/tools/mangle-test-json/go.sum /tmp/mod-download/v2/tools/mangle-test-json/
 # Now do all the downloads
-RUN find /tmp/mod-download -name go.mod -execdir pwd \; -execdir go mod download \;
+RUN mkdir -p /go/pkg/mod && \
+    chown -R vscode:vscode /go/pkg/mod && \
+    find /tmp/mod-download -name go.mod -execdir pwd \; -execdir go mod download \;
 
 # Clean up temporary module download directory
 RUN rm -rf /tmp/mod-download
-
-# Fix permissions so the vscode user can write to the module cache
-RUN chown -R vscode:vscode /go/pkg/mod
 
 # Setup envtest
 # NB: if you change this, dev.sh also likely needs updating, also need to update the env below

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -43,6 +43,9 @@ RUN find /tmp/mod-download -name go.mod -execdir pwd \; -execdir go mod download
 # Clean up temporary module download directory
 RUN rm -rf /tmp/mod-download
 
+# Fix permissions so the vscode user can write to the module cache
+RUN chown -R vscode:vscode /go/pkg/mod
+
 # Setup envtest
 # NB: if you change this, dev.sh also likely needs updating, also need to update the env below
 RUN setup-envtest use 1.35.0 --bin-dir /usr/local/envtest/bin

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -38,9 +38,10 @@ COPY v2/tools/generator/go.mod v2/tools/generator/go.sum /tmp/mod-download/v2/to
 # mangle-test-json (standalone, no replace directives)
 COPY v2/tools/mangle-test-json/go.mod v2/tools/mangle-test-json/go.sum /tmp/mod-download/v2/tools/mangle-test-json/
 # Now do all the downloads
+ENV GOFLAGS=-modcacherw
 RUN mkdir -p /go/pkg/mod && \
-    chown -R vscode:vscode /go/pkg/mod && \
-    find /tmp/mod-download -name go.mod -execdir pwd \; -execdir go mod download \;
+    find /tmp/mod-download -name go.mod -execdir pwd \; -execdir go mod download \; && \
+    chmod -R a+rwX /go/pkg/mod
 
 # Clean up temporary module download directory
 RUN rm -rf /tmp/mod-download


### PR DESCRIPTION
## What this PR does

The active user when building the devcontainer is different to the active user when using it - and the permissions for the `go mod download` cache made it readonly, causing builds to fail.

Tweaking the permissions should work.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbmYzamFlNDN4OTNya3dkamhtbXoxM3h4azUxMzh3cXFhZmo1czViNCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3osxY5pSBcc9ZfWN20/giphy.gif)
