### PR TITLE
Update version of golangci-lint

### DIFF
--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -228,8 +228,8 @@ if should-install "$TOOL_DEST/setup-envtest"; then
 fi
 
 # Stricter GO formatting
-#doc# | gofumpt | latest | https://pkg.go.dev/mvdan.cc/gofumpt |
-go-install gofumpt mvdan.cc/gofumpt@latest
+#doc# | gofumpt | v0.9.0 | https://github.com/mvdan/gofumpt |
+go-install gofumpt mvdan.cc/gofumpt@v0.9.0
 
 # Install golangci-lint
 #doc# | golangci-lint | 2.12.1 | https://github.com/golangci/golangci-lint |

--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -232,13 +232,13 @@ fi
 go-install gofumpt mvdan.cc/gofumpt@latest
 
 # Install golangci-lint
-#doc# | golangci-lint | 2.8.0 | https://github.com/golangci/golangci-lint |
+#doc# | golangci-lint | 2.12.1 | https://github.com/golangci/golangci-lint |
 write-verbose "Checking for $TOOL_DEST/golangci-lint"
 if should-install "$TOOL_DEST/golangci-lint"; then
     write-info "Installing golangci-lint"
     # golangci-lint is provided by base image if in devcontainer
     # this command copied from there
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$TOOL_DEST" v2.8.0 2>&1
+    curl -sSfL https://golangci-lint.run/install.sh  | sh -s -- -b "$TOOL_DEST" v2.12.1 2>&1
 fi
 
 # Install Task

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,9 @@ linters:
   settings:
     exhaustive:
       default-signifies-exhaustive: true
+    govet:
+      disable:
+        - inline # doesn't support type parameter inference for generic functions yet
     staticcheck:
       checks:
         - "-S1002" # Comparison to bool explicitly can sometimes add clarity

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -126,6 +126,15 @@ tasks:
       - task: generator:go-mod-tidy
       - task: mangle-test:go-mod-tidy
 
+  lint:
+    desc: Run lint checks.
+    dir: v2
+    cmds:
+      - task: asoctl:lint
+      - task: generator:lint
+      - task: controller:lint
+      - task: mangle-test:lint
+
   build-docs-site:
     cmds:
       - task: doc:build-site

