### PR TITLE
Fix additional devcontainer directory permissions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -39,9 +39,9 @@ COPY v2/tools/generator/go.mod v2/tools/generator/go.sum /tmp/mod-download/v2/to
 COPY v2/tools/mangle-test-json/go.mod v2/tools/mangle-test-json/go.sum /tmp/mod-download/v2/tools/mangle-test-json/
 # Now do all the downloads
 ENV GOFLAGS=-modcacherw
-RUN mkdir -p /go/pkg/mod && \
+RUN mkdir -p /go/pkg/mod /go/pkg/sumdb && \
     find /tmp/mod-download -name go.mod -execdir pwd \; -execdir go mod download \; && \
-    chmod -R a+rwX /go/pkg/mod
+    chmod -R a+rwX /go/pkg/mod /go/pkg/sumdb
 
 # Clean up temporary module download directory
 RUN rm -rf /tmp/mod-download


### PR DESCRIPTION
## What this PR does

Fixes another permissions issue with pre-cached Go modules in the devcontainer.

If this isn't sufficient, perhaps we just remove the precaching entirely.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZHphc3IxaW56MmtjMzh4dmRhdWxrc2gyY3F2aG5lamVxMnk2N2pjaCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/lNubxCPAPvSUw/giphy.gif)