--- a/docs/hugo/content/contributing/dependencies.md
+++ b/docs/hugo/content/contributing/dependencies.md
@@ -17,7 +17,7 @@ If you prefer to install those dependencies manually (instead of using the `.dev
 | crddoc | latest | https://github.com/theunrepentantgeek/crddoc |
 | Go | 1.25 | https://golang.org/doc/install #
 | go-vcr-tidy | latest | https://github.com/theunrepentantgeek/go-vcr-tidy |
-| gofumpt | latest | https://pkg.go.dev/mvdan.cc/gofumpt |
+| gofumpt | v0.9.0 | https://github.com/mvdan/gofumpt |
 | golangci-lint | 2.12.1 | https://github.com/golangci/golangci-lint |
 | Helm | v3.19.0 | https://helm.sh/ |
 | htmltest | latest | https://github.com/wjdp/htmltest (but see https://github.com/theunrepentantgeek/htmltest for our custom build )

--- a/docs/hugo/content/contributing/dependencies.md
+++ b/docs/hugo/content/contributing/dependencies.md
@@ -16,9 +16,9 @@ If you prefer to install those dependencies manually (instead of using the `.dev
 | conversion-gen | v0.34.1 | https://pkg.go.dev/k8s.io/code-generator/cmd/conversion-gen |
 | crddoc | latest | https://github.com/theunrepentantgeek/crddoc |
 | Go | 1.25 | https://golang.org/doc/install #
-| gofumpt | latest | https://pkg.go.dev/mvdan.cc/gofumpt |
-| golangci-lint | 2.8.0 | https://github.com/golangci/golangci-lint |
 | go-vcr-tidy | latest | https://github.com/theunrepentantgeek/go-vcr-tidy |
+| gofumpt | latest | https://pkg.go.dev/mvdan.cc/gofumpt |
+| golangci-lint | 2.12.1 | https://github.com/golangci/golangci-lint |
 | Helm | v3.19.0 | https://helm.sh/ |
 | htmltest | latest | https://github.com/wjdp/htmltest (but see https://github.com/theunrepentantgeek/htmltest for our custom build )
 | hugo | v0.152.2 | https://gohugo.io/ |
@@ -28,7 +28,7 @@ If you prefer to install those dependencies manually (instead of using the `.dev
 | PostCSS | latest | https://postcss.org/ |
 | setup-envtest | v0.23.1 | https://book.kubebuilder.io/reference/envtest.html |
 | Task | v3.49.1 | https://taskfile.dev/ |
-| Trivy | v0.67.2 | https://trivy.dev/ |
+| Trivy | v0.69.3 | https://trivy.dev/ |
 | YQ | v4.48.1 | https://github.com/mikefarah/yq/ |
 
 Dependencies are listed alphabetically. Refer to `install-dependencies.sh` for a recommended order of installation.

--- a/v2/api/apimanagement/customizations/product_extensions.go
+++ b/v2/api/apimanagement/customizations/product_extensions.go
@@ -66,7 +66,8 @@ func (extension *ProductExtension) Delete(
 		"*",
 		&armapimanagement.ProductClientDeleteOptions{
 			DeleteSubscriptions: to.Ptr(true),
-		})
+		},
+	)
 	if err != nil {
 		// If the product (or its parent) is already gone, treat as success
 		if genericarmclient.IsNotFoundError(err) {

--- a/v2/api/authorization/customizations/role_assignment_extensions.go
+++ b/v2/api/authorization/customizations/role_assignment_extensions.go
@@ -72,7 +72,8 @@ func (extension *RoleAssignmentExtension) ModifyARMResource(
 	if !ok {
 		return nil, eris.Errorf(
 			"Cannot run RoleAssignmentExtension.ModifyARMResource() with unexpected resource type %T",
-			obj)
+			obj,
+		)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -126,7 +127,8 @@ func resolveBuiltInRoleDefinition(
 		return "", eris.Errorf(
 			"unable to find Azure built-in role-definition with well-known name %q (see %s)",
 			roleDefinitionName,
-			"https://learn.microsoft.com/azure/role-based-access-control/built-in-roles")
+			"https://learn.microsoft.com/azure/role-based-access-control/built-in-roles",
+		)
 	}
 
 	// We need the subscription ID from the resource to construct the ARM ID for a well known role
@@ -138,7 +140,8 @@ func resolveBuiltInRoleDefinition(
 	armID := fmt.Sprintf(
 		"/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s",
 		roleARMId.SubscriptionID,
-		roleId)
+		roleId,
+	)
 
 	return armID, nil
 }

--- a/v2/api/authorization/v1api20200801preview/webhook/role_assignment_defaults.go
+++ b/v2/api/authorization/v1api20200801preview/webhook/role_assignment_defaults.go
@@ -62,6 +62,8 @@ func (webhook *RoleAssignment) defaultAzureName(_ context.Context, assignment *v
 				assignment.Owner(),
 				gk,
 				assignment.Namespace,
-				assignment.Name))
+				assignment.Name,
+			),
+		)
 	}
 }

--- a/v2/api/authorization/v1api20220401/webhook/role_assignment_defaults.go
+++ b/v2/api/authorization/v1api20220401/webhook/role_assignment_defaults.go
@@ -71,7 +71,9 @@ func (webhook *RoleAssignment) defaultAzureName(_ context.Context, assignment *v
 					assignment.Owner(),
 					gk,
 					assignment.Namespace,
-					assignment.Name))
+					assignment.Name,
+				),
+			)
 		}
 	}
 }

--- a/v2/api/authorization/v1api20220401/webhook/role_definition_defaults.go
+++ b/v2/api/authorization/v1api20220401/webhook/role_definition_defaults.go
@@ -63,7 +63,9 @@ func (webhook *RoleDefinition) defaultAzureName(_ context.Context, definition *v
 					definition.Owner(),
 					gk,
 					definition.Namespace,
-					definition.Name))
+					definition.Name,
+				),
+			)
 		}
 	}
 }

--- a/v2/api/communication/customizations/communication_service_extensions.go
+++ b/v2/api/communication/customizations/communication_service_extensions.go
@@ -46,7 +46,8 @@ func (ext *CommunicationServiceExtension) ExportKubernetesSecrets(
 	typedObj, ok := obj.(*communication.CommunicationService)
 	if !ok {
 		return nil, eris.Errorf(
-			"cannot run on unknown resource type %T, expected *communication.CommunicationService", obj)
+			"cannot run on unknown resource type %T, expected *communication.CommunicationService", obj,
+		)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if

--- a/v2/api/communication/v20230401/webhook/domain_webhook_types.go
+++ b/v2/api/communication/v20230401/webhook/domain_webhook_types.go
@@ -51,7 +51,8 @@ func (domain *Domain) validateAzureManagedDomainName(_ context.Context, obj *v20
 			"when spec.domainManagement is %q, spec.azureName must be %q, but got %q",
 			v20230401.DomainManagement_AzureManaged,
 			"AzureManagedDomain",
-			obj.Spec.AzureName)
+			obj.Spec.AzureName,
+		)
 	}
 
 	return nil, nil

--- a/v2/api/communication/v20230401/webhook/sender_username_webhook_types.go
+++ b/v2/api/communication/v20230401/webhook/sender_username_webhook_types.go
@@ -50,7 +50,8 @@ func (username *SenderUsername) validateAzureNameMatchesUsername(_ context.Conte
 		return nil, eris.Errorf(
 			"spec.azureName (%q) must match spec.username (%q) (case-insensitive) — Azure requires the resource name to match the username",
 			obj.Spec.AzureName,
-			*obj.Spec.Username)
+			*obj.Spec.Username,
+		)
 	}
 
 	return nil, nil

--- a/v2/api/containerservice/customizations/managed_cluster_extensions.go
+++ b/v2/api/containerservice/customizations/managed_cluster_extensions.go
@@ -193,7 +193,8 @@ func (ext *ManagedClusterExtension) PreReconcileCheck(
 	state := managedCluster.Status.ProvisioningState
 	if state != nil && clusterProvisioningStateBlocksReconciliation(state) {
 		return extensions.BlockReconcile(
-				fmt.Sprintf("Managed cluster is in provisioning state %q", *state)),
+				fmt.Sprintf("Managed cluster is in provisioning state %q", *state),
+			),
 			nil
 	}
 

--- a/v2/api/containerservice/customizations/managed_clusters_agent_pool_extensions.go
+++ b/v2/api/containerservice/customizations/managed_clusters_agent_pool_extensions.go
@@ -50,7 +50,8 @@ func (ext *ManagedClustersAgentPoolExtension) PreReconcileOwnerCheck(
 		state := managedCluster.Status.ProvisioningState
 		if state != nil && clusterProvisioningStateBlocksReconciliation(state) {
 			return extensions.BlockReconcile(
-					fmt.Sprintf("Managed cluster %q is in provisioning state %q", owner.GetName(), *state)),
+					fmt.Sprintf("Managed cluster %q is in provisioning state %q", owner.GetName(), *state),
+				),
 				nil
 		}
 	}
@@ -85,7 +86,8 @@ func (ext *ManagedClustersAgentPoolExtension) PreReconcileCheck(
 	state := agentPool.Status.ProvisioningState
 	if state != nil && agentPoolProvisioningStateBlocksReconciliation(state) {
 		return extensions.BlockReconcile(
-				fmt.Sprintf("Managed cluster agent pool is in provisioning state %q", *state)),
+				fmt.Sprintf("Managed cluster agent pool is in provisioning state %q", *state),
+			),
 			nil
 	}
 

--- a/v2/api/dbformysql/v1/webhook/user_webhook_types.go
+++ b/v2/api/dbformysql/v1/webhook/user_webhook_types.go
@@ -111,7 +111,8 @@ func (webhook *User_Webhook) ValidateUpdate(ctx context.Context, oldObj runtime.
 		ctx,
 		oldResource,
 		newResource,
-		validations)
+		validations,
+	)
 }
 
 // createValidations validates the creation of the resource
@@ -151,7 +152,8 @@ func (webhook *User_Webhook) validateWriteOncePropertiesNotChanged(_ context.Con
 		err := eris.Errorf(
 			"updating 'AzureName' is not allowed for '%s : %s",
 			oldObj.GetObjectKind().GroupVersionKind(),
-			oldObj.GetName())
+			oldObj.GetName(),
+		)
 
 		errs = append(errs, err)
 	}
@@ -168,14 +170,16 @@ func (webhook *User_Webhook) validateWriteOncePropertiesNotChanged(_ context.Con
 		err := eris.Errorf(
 			"updating 'Owner.Name' is not allowed for '%s : %s",
 			oldObj.GetObjectKind().GroupVersionKind(),
-			oldObj.GetName())
+			oldObj.GetName(),
+		)
 
 		errs = append(errs, err)
 	} else if ownerRemoved {
 		err := eris.Errorf(
 			"removing 'Owner' is not allowed for '%s : %s",
 			oldObj.GetObjectKind().GroupVersionKind(),
-			oldObj.GetName())
+			oldObj.GetName(),
+		)
 
 		errs = append(errs, err)
 	}

--- a/v2/api/dbforpostgresql/customizations/flexible_server_extensions.go
+++ b/v2/api/dbforpostgresql/customizations/flexible_server_extensions.go
@@ -124,7 +124,9 @@ func (ext *FlexibleServerExtension) PreReconcileCheck(
 		return extensions.BlockReconcile(
 			fmt.Sprintf(
 				"Flexible Server is in state %q",
-				*state)), nil
+				*state,
+			),
+		), nil
 	}
 
 	return next(ctx, obj, resourceResolver, armClient, log)

--- a/v2/api/dbforpostgresql/customizations/flexible_servers_database_extensions.go
+++ b/v2/api/dbforpostgresql/customizations/flexible_servers_database_extensions.go
@@ -36,7 +36,9 @@ func (extension *FlexibleServersDatabaseExtension) PreReconcileOwnerCheck(
 			return extensions.BlockReconcile(
 				fmt.Sprintf(
 					"Owning FlexibleServer is in state %q",
-					*serverState)), nil
+					*serverState,
+				),
+			), nil
 		}
 	}
 

--- a/v2/api/dbforpostgresql/customizations/flexible_servers_firewall_rule_extensions.go
+++ b/v2/api/dbforpostgresql/customizations/flexible_servers_firewall_rule_extensions.go
@@ -35,7 +35,9 @@ func (ext *FlexibleServersFirewallRuleExtension) PreReconcileOwnerCheck(
 			return extensions.BlockReconcile(
 				fmt.Sprintf(
 					"Owning FlexibleServer is in state %q",
-					*serverState)), nil
+					*serverState,
+				),
+			), nil
 		}
 	}
 

--- a/v2/api/dbforpostgresql/v1/webhook/user_webhook_types.go
+++ b/v2/api/dbforpostgresql/v1/webhook/user_webhook_types.go
@@ -108,7 +108,8 @@ func (webhook *User_Webhook) ValidateUpdate(ctx context.Context, oldObj runtime.
 		ctx,
 		oldResource,
 		newResource,
-		validations)
+		validations,
+	)
 }
 
 // createValidations validates the creation of the resource

--- a/v2/api/documentdb/customizations/cassandra_data_center_extensions.go
+++ b/v2/api/documentdb/customizations/cassandra_data_center_extensions.go
@@ -50,7 +50,9 @@ func (ext *CassandraDataCenterExtension) PreReconcileOwnerCheck(
 			return extensions.BlockReconcile(
 				fmt.Sprintf(
 					"Owning CassandraCluster is in provisioning state %q",
-					*serverState)), nil
+					*serverState,
+				),
+			), nil
 		}
 	}
 

--- a/v2/api/documentdb/v1api20210515/webhook/sql_role_assignment_defaults.go
+++ b/v2/api/documentdb/v1api20210515/webhook/sql_role_assignment_defaults.go
@@ -55,6 +55,8 @@ func (webhook *SqlRoleAssignment) defaultAzureName(_ context.Context, assignment
 				assignment.Owner(),
 				gk,
 				assignment.Namespace,
-				assignment.Name))
+				assignment.Name,
+			),
+		)
 	}
 }

--- a/v2/api/documentdb/v1api20231115/webhook/sql_role_assignment_defaults.go
+++ b/v2/api/documentdb/v1api20231115/webhook/sql_role_assignment_defaults.go
@@ -55,6 +55,8 @@ func (webhook *SqlRoleAssignment) defaultAzureName(_ context.Context, assignment
 				assignment.Owner(),
 				gk,
 				assignment.Namespace,
-				assignment.Name))
+				assignment.Name,
+			),
+		)
 	}
 }

--- a/v2/api/documentdb/v1api20240815/webhook/sql_role_assignment_defaults.go
+++ b/v2/api/documentdb/v1api20240815/webhook/sql_role_assignment_defaults.go
@@ -55,6 +55,8 @@ func (webhook *SqlRoleAssignment) defaultAzureName(_ context.Context, assignment
 				assignment.Owner(),
 				gk,
 				assignment.Namespace,
-				assignment.Name))
+				assignment.Name,
+			),
+		)
 	}
 }

--- a/v2/api/keyvault/customizations/vault_extensions.go
+++ b/v2/api/keyvault/customizations/vault_extensions.go
@@ -54,7 +54,8 @@ func (ex *VaultExtension) ModifyARMResource(
 	if !ok {
 		return nil, eris.Errorf(
 			"Cannot run VaultExtension.ModifyARMResource() with unexpected resource type %T",
-			obj)
+			obj,
+		)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -141,7 +142,8 @@ func (ex *VaultExtension) handleCreateOrRecover(
 		"KeyVault reconciliation requested CreateOrRecover",
 		"KeyVault", kv.Name,
 		"softDeletedKeyvaultExists", deletedKeyVault.Exists,
-		"createMode", result)
+		"createMode", result,
+	)
 
 	return result, err
 }
@@ -164,7 +166,8 @@ func (ex *VaultExtension) handlePurgeThenCreate(
 	log.Info(
 		"KeyVault reconciliation requested PurgeThenCreate",
 		"KeyVault", kv.Name,
-		"softDeletedKeyVaultExists", deletedKeyVault.Exists)
+		"softDeletedKeyVaultExists", deletedKeyVault.Exists,
+	)
 
 	if deletedKeyVault.Exists {
 		location := to.Value(kv.Spec.Location)
@@ -311,7 +314,8 @@ func checkResourceGroupsMatch(new *arm.ResourceID, old *arm.ResourceID) error {
 			eris.Errorf(
 				"cannot recover KeyVault: new resourceGroup %s does not match old resource group %s",
 				new.ResourceGroupName,
-				old.ResourceGroupName),
+				old.ResourceGroupName,
+			),
 
 			conditions.ConditionSeverityError,
 			conditions.ReasonFailed,

--- a/v2/api/kusto/customizations/cluster_extensions.go
+++ b/v2/api/kusto/customizations/cluster_extensions.go
@@ -64,7 +64,8 @@ func (ext *ClusterExtension) PreReconcileCheck(
 	state := cluster.Status.ProvisioningState
 	if state != nil && clusterProvisioningStateBlocksReconciliation(state) {
 		return extensions.BlockReconcile(
-				fmt.Sprintf("Cluster is in provisioning state %q", *state)),
+				fmt.Sprintf("Cluster is in provisioning state %q", *state),
+			),
 			nil
 	}
 

--- a/v2/api/kusto/customizations/database_extensions.go
+++ b/v2/api/kusto/customizations/database_extensions.go
@@ -49,7 +49,8 @@ func (ext *DatabaseExtension) PreReconcileOwnerCheck(
 		state := cluster.Status.ProvisioningState
 		if state != nil && clusterProvisioningStateBlocksReconciliation(state) {
 			return extensions.BlockReconcile(
-					fmt.Sprintf("Owning cluster is in provisioning state %q", *state)),
+					fmt.Sprintf("Owning cluster is in provisioning state %q", *state),
+				),
 				nil
 		}
 

--- a/v2/api/managedidentity/customizations/user_assigned_identity_extention_authorization.go
+++ b/v2/api/managedidentity/customizations/user_assigned_identity_extention_authorization.go
@@ -34,7 +34,8 @@ func (ext *UserAssignedIdentityExtension) ExportKubernetesSecrets(
 	typedObj, ok := obj.(*v20230131s.UserAssignedIdentity)
 	if !ok {
 		return nil, fmt.Errorf(
-			"cannot run on unknown resource type %T, expected *v20230131s.UserAssignedIdentity", obj)
+			"cannot run on unknown resource type %T, expected *v20230131s.UserAssignedIdentity", obj,
+		)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if

--- a/v2/api/network/customizations/private_endpoints_extensions.go
+++ b/v2/api/network/customizations/private_endpoints_extensions.go
@@ -62,7 +62,9 @@ func (extension *PrivateEndpointExtension) PostReconcileCheck(
 		return extensions.PostReconcileCheckResultFailure(
 			fmt.Sprintf(
 				"Private connection(s) '%q' to the PrivateEndpoint requires approval",
-				reqApprovals)), nil
+				reqApprovals,
+			),
+		), nil
 	}
 
 	return extensions.PostReconcileCheckResultSuccess(), nil

--- a/v2/api/network/customizations/route_table_extensions_test.go
+++ b/v2/api/network/customizations/route_table_extensions_test.go
@@ -102,7 +102,9 @@ func Test_FuzzySetRoute(t *testing.T) {
 
 				err = fuzzySetResource(raw, val)
 				return err == nil, err
-			}))
+			},
+		),
+	)
 
 	properties.TestingRun(t, gopter.NewFormatedReporter(false, 240, os.Stdout))
 }

--- a/v2/api/network/customizations/virtual_network_extensions_test.go
+++ b/v2/api/network/customizations/virtual_network_extensions_test.go
@@ -116,7 +116,9 @@ func Test_FuzzySetSubnet(t *testing.T) {
 
 				err = fuzzySetResource(raw, val)
 				return err == nil, err
-			}))
+			},
+		),
+	)
 
 	properties.TestingRun(t, gopter.NewFormatedReporter(false, 240, os.Stdout))
 }

--- a/v2/api/servicebus/customizations/namespace_extensions.go
+++ b/v2/api/servicebus/customizations/namespace_extensions.go
@@ -70,7 +70,8 @@ func (ext *NamespaceExtension) ExportKubernetesSecrets(
 	clientFactory, err := armservicebus.NewClientFactory(
 		id.SubscriptionID,
 		armClient.Creds(),
-		armClient.ClientOptions())
+		armClient.ClientOptions(),
+	)
 	if err != nil {
 		return nil, eris.Wrapf(err, "failed to create ARM servicebus client factory")
 	}
@@ -86,12 +87,14 @@ func (ext *NamespaceExtension) ExportKubernetesSecrets(
 		id.ResourceGroupName,
 		id.Name,
 		rootRuleName,
-		&options)
+		&options,
+	)
 	if err != nil {
 		return nil, eris.Wrapf(
 			err,
 			"failed to retrieve namespace management keys from authorization rule %q",
-			rootRuleName)
+			rootRuleName,
+		)
 	}
 
 	secretSlice, err := namespaceSecretsToWrite(namespace, response)

--- a/v2/api/servicebus/customizations/namespaces_authorization_rule_extensions.go
+++ b/v2/api/servicebus/customizations/namespaces_authorization_rule_extensions.go
@@ -39,7 +39,8 @@ func (ext *NamespacesAuthorizationRuleExtension) ExportKubernetesSecrets(
 	if !ok {
 		return nil, eris.Errorf(
 			"cannot run on unknown resource type %T, expected *servicebus.NamespacesAuthorizationRule",
-			obj)
+			obj,
+		)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -75,7 +76,8 @@ func (ext *NamespacesAuthorizationRuleExtension) ExportKubernetesSecrets(
 		return nil, eris.Wrapf(
 			err,
 			"failed to retrieve keys for authorization rule %q",
-			rule.Name)
+			rule.Name,
+		)
 	}
 
 	ruleSecrets, err := authorizationRuleSecretsToWrite(rule, response)
@@ -83,7 +85,8 @@ func (ext *NamespacesAuthorizationRuleExtension) ExportKubernetesSecrets(
 		return nil, eris.Wrapf(
 			err,
 			"failed to create secrets for authorization rule %q",
-			rule.Name)
+			rule.Name,
+		)
 	}
 
 	resolvedSecrets := map[string]string{}
@@ -139,7 +142,8 @@ func authorizationRuleSecretsToWrite(
 		rule.Spec.OperatorSpec.Secrets == nil {
 		return nil, eris.Errorf(
 			"authorization rule %q has no secrets specified",
-			rule.Name)
+			rule.Name,
+		)
 	}
 
 	specSecrets := rule.Spec.OperatorSpec.Secrets

--- a/v2/api/servicebus/customizations/topic_authorization_rule_extensions.go
+++ b/v2/api/servicebus/customizations/topic_authorization_rule_extensions.go
@@ -39,7 +39,8 @@ func (ext *TopicAuthorizationRuleExtension) ExportKubernetesSecrets(
 	if !ok {
 		return nil, eris.Errorf(
 			"cannot run on unknown resource type %T, expected *servicebus.TopicAuthorizationRule",
-			obj)
+			obj,
+		)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -77,7 +78,8 @@ func (ext *TopicAuthorizationRuleExtension) ExportKubernetesSecrets(
 		return nil, eris.Wrapf(
 			err,
 			"failed to retrieve keys for topic authorization rule %q",
-			rule.Name)
+			rule.Name,
+		)
 	}
 
 	ruleSecrets, err := topicAuthorizationRuleSecretsToWrite(rule, response)
@@ -85,7 +87,8 @@ func (ext *TopicAuthorizationRuleExtension) ExportKubernetesSecrets(
 		return nil, eris.Wrapf(
 			err,
 			"failed to create secrets for topic authorization rule %q",
-			rule.Name)
+			rule.Name,
+		)
 	}
 
 	resolvedSecrets := map[string]string{}
@@ -141,7 +144,8 @@ func topicAuthorizationRuleSecretsToWrite(
 		rule.Spec.OperatorSpec.Secrets == nil {
 		return nil, eris.Errorf(
 			"topic authorization rule %q has no secrets specified",
-			rule.Name)
+			rule.Name,
+		)
 	}
 
 	specSecrets := rule.Spec.OperatorSpec.Secrets

--- a/v2/api/signalrservice/customizations/signal_r_extension_authorization.go
+++ b/v2/api/signalrservice/customizations/signal_r_extension_authorization.go
@@ -45,7 +45,8 @@ func (ext *SignalRExtension) ExportKubernetesSecrets(
 	typedObj, ok := obj.(*signalr.SignalR)
 	if !ok {
 		return nil, eris.Errorf(
-			"cannot run on unknown resource type %T, expected *signalr.SignalR", obj)
+			"cannot run on unknown resource type %T, expected *signalr.SignalR", obj,
+		)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if

--- a/v2/api/sql/v1/webhook/user_webhook_types.go
+++ b/v2/api/sql/v1/webhook/user_webhook_types.go
@@ -111,7 +111,8 @@ func (webhook *User_Webhook) ValidateUpdate(ctx context.Context, oldObj runtime.
 		ctx,
 		oldResource,
 		newResource,
-		validations)
+		validations,
+	)
 }
 
 // createValidations validates the creation of the resource
@@ -146,7 +147,8 @@ func (webhook *User_Webhook) validateWriteOncePropertiesNotChanged(_ context.Con
 		err := eris.Errorf(
 			"updating 'AzureName' is not allowed for '%s : %s",
 			oldObj.GetObjectKind().GroupVersionKind(),
-			oldObj.GetName())
+			oldObj.GetName(),
+		)
 
 		errs = append(errs, err)
 	}
@@ -163,14 +165,16 @@ func (webhook *User_Webhook) validateWriteOncePropertiesNotChanged(_ context.Con
 		err := eris.Errorf(
 			"updating 'Owner.Name' is not allowed for '%s : %s",
 			oldObj.GetObjectKind().GroupVersionKind(),
-			oldObj.GetName())
+			oldObj.GetName(),
+		)
 
 		errs = append(errs, err)
 	} else if ownerRemoved {
 		err := eris.Errorf(
 			"removing 'Owner' is not allowed for '%s : %s",
 			oldObj.GetObjectKind().GroupVersionKind(),
-			oldObj.GetName())
+			oldObj.GetName(),
+		)
 
 		errs = append(errs, err)
 	}

--- a/v2/internal/reflecthelpers/reflect_helpers.go
+++ b/v2/internal/reflecthelpers/reflect_helpers.go
@@ -24,7 +24,7 @@ import (
 // TODO: Can we delete this helper later when we have some better code generated functions?
 func ValueOfPtr(ptr interface{}) interface{} {
 	v := reflect.ValueOf(ptr)
-	if v.Kind() != reflect.Ptr {
+	if v.Kind() != reflect.Pointer {
 		panic(fmt.Sprintf("Can't get value of pointer for non-pointer type %T", ptr))
 	}
 	val := reflect.Indirect(v)
@@ -314,7 +314,7 @@ func SetObjectListItems(listPtr client.ObjectList, items []client.Object) (retur
 	for _, item := range items {
 		val := reflect.ValueOf(item)
 
-		if val.Kind() == reflect.Ptr {
+		if val.Kind() == reflect.Pointer {
 			val = val.Elem()
 		}
 		slice = reflect.Append(slice, val)
@@ -326,7 +326,7 @@ func SetObjectListItems(listPtr client.ObjectList, items []client.Object) (retur
 
 func getItemsField(listPtr client.ObjectList) (reflect.Value, error) {
 	val := reflect.ValueOf(listPtr)
-	if val.Kind() != reflect.Ptr {
+	if val.Kind() != reflect.Pointer {
 		return reflect.Value{}, eris.Errorf("provided list was not a pointer, was %s", val.Kind())
 	}
 
@@ -378,7 +378,7 @@ func setPropertyCore(obj any, propertyPath []string, value any) (err error) {
 	subject := reflect.ValueOf(obj)
 
 	// Dereference pointers
-	if subject.Kind() == reflect.Ptr {
+	if subject.Kind() == reflect.Pointer {
 		subject = subject.Elem()
 	}
 
@@ -397,7 +397,7 @@ func setPropertyCore(obj any, propertyPath []string, value any) (err error) {
 
 	// If this is not the last property in the path, we need to recurse
 	if len(propertyPath) > 1 {
-		if field.Kind() == reflect.Ptr {
+		if field.Kind() == reflect.Pointer {
 			// Field is a pointer; initialize it if needed, then pass the pointer recursively
 			if field.IsNil() {
 				newValue := reflect.New(field.Type().Elem())

--- a/v2/internal/reflecthelpers/reflect_visitor.go
+++ b/v2/internal/reflecthelpers/reflect_visitor.go
@@ -84,7 +84,7 @@ func (r *ReflectVisitor) visit(val reflect.Value, ctx interface{}) error {
 	}
 
 	switch kind {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		return r.VisitPtr(r, val, ctx)
 	case reflect.Slice:
 		return r.VisitSlice(r, val, ctx)

--- a/v2/internal/set/set.go
+++ b/v2/internal/set/set.go
@@ -6,7 +6,8 @@
 package set
 
 import (
-	"golang.org/x/exp/constraints"
+	"cmp"
+
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 )
@@ -102,7 +103,7 @@ func (set Set[T]) Except(other Set[T]) Set[T] {
 }
 
 // AsSortedSlice returns a sorted slice of values from this set
-func AsSortedSlice[T constraints.Ordered](set Set[T]) []T {
+func AsSortedSlice[T cmp.Ordered](set Set[T]) []T {
 	result := maps.Keys(set)
 	slices.Sort(result)
 	return result

--- a/v2/internal/testcommon/reflect/reflect.go
+++ b/v2/internal/testcommon/reflect/reflect.go
@@ -22,7 +22,7 @@ func PopulateStruct(s any) {
 		fieldType := valType.Field(i)
 
 		switch field.Kind() {
-		case reflect.Ptr:
+		case reflect.Pointer:
 			newVal := reflect.New(fieldType.Type.Elem())
 			field.Set(newVal)
 			PopulateStruct(field.Interface())

--- a/v2/internal/testcommon/samples_tester.go
+++ b/v2/internal/testcommon/samples_tester.go
@@ -455,7 +455,7 @@ func isField(field string) func(name string) bool {
 }
 
 func (t *SamplesTester) conditionalAssignString(field reflect.Value, match string, value string) {
-	if field.Kind() == reflect.Ptr {
+	if field.Kind() == reflect.Pointer {
 		field = field.Elem()
 	}
 
@@ -469,7 +469,7 @@ func (t *SamplesTester) conditionalAssignString(field reflect.Value, match strin
 }
 
 func (t *SamplesTester) replaceString(field reflect.Value, old string, new string) {
-	if field.Kind() == reflect.Ptr {
+	if field.Kind() == reflect.Pointer {
 		field = field.Elem()
 	}
 

--- a/v2/internal/util/cel/cel.go
+++ b/v2/internal/util/cel/cel.go
@@ -422,7 +422,7 @@ func simplePkgAlias(pkgPath string) string {
 
 // getResourceTypename should return the package name +
 func getTypeImportPath(t reflect.Type) string {
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 
@@ -430,7 +430,7 @@ func getTypeImportPath(t reflect.Type) string {
 }
 
 func findTypesRecursive(t reflect.Type) []reflect.Type { // Returns any here because that's what cel.Native expects
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 

--- a/v2/pkg/genruntime/resource_reference.go
+++ b/v2/pkg/genruntime/resource_reference.go
@@ -233,7 +233,7 @@ func (ref *ResourceReference) GroupKind() schema.GroupKind {
 // ResourceReference
 func LookupOwnerGroupKind(v interface{}) (string, string) {
 	t := reflect.TypeOf(v)
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 

--- a/v2/tools/generator/internal/codegen/pipeline/property_assignment_test_cases.go
+++ b/v2/tools/generator/internal/codegen/pipeline/property_assignment_test_cases.go
@@ -6,8 +6,9 @@
 package pipeline
 
 import (
+	"context"
+
 	"github.com/rotisserie/eris"
-	"golang.org/x/net/context"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"

--- a/v2/tools/generator/internal/codegen/pipeline/resource_conversion_test_cases.go
+++ b/v2/tools/generator/internal/codegen/pipeline/resource_conversion_test_cases.go
@@ -6,8 +6,9 @@
 package pipeline
 
 import (
+	"context"
+
 	"github.com/rotisserie/eris"
-	"golang.org/x/net/context"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"


### PR DESCRIPTION
## What this PR does

Updates version of `golangci-lint` as well as updating the source location for the installation script.

Pins the version of gofumpt to v0.9.0 as the v0.10.0 will trigger widespread changes best isolated in a separate PR.

Closes #5351 

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExejg2ZnV5OTJnNjJrNTJwcTNzaXlzdWxuem81YWl4Y2w1dGUzZ2thNCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/GysX9qLF0N5bG/giphy.gif)

