### PR TITLE
Upgrade gofumpt to v0.10.0

### DIFF
--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -228,8 +228,8 @@ if should-install "$TOOL_DEST/setup-envtest"; then
 fi
 
 # Stricter GO formatting
-#doc# | gofumpt | v0.9.0 | https://github.com/mvdan/gofumpt |
-go-install gofumpt mvdan.cc/gofumpt@v0.9.0
+#doc# | gofumpt | v0.10.0 | https://github.com/mvdan/gofumpt |
+go-install gofumpt mvdan.cc/gofumpt@v0.10.0
 
 # Install golangci-lint
 #doc# | golangci-lint | 2.12.1 | https://github.com/golangci/golangci-lint |

--- a/docs/hugo/content/contributing/dependencies.md
+++ b/docs/hugo/content/contributing/dependencies.md
@@ -17,7 +17,7 @@ If you prefer to install those dependencies manually (instead of using the `.dev
 | crddoc | latest | https://github.com/theunrepentantgeek/crddoc |
 | Go | 1.25 | https://golang.org/doc/install #
 | go-vcr-tidy | latest | https://github.com/theunrepentantgeek/go-vcr-tidy |
-| gofumpt | v0.9.0 | https://github.com/mvdan/gofumpt |
+| gofumpt | v0.10.0 | https://github.com/mvdan/gofumpt |
 | golangci-lint | 2.12.1 | https://github.com/golangci/golangci-lint |
 | Helm | v3.19.0 | https://helm.sh/ |
 | htmltest | latest | https://github.com/wjdp/htmltest (but see https://github.com/theunrepentantgeek/htmltest for our custom build )

--- a/v2/cmd/asoctl/cmd/clean-crds.go
+++ b/v2/cmd/asoctl/cmd/clean-crds.go
@@ -47,7 +47,8 @@ func newCleanCRDsCommand() *cobra.Command {
 				apiExtClient.CustomResourceDefinitions(),
 				cl,
 				dryRun,
-				CreateLogger()).Run(ctx)
+				CreateLogger(),
+			).Run(ctx)
 		},
 	}
 

--- a/v2/cmd/asoctl/cmd/export_template.go
+++ b/v2/cmd/asoctl/cmd/export_template.go
@@ -107,14 +107,16 @@ asoctl export template --version v2.6.0 --crd-pattern "resources.azure.com/*;con
 		"source",
 		"s",
 		"",
-		"File or URL path to the ASO YAML template. Use this if you've customized the base ASO YAML locally or are using a base YAML other than the one hosted at https://github.com/Azure/azure-service-operator/tags")
+		"File or URL path to the ASO YAML template. Use this if you've customized the base ASO YAML locally or are using a base YAML other than the one hosted at https://github.com/Azure/azure-service-operator/tags",
+	)
 
 	cmd.Flags().StringVarP(
 		&options.version,
 		"version",
 		"v",
 		"",
-		"Release version to use.")
+		"Release version to use.",
+	)
 
 	cmd.MarkFlagsOneRequired("source", "version")
 	cmd.MarkFlagsMutuallyExclusive("source", "version")
@@ -123,14 +125,16 @@ asoctl export template --version v2.6.0 --crd-pattern "resources.azure.com/*;con
 		&options.raw,
 		"raw",
 		false,
-		"Export the YAML without any variable replacements")
+		"Export the YAML without any variable replacements",
+	)
 
 	cmd.Flags().StringSliceVarP(
 		&options.crdPattern,
 		"crd-pattern",
 		"p",
 		nil,
-		"What new CRDs to install. Existing ASO CRDs in the cluster will always be upgraded even if crdPattern is empty. See https://azure.github.io/azure-service-operator/guide/crd-management/ for more details.")
+		"What new CRDs to install. Existing ASO CRDs in the cluster will always be upgraded even if crdPattern is empty. See https://azure.github.io/azure-service-operator/guide/crd-management/ for more details.",
+	)
 
 	cmd.MarkFlagsOneRequired("crd-pattern", "raw")
 	cmd.MarkFlagsMutuallyExclusive("crd-pattern", "raw")

--- a/v2/cmd/asoctl/cmd/import_azure_resource.go
+++ b/v2/cmd/asoctl/cmd/import_azure_resource.go
@@ -76,14 +76,16 @@ https://docs.microsoft.com/azure/active-directory/develop/authentication-nationa
 		"output",
 		"o",
 		"",
-		"Write ARM resource CRDs to a single file")
+		"Write ARM resource CRDs to a single file",
+	)
 
 	cmd.Flags().StringVarP(
 		&options.outputFolder,
 		"output-folder",
 		"f",
 		"",
-		"Write ARM resource CRDs to individual files in a folder")
+		"Write ARM resource CRDs to individual files in a folder",
+	)
 
 	cmd.MarkFlagsMutuallyExclusive("output", "output-folder")
 
@@ -92,35 +94,40 @@ https://docs.microsoft.com/azure/active-directory/develop/authentication-nationa
 		"namespace",
 		"n",
 		"",
-		"Set the namespace of the the imported resources")
+		"Set the namespace of the the imported resources",
+	)
 
 	cmd.Flags().StringSliceVarP(
 		&options.labels,
 		"label",
 		"l",
 		nil,
-		"Add labels to the imported resources. Multiple comma-separated labels can be specified (--label example.com/mylabel=foo,example.com/mylabel2=bar) or the --label (-l) argument can be used multiple times (-l example.com/mylabel=foo -l example.com/mylabel2=bar)")
+		"Add labels to the imported resources. Multiple comma-separated labels can be specified (--label example.com/mylabel=foo,example.com/mylabel2=bar) or the --label (-l) argument can be used multiple times (-l example.com/mylabel=foo -l example.com/mylabel2=bar)",
+	)
 
 	cmd.Flags().StringSliceVarP(
 		&options.annotations,
 		"annotation",
 		"a",
 		nil,
-		"Add annotations to the imported resources. Multiple comma-separated annotations can be specified (--annotation example.com/myannotation=foo,example.com/myannotation2=bar) or the --annotation (-a) argument can be used multiple times (-a example.com/myannotation=foo -a example.com/myannotation2=bar)")
+		"Add annotations to the imported resources. Multiple comma-separated annotations can be specified (--annotation example.com/myannotation=foo,example.com/myannotation2=bar) or the --annotation (-a) argument can be used multiple times (-a example.com/myannotation=foo -a example.com/myannotation2=bar)",
+	)
 
 	cmd.Flags().IntVarP(
 		&options.workers,
 		"workers",
 		"w",
 		4,
-		"The number of parallel workers to use when importing resources")
+		"The number of parallel workers to use when importing resources",
+	)
 
 	cmd.Flags().BoolVarP(
 		&options.simpleLogging,
 		"simple-logging",
 		"s",
 		false,
-		"Use simple logging instead of progress bars")
+		"Use simple logging instead of progress bars",
+	)
 
 	return cmd
 }
@@ -253,7 +260,8 @@ func newChainedCredential(cloud cloud.Configuration) (azcore.TokenCredential, er
 			ClientOptions: azcore.ClientOptions{
 				Cloud: cloud,
 			},
-		})
+		},
+	)
 	if err != nil {
 		credErrors = append(credErrors, fmt.Sprintf("EnvironmentCredential: %s", err.Error()))
 	} else {
@@ -265,7 +273,8 @@ func newChainedCredential(cloud cloud.Configuration) (azcore.TokenCredential, er
 			ClientOptions: azcore.ClientOptions{
 				Cloud: cloud,
 			},
-		})
+		},
+	)
 	if err != nil {
 		credErrors = append(credErrors, fmt.Sprintf("WorkloadIdentityCredential: %s", err.Error()))
 	} else {
@@ -277,7 +286,8 @@ func newChainedCredential(cloud cloud.Configuration) (azcore.TokenCredential, er
 			ClientOptions: azcore.ClientOptions{
 				Cloud: cloud,
 			},
-		})
+		},
+	)
 	if err != nil {
 		credErrors = append(credErrors, fmt.Sprintf("ManagedIdentityCredential: %s", err.Error()))
 	} else {
@@ -340,7 +350,8 @@ func writeResources(
 	if file, ok := options.writeToFile(); ok {
 		log.Info(
 			"Writing to a single file",
-			"file", file)
+			"file", file,
+		)
 		err := result.SaveToSingleFile(file)
 		if err != nil {
 			return eris.Wrapf(err, "failed to write to file %s", file)
@@ -353,7 +364,8 @@ func writeResources(
 	if folder, ok := options.writeToFolder(); ok {
 		log.Info(
 			"Writing to individual files in folder",
-			"folder", folder)
+			"folder", folder,
+		)
 		err := result.SaveToIndividualFilesInFolder(folder)
 		if err != nil {
 			return eris.Wrapf(err, "failed to write into folder %s", folder)

--- a/v2/cmd/asoctl/internal/crd/cleaner.go
+++ b/v2/cmd/asoctl/internal/crd/cleaner.go
@@ -89,7 +89,8 @@ func (c *Cleaner) Run(ctx context.Context) error {
 	crds := make(
 		[]apiextensions.CustomResourceDefinition,
 		0,
-		len(crdsWithNewLabel.Items)+len(crdsWithOldLabel.Items))
+		len(crdsWithNewLabel.Items)+len(crdsWithOldLabel.Items),
+	)
 	crds = append(crds, crdsWithNewLabel.Items...)
 	crds = append(crds, crdsWithOldLabel.Items...)
 
@@ -109,7 +110,8 @@ func (c *Cleaner) Run(ctx context.Context) error {
 		if len(newStoredVersions) == len(crd.Status.StoredVersions) {
 			c.log.Info(
 				"Nothing to update",
-				"crd-name", crd.Name)
+				"crd-name", crd.Name,
+			)
 			continue
 		}
 
@@ -118,7 +120,8 @@ func (c *Cleaner) Run(ctx context.Context) error {
 		activeVersion := newStoredVersions[len(newStoredVersions)-1]
 		c.log.Info(
 			"Starting cleanup",
-			"crd-name", crd.Name)
+			"crd-name", crd.Name,
+		)
 
 		objectsToMigrate, err := c.getObjectsForMigration(ctx, crd, activeVersion)
 		if err != nil {
@@ -147,7 +150,8 @@ func (c *Cleaner) Run(ctx context.Context) error {
 	} else {
 		c.log.Info(
 			"Update finished",
-			"crd-count", updated)
+			"crd-count", updated,
+		)
 	}
 
 	return nil
@@ -162,7 +166,8 @@ func (c *Cleaner) updateStorageVersions(
 		c.log.Info(
 			"Would update storedVersions",
 			"crd-name", crd.Name,
-			"storedVersions", newStoredVersions)
+			"storedVersions", newStoredVersions,
+		)
 		return nil
 	}
 
@@ -174,7 +179,8 @@ func (c *Cleaner) updateStorageVersions(
 	c.log.Info(
 		"Updated CRD status storedVersions",
 		"crd-name", crd.Name,
-		"storedVersions", updatedCrd.Status.StoredVersions)
+		"storedVersions", updatedCrd.Status.StoredVersions,
+	)
 
 	return nil
 }
@@ -186,7 +192,8 @@ func (c *Cleaner) migrateObjects(ctx context.Context, objectsToMigrate *unstruct
 			c.log.Info(
 				"Would migrate resource",
 				"name", obj.GetName(),
-				"kind", obj.GroupVersionKind().Kind)
+				"kind", obj.GroupVersionKind().Kind,
+			)
 			continue
 		}
 
@@ -211,7 +218,8 @@ func (c *Cleaner) migrateObjects(ctx context.Context, objectsToMigrate *unstruct
 			c.log.Info(
 				"originalVersion not found. Continuing with the latest.",
 				"name", obj.GetName(),
-				"kind", obj.GroupVersionKind().Kind)
+				"kind", obj.GroupVersionKind().Kind,
+			)
 		}
 
 		err = retry.OnError(c.migrationBackoff, isErrorFatal, func() error { return c.client.Update(ctx, &obj) })
@@ -222,12 +230,14 @@ func (c *Cleaner) migrateObjects(ctx context.Context, objectsToMigrate *unstruct
 		c.log.Info(
 			"Migrated resource",
 			"name", obj.GetName(),
-			"kind", obj.GroupVersionKind().Kind)
+			"kind", obj.GroupVersionKind().Kind,
+		)
 	}
 
 	c.log.Info(
 		"Migration finished",
-		"resource-count", len(objectsToMigrate.Items))
+		"resource-count", len(objectsToMigrate.Items),
+	)
 
 	return nil
 }

--- a/v2/cmd/asoctl/internal/crd/cleaner_test.go
+++ b/v2/cmd/asoctl/internal/crd/cleaner_test.go
@@ -43,7 +43,8 @@ func makeClientSets() *clientSet {
 		fakeAPIExtClient.CustomResourceDefinitions(),
 		fakeClient,
 		false, // dry-run
-		logr.Discard())
+		logr.Discard(),
+	)
 	return &clientSet{
 		fakeAPIExtClient: fakeAPIExtClient,
 		fakeClient:       fakeClient,
@@ -120,7 +121,8 @@ func Test_CleanDeprecatedCRDVersions_CleansTrustedAccessRoleBindings(t *testing.
 		"trustedaccessrolebindings",
 		"TrustedAccessRoleBindingList",
 		oldVersion,
-		newVersion)
+		newVersion,
+	)
 
 	_, err := c.fakeAPIExtClient.CustomResourceDefinitions().Create(context.TODO(), definition, metav1.CreateOptions{})
 	g.Expect(err).To(BeNil())
@@ -298,7 +300,8 @@ func Test_MigrateAndCleanDeprecatedCRDResources_DryRun_NoAction(t *testing.T) {
 		fakeAPIExtClient.CustomResourceDefinitions(),
 		fakeClient,
 		true, // dry-run
-		logr.Discard())
+		logr.Discard(),
+	)
 
 	betaVersion := "v1beta20200601"
 	gaVersion := "v1api20200601"

--- a/v2/cmd/asoctl/pkg/importreporter/bar.go
+++ b/v2/cmd/asoctl/pkg/importreporter/bar.go
@@ -36,10 +36,13 @@ func newBarProgress(
 	bar := progress.AddBar(
 		0, // zero total because we don't know how much work will be needed
 		mpb.PrependDecorators(
-			decor.Name(name, decor.WCSyncSpaceR)),
+			decor.Name(name, decor.WCSyncSpaceR),
+		),
 		mpb.AppendDecorators(
-			decor.CountersNoUnit("%d/%d", decor.WCSyncSpaceR)),
-		mpb.BarRemoveOnComplete())
+			decor.CountersNoUnit("%d/%d", decor.WCSyncSpaceR),
+		),
+		mpb.BarRemoveOnComplete(),
+	)
 
 	result := &barReporter{
 		updates:  make(chan progressDelta),

--- a/v2/cmd/asoctl/pkg/importresources/import_factory.go
+++ b/v2/cmd/asoctl/pkg/importresources/import_factory.go
@@ -57,7 +57,8 @@ func (f *importFactory) selectVersionFromGK(gk schema.GroupKind) (schema.GroupVe
 			eris.Errorf(
 				"no known versions for Group %s, Kind %s",
 				gk.Group,
-				gk.Kind)
+				gk.Kind,
+			)
 	}
 
 	// Scan for the GVK that implements genruntime.ImportableResource
@@ -76,7 +77,8 @@ func (f *importFactory) selectVersionFromGK(gk schema.GroupKind) (schema.GroupVe
 					eris.Errorf(
 						"multiple known versions for Group %s, Kind %s implement genruntime.ImportableResource",
 						gk.Group,
-						gk.Kind)
+						gk.Kind,
+					)
 			}
 
 			result = &gvk
@@ -88,7 +90,8 @@ func (f *importFactory) selectVersionFromGK(gk schema.GroupKind) (schema.GroupVe
 			eris.Errorf(
 				"no known versions for Group %s, Kind %s implement genruntime.ImportableResource",
 				gk.Group,
-				gk.Kind)
+				gk.Kind,
+			)
 	}
 
 	return *result, nil

--- a/v2/cmd/asoctl/pkg/importresources/importable_arm_resource.go
+++ b/v2/cmd/asoctl/pkg/importresources/importable_arm_resource.go
@@ -198,7 +198,8 @@ func (i *importableARMResource) findChildren(
 		eris.Wrapf(
 			kerrors.NewAggregate(errs),
 			"importing childresources of %s",
-			i.armID)
+			i.armID,
+		)
 }
 
 func (i *importableARMResource) createImportFunction(
@@ -332,7 +333,8 @@ func (i *importableARMResource) importChildResources(
 	imp, ok := obj.(genruntime.ImportableARMResource)
 	if !ok {
 		return nil, eris.Errorf(
-			"unable to create blank resource, expected %s to identify an importable ARM object", childResourceType)
+			"unable to create blank resource, expected %s to identify an importable ARM object", childResourceType,
+		)
 	}
 
 	// Based on the ARM ID of our owner, create the container URI to list the child resources
@@ -341,7 +343,8 @@ func (i *importableARMResource) importChildResources(
 		ctx,
 		i.client,
 		containerURI,
-		imp.GetAPIVersion())
+		imp.GetAPIVersion(),
+	)
 	if err != nil {
 		if _, nonfatal := i.classifyError(err); nonfatal {
 			// Non-fatal error, we'll just skip this child resource type
@@ -427,7 +430,8 @@ func (i *importableARMResource) createImportableObjectFromID(
 	importable, ok := obj.(genruntime.ImportableARMResource)
 	if !ok {
 		return nil, eris.Errorf(
-			"unable to create blank resource, expected %s to identify an importable ARM object", armID)
+			"unable to create blank resource, expected %s to identify an importable ARM object", armID,
+		)
 	}
 
 	i.SetAzureName(armID.Name, importable)

--- a/v2/cmd/asoctl/pkg/importresources/resource_importer.go
+++ b/v2/cmd/asoctl/pkg/importresources/resource_importer.go
@@ -294,7 +294,8 @@ func (ri *ResourceImporter) startCollationOfResults(
 			ri.log.Info(
 				"Imported",
 				"kind", gk,
-				"name", rsrc.Name())
+				"name", rsrc.Name(),
+			)
 
 			report.AddSuccessfulImport(gk)
 			ri.imported[rsrc.ID()] = rsrc
@@ -319,7 +320,8 @@ func (ri *ResourceImporter) startCollationOfErrors(
 					"Skipped",
 					"kind", ie.gk,
 					"name", ie.name,
-					"because", skipped.Because)
+					"because", skipped.Because,
+				)
 				report.AddSkippedImport(ie.gk, skipped.Because)
 			} else {
 				ri.log.Error(ie.err,

--- a/v2/cmd/asoctl/pkg/importresources/resource_importer_report.go
+++ b/v2/cmd/asoctl/pkg/importresources/resource_importer_report.go
@@ -103,7 +103,8 @@ func (r *resourceImportReport) WriteToLog(log logr.Logger) {
 		keys,
 		func(left resourceImportReportKey, right resourceImportReportKey) int {
 			return left.compareTo(right)
-		})
+		},
+	)
 
 	for _, key := range keys {
 		count := r.content[key]
@@ -146,20 +147,23 @@ func (k *resourceImportReportKey) WriteToLog(log logr.Logger, count int) {
 			"Successful imports",
 			"Group", k.group,
 			"Kind", k.kind,
-			"Count", count)
+			"Count", count,
+		)
 	case Skipped:
 		log.V(1).Info(
 			"Skipped imports",
 			"Group", k.group,
 			"Kind", k.kind,
 			"Count", count,
-			"Reason", k.reason)
+			"Reason", k.reason,
+		)
 	case Failed:
 		log.Error(
 			errors.New(k.reason),
 			"Failed imports",
 			"Group", k.group,
 			"Kind", k.kind,
-			"Count", count)
+			"Count", count,
+		)
 	}
 }

--- a/v2/cmd/asoctl/pkg/importresources/result.go
+++ b/v2/cmd/asoctl/pkg/importresources/result.go
@@ -182,7 +182,8 @@ func (*Result) writeTo(resources []ImportedResource, destination io.Writer) erro
 			}
 
 			return strings.Compare(left.Name(), right.Name())
-		})
+		},
+	)
 
 	for _, resource := range resources {
 		data, err := yaml.Marshal(resource.Resource())

--- a/v2/cmd/asoctl/pkg/importresources/skipped_error.go
+++ b/v2/cmd/asoctl/pkg/importresources/skipped_error.go
@@ -43,5 +43,6 @@ func (e SkippedError) Error() string {
 		e.GroupKind.Group,
 		e.GroupKind.Kind,
 		e.Name,
-		e.Because)
+		e.Because,
+	)
 }

--- a/v2/cmd/controller/app/flags.go
+++ b/v2/cmd/controller/app/flags.go
@@ -33,7 +33,8 @@ func (f Flags) String() string {
 		f.WebhookCertDir,
 		f.EnableLeaderElection,
 		f.CRDManagementMode,
-		f.CRDPatterns)
+		f.CRDPatterns,
+	)
 }
 
 func InitFlags(flagSet *flag.FlagSet) *Flags {

--- a/v2/cmd/controller/app/setup.go
+++ b/v2/cmd/controller/app/setup.go
@@ -313,7 +313,8 @@ func getDefaultAzureTokenCredential(cfg config.Values, setupLog logr.Logger) (az
 				TenantID:                   cfg.TenantID,
 				TokenFilePath:              identity.FederatedTokenFilePath,
 				AdditionallyAllowedTenants: cfg.AdditionalTenants,
-			})
+			},
+		)
 		if err != nil {
 			return nil, eris.Wrapf(err, "unable to get workload identity credential")
 		}
@@ -333,7 +334,8 @@ func getDefaultAzureTokenCredential(cfg config.Values, setupLog logr.Logger) (az
 					Cloud: cfg.Cloud(),
 				},
 				AdditionallyAllowedTenants: cfg.AdditionalTenants,
-			})
+			},
+		)
 		if err != nil {
 			return nil, eris.Wrapf(err, "unable to get client certificate credential")
 		}
@@ -370,7 +372,8 @@ func newChainedCredential(cfg config.Values, setupLog logr.Logger) (azcore.Token
 			ClientOptions: azcore.ClientOptions{
 				Cloud: cfg.Cloud(),
 			},
-		})
+		},
+	)
 	if err != nil {
 		setupLog.Error(err, "EnvironmentCredential not available")
 	} else {
@@ -450,19 +453,22 @@ func initializeClients(cfg config.Values, mgr ctrl.Manager) (*clients, error) {
 		&identity.CredentialProviderOptions{
 			Cloud:                   to.Ptr(cfg.Cloud()),
 			AllowMultiEnvManagement: cfg.AllowMultiEnvManagement,
-		})
+		},
+	)
 
 	armClientCache := armreconciler.NewARMClientCache(
 		credentialProvider,
 		cfg.Cloud(),
 		nil,
-		armMetrics)
+		armMetrics,
+	)
 
 	genericarmclient.AddToUserAgent(cfg.UserAgentSuffix)
 
 	entraClientCache := entrareconciler.NewEntraClientCache(
 		credentialProvider,
-		nil)
+		nil,
+	)
 
 	positiveConditions := conditions.NewPositiveConditionBuilder(clock.New())
 
@@ -511,7 +517,8 @@ func initializeWatchers(
 		clients.credentialProvider,
 		clients.positiveConditions,
 		clients.expressionEvaluator,
-		clients.options)
+		clients.options,
+	)
 	if err != nil {
 		return eris.Wrap(err, "failed getting storage types and reconcilers")
 	}
@@ -528,7 +535,8 @@ func initializeWatchers(
 		clients.kubeClient,
 		clients.positiveConditions,
 		objs,
-		clients.options)
+		clients.options,
+	)
 	if err != nil {
 		return eris.Wrap(err, "failed to register gvks")
 	}
@@ -556,7 +564,8 @@ func makeControllerOptions(cfg config.Values) generic.Options {
 			additionalRateLimiters,
 			&workqueue.TypedBucketRateLimiter[reconcile.Request]{
 				Limiter: rate.NewLimiter(rate.Limit(cfg.RateLimit.QPS), cfg.RateLimit.BucketSize),
-			})
+			},
+		)
 	}
 
 	// If sync period isn't set, set verySlow delay at DefaultSyncInterval (1h), otherwise set it
@@ -584,7 +593,8 @@ func makeControllerOptions(cfg config.Values) generic.Options {
 				ErrorMaxSlowDelay:  3 * time.Minute,
 				ErrorVerySlowDelay: verySlowDelay,
 				SyncPeriod:         cfg.SyncPeriod,
-			}),
+			},
+		),
 	}
 }
 
@@ -600,7 +610,8 @@ func newCRDManager(
 		client.Options{
 			Scheme: crdScheme,
 			// nil cache means we don't use the cache (reading direct from API server)
-		})
+		},
+	)
 	if err != nil {
 		return nil, eris.Wrap(err, "unable to create CRD client")
 	}

--- a/v2/internal/controllers/app_containerapp_20230301_test.go
+++ b/v2/internal/controllers/app_containerapp_20230301_test.go
@@ -52,7 +52,8 @@ func Test_App_ContainerApps_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armID,
-		string(app.APIVersion_Value))
+		string(app.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/app_containerapp_20250101_test.go
+++ b/v2/internal/controllers/app_containerapp_20250101_test.go
@@ -52,7 +52,8 @@ func Test_App_ContainerApps_20250101_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armID,
-		string(app.APIVersion_Value))
+		string(app.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/app_job_20230301_test.go
+++ b/v2/internal/controllers/app_job_20230301_test.go
@@ -67,7 +67,8 @@ func Test_App_Job_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(app.APIVersion_Value))
+		string(app.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/app_job_20250101_test.go
+++ b/v2/internal/controllers/app_job_20250101_test.go
@@ -67,7 +67,8 @@ func Test_App_Job_20250101_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(app.APIVersion_Value))
+		string(app.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/app_managedenvironment_20230301_test.go
+++ b/v2/internal/controllers/app_managedenvironment_20230301_test.go
@@ -39,7 +39,8 @@ func Test_App_ManagedEnvironment_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(app.APIVersion_Value))
+		string(app.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/app_managedenvironment_20250101_test.go
+++ b/v2/internal/controllers/app_managedenvironment_20250101_test.go
@@ -39,7 +39,8 @@ func Test_App_ManagedEnvironment_20250101_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(app.APIVersion_Value))
+		string(app.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/appconfiguration_configstore_crud_v20220501_test.go
+++ b/v2/internal/controllers/appconfiguration_configstore_crud_v20220501_test.go
@@ -61,14 +61,16 @@ func Test_AppConfiguration_ConfigurationStore_v20220501_CRUD(t *testing.T) {
 			Test: func(tc *testcommon.KubePerTestContext) {
 				ConfigStore_WriteSecrets(tc, cs)
 			},
-		})
+		},
+	)
 
 	tc.DeleteResourceAndWait(cs)
 
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(appconfig.APIVersion_Value))
+		string(appconfig.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(gomega.HaveOccurred())
 	tc.Expect(exists).To(gomega.BeFalse())
 }
@@ -91,5 +93,6 @@ func ConfigStore_WriteSecrets(tc *testcommon.KubePerTestContext, cs *appconfig.C
 		"primaryConnectionString",
 		"secondaryConnectionString",
 		"primaryReadOnlyConnectionString",
-		"secondaryReadOnlyConnectionString")
+		"secondaryReadOnlyConnectionString",
+	)
 }

--- a/v2/internal/controllers/appconfiguration_keyvalue_v20240601_crud_test.go
+++ b/v2/internal/controllers/appconfiguration_keyvalue_v20240601_crud_test.go
@@ -60,7 +60,8 @@ func Test_AppConfiguration_KeyValue_v20240601_CRUD(t *testing.T) {
 			Test: func(tc *testcommon.KubePerTestContext) {
 				AppConfiguration_Snapshot_v1api20240601_CRUD(tc, cs)
 			},
-		})
+		},
+	)
 
 	tc.DeleteResourceAndWait(cs)
 }
@@ -103,7 +104,8 @@ func AppConfiguration_KeyValue_v1api20240601_CRUD(tc *testcommon.KubePerTestCont
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(appconfig.APIVersion_Value))
+		string(appconfig.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }
@@ -135,7 +137,8 @@ func AppConfiguration_Replica_v1api20240601_CRUD(tc *testcommon.KubePerTestConte
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(appconfig.APIVersion_Value))
+		string(appconfig.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/authorization_roleassignment_20220401_test.go
+++ b/v2/internal/controllers/authorization_roleassignment_20220401_test.go
@@ -85,7 +85,8 @@ func Test_Authorization_RoleAssignment_OnResourceGroup_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(authorization.APIVersion_Value))
+		string(authorization.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }
@@ -152,7 +153,8 @@ func Test_Authorization_RoleAssignmentOfBuiltInRole_OnResourceGroup_CRUD(t *test
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(authorization.APIVersion_Value))
+		string(authorization.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }
@@ -244,7 +246,8 @@ func Test_Authorization_RoleAssignment_OnStorageAccount_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(authorization.APIVersion_Value))
+		string(authorization.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/authorization_roledefinition_test.go
+++ b/v2/internal/controllers/authorization_roledefinition_test.go
@@ -71,7 +71,8 @@ func Test_Authorization_RoleDefinitionSubscriptionScope_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(authorization.APIVersion_Value))
+		string(authorization.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }
@@ -113,7 +114,8 @@ func Test_Authorization_RoleDefinitionResourceGroupScope_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(authorization.APIVersion_Value))
+		string(authorization.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/cache_redis_crud_v20230401_test.go
+++ b/v2/internal/controllers/cache_redis_crud_v20230401_test.go
@@ -58,7 +58,8 @@ func Test_Cache_Redis_20230401_CRUD(t *testing.T) {
 			Test: func(tc *testcommon.KubePerTestContext) {
 				Redis_FirewallRule_20230401_CRUD(tc, redis1)
 			},
-		})
+		},
+	)
 
 	tc.RunParallelSubtests(
 		testcommon.Subtest{

--- a/v2/internal/controllers/cache_redis_crud_v20230801_test.go
+++ b/v2/internal/controllers/cache_redis_crud_v20230801_test.go
@@ -58,7 +58,8 @@ func Test_Cache_Redis_20230801_CRUD(t *testing.T) {
 			Test: func(tc *testcommon.KubePerTestContext) {
 				Redis_FirewallRule_20230801_CRUD(tc, redis1)
 			},
-		})
+		},
+	)
 
 	tc.RunParallelSubtests(
 		testcommon.Subtest{

--- a/v2/internal/controllers/cache_redis_crud_v20241101_test.go
+++ b/v2/internal/controllers/cache_redis_crud_v20241101_test.go
@@ -54,7 +54,8 @@ func Test_Cache_Redis_20241101_CRUD(t *testing.T) {
 			Test: func(tc *testcommon.KubePerTestContext) {
 				Redis_FirewallRule_20241101_CRUD(tc, redis1)
 			},
-		})
+		},
+	)
 
 	// Run these before the linked server stuff because they are quick and the linked server stuff seems to get stuck (or at least take a really long time) if you mess with
 	// it much...

--- a/v2/internal/controllers/cdn_profile_crud_v20210601_test.go
+++ b/v2/internal/controllers/cdn_profile_crud_v20210601_test.go
@@ -51,7 +51,8 @@ func Test_CDN_Profile_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(cdn.APIVersion_Value))
+		string(cdn.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/cel_configmap_export_test.go
+++ b/v2/internal/controllers/cel_configmap_export_test.go
@@ -60,7 +60,8 @@ func Test_CELExportConfigMap(t *testing.T) {
 		configMapName,
 		"principalId", *mi.Status.PrincipalId,
 		"greeting", "hello",
-		"classification", "friend")
+		"classification", "friend",
+	)
 }
 
 func Test_CELExportConflictingConfigMaps_Rejected(t *testing.T) {
@@ -230,5 +231,6 @@ func Test_CELExportConfigMapPropertyOnDifferentVersion(t *testing.T) {
 	// The ConfigMap should exist with the expected values
 	tc.ExpectConfigMapHasKeysAndValues(
 		configMapName,
-		"policy", "false")
+		"policy", "false",
+	)
 }

--- a/v2/internal/controllers/compute_availabilityset_v1api20241101_crud_test.go
+++ b/v2/internal/controllers/compute_availabilityset_v1api20241101_crud_test.go
@@ -55,7 +55,8 @@ func Test_Compute_AvailabilitySet_v20241101_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(compute.APIVersion_Value))
+		string(compute.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/compute_disk_20200930_test.go
+++ b/v2/internal/controllers/compute_disk_20200930_test.go
@@ -60,7 +60,8 @@ func Test_Compute_Disk_20200930_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(compute.APIVersion_Value))
+		string(compute.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/compute_disk_20240302_test.go
+++ b/v2/internal/controllers/compute_disk_20240302_test.go
@@ -59,7 +59,8 @@ func Test_Compute_Disk_20240302_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(compute.APIVersion_Value))
+		string(compute.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/compute_diskaccess_20240302_test.go
+++ b/v2/internal/controllers/compute_diskaccess_20240302_test.go
@@ -108,7 +108,8 @@ func Test_Compute_DiskAccess_20240302_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(compute.APIVersion_Value))
+		string(compute.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/compute_vmss_crud_v20201201_test.go
+++ b/v2/internal/controllers/compute_vmss_crud_v20201201_test.go
@@ -100,7 +100,8 @@ func newLoadBalancerForVMSS(tc *testcommon.KubePerTestContext, rg *resources.Res
 		"loadBalancers",
 		lbName,
 		"frontendIPConfigurations",
-		lbFrontendName)
+		lbFrontendName,
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/v2/internal/controllers/containerservice_managedcluster_crud_v1api20240901_test.go
+++ b/v2/internal/controllers/containerservice_managedcluster_crud_v1api20240901_test.go
@@ -72,7 +72,8 @@ func Test_AKS_ManagedCluster_20240901_CRUD(t *testing.T) {
 			Test: func(tc *testcommon.KubePerTestContext) {
 				AKS_ManagedCluster_Kubeconfig_20240901_Secrets(tc, cluster)
 			},
-		})
+		},
+	)
 	tc.RunParallelSubtests(
 		testcommon.Subtest{
 			Name: "AKS AgentPool CRUD",

--- a/v2/internal/controllers/containerservice_managedcluster_crud_v1api20250801_test.go
+++ b/v2/internal/controllers/containerservice_managedcluster_crud_v1api20250801_test.go
@@ -74,7 +74,8 @@ func Test_AKS_ManagedCluster_20250801_CRUD(t *testing.T) {
 			Test: func(tc *testcommon.KubePerTestContext) {
 				AKS_ManagedCluster_Kubeconfig_20250801_Secrets(tc, cluster)
 			},
-		})
+		},
+	)
 	tc.RunParallelSubtests(
 		testcommon.Subtest{
 			Name: "AKS AgentPool CRUD",

--- a/v2/internal/controllers/containerservice_managedcluster_crud_v20251002preview_test.go
+++ b/v2/internal/controllers/containerservice_managedcluster_crud_v20251002preview_test.go
@@ -72,7 +72,8 @@ func Test_AKS_ManagedCluster_20251002preview_CRUD(t *testing.T) {
 			Test: func(tc *testcommon.KubePerTestContext) {
 				AKS_ManagedCluster_Kubeconfig_20251002preview_Secrets(tc, cluster)
 			},
-		})
+		},
+	)
 	tc.RunParallelSubtests(
 		testcommon.Subtest{
 			Name: "AKS AgentPool CRUD",

--- a/v2/internal/controllers/controller_resources.go
+++ b/v2/internal/controllers/controller_resources.go
@@ -79,7 +79,8 @@ func GetKnownStorageTypes(
 		resourceResolver,
 		positiveConditions,
 		expressionEvaluator,
-		options)
+		options,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +105,8 @@ func GetKnownStorageTypes(
 				resourceResolver,
 				positiveConditions,
 				credentialProvider,
-				options.Config),
+				options.Config,
+			),
 			Predicate: makeStandardPredicate(),
 			Indexes: []registration.Index{
 				{
@@ -118,7 +120,8 @@ func GetKnownStorageTypes(
 					MakeEventHandler: watchSecretsFactory([]string{".spec.localUser.password"}, &mysqlv1.UserList{}),
 				},
 			},
-		})
+		},
+	)
 
 	// dbforpostgresql
 	knownStorageTypes = append(
@@ -130,7 +133,8 @@ func GetKnownStorageTypes(
 				clients.KubeClient,
 				resourceResolver,
 				positiveConditions,
-				options.Config),
+				options.Config,
+			),
 			Predicate: makeStandardPredicate(),
 			Indexes: []registration.Index{
 				{
@@ -144,7 +148,8 @@ func GetKnownStorageTypes(
 					MakeEventHandler: watchSecretsFactory([]string{".spec.localUser.password"}, &postgresqlv1.UserList{}),
 				},
 			},
-		})
+		},
+	)
 
 	// azuresql
 	knownStorageTypes = append(
@@ -157,7 +162,8 @@ func GetKnownStorageTypes(
 				resourceResolver,
 				positiveConditions,
 				credentialProvider,
-				options.Config),
+				options.Config,
+			),
 			Predicate: makeStandardPredicate(),
 			Indexes: []registration.Index{
 				{
@@ -171,7 +177,8 @@ func GetKnownStorageTypes(
 					MakeEventHandler: watchSecretsFactory([]string{".spec.localUser.password"}, &azuresqlv1.UserList{}),
 				},
 			},
-		})
+		},
+	)
 
 	// entra
 	knownStorageTypes = append(
@@ -184,11 +191,13 @@ func GetKnownStorageTypes(
 				clients.EntraConnectionFactory,
 				resourceResolver,
 				positiveConditions,
-				options.Config),
+				options.Config,
+			),
 			Predicate: makeStandardPredicate(),
 			Indexes:   []registration.Index{},
 			Watches:   []registration.Watch{},
-		})
+		},
+	)
 
 	return knownStorageTypes, nil
 }
@@ -232,7 +241,8 @@ func getGeneratedStorageTypes(
 			expressionEvaluator,
 			options,
 			extension,
-			t)
+			t,
+		)
 	}
 
 	return knownStorageTypes, nil
@@ -255,7 +265,8 @@ func augmentWithARMReconciler(
 		positiveConditions,
 		expressionEvaluator,
 		options.Config,
-		extension)
+		extension,
+	)
 }
 
 func augmentWithPredicate(t *registration.StorageType) {
@@ -268,7 +279,8 @@ func makeStandardPredicate() predicate.Predicate {
 	return predicate.Or(
 		predicate.GenerationChangedPredicate{},
 		reconcilers.ARMReconcilerAnnotationChangedPredicate(),
-		reconcilers.ARMPerResourceSecretAnnotationChangedPredicate())
+		reconcilers.ARMPerResourceSecretAnnotationChangedPredicate(),
+	)
 }
 
 func augmentWithControllerName(t *registration.StorageType) error {
@@ -311,7 +323,8 @@ func GetKnownTypes() []*registration.KnownType {
 			Obj:       &mysqlv1.User{},
 			Defaulter: &mysqlv1webhook.User_Webhook{},
 			Validator: &mysqlv1webhook.User_Webhook{},
-		})
+		},
+	)
 
 	// dbforpostgresql
 	knownTypes = append(
@@ -320,7 +333,8 @@ func GetKnownTypes() []*registration.KnownType {
 			Obj:       &postgresqlv1.User{},
 			Defaulter: &postgresqlv1webhook.User_Webhook{},
 			Validator: &postgresqlv1webhook.User_Webhook{},
-		})
+		},
+	)
 
 	// Azure SQL
 	knownTypes = append(
@@ -329,7 +343,8 @@ func GetKnownTypes() []*registration.KnownType {
 			Obj:       &azuresqlv1.User{},
 			Defaulter: &azuresqlv1webhook.User_Webhook{},
 			Validator: &azuresqlv1webhook.User_Webhook{},
-		})
+		},
+	)
 	// Entra
 	knownTypes = append(
 		knownTypes,
@@ -337,7 +352,8 @@ func GetKnownTypes() []*registration.KnownType {
 			Obj:       &entrav1.SecurityGroup{},
 			Defaulter: &entrav1webhook.SecurityGroup_Webhook{},
 			Validator: &entrav1webhook.SecurityGroup_Webhook{},
-		})
+		},
+	)
 
 	return knownTypes
 }
@@ -404,7 +420,8 @@ func watchEntity(c client.Client, log logr.Logger, keys []string, objList client
 				"namespace", o.GetNamespace(),
 				"name", o.GetName(),
 				"actual", fmt.Sprintf("%T", o),
-				"expected", fmt.Sprintf("%T", entity))
+				"expected", fmt.Sprintf("%T", entity),
+			)
 			return nil
 		}
 

--- a/v2/internal/controllers/crd_datafactory_test.go
+++ b/v2/internal/controllers/crd_datafactory_test.go
@@ -61,7 +61,8 @@ func Test_Data_Factory_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		factoryArmId,
-		string(datafactory.APIVersion_Value))
+		string(datafactory.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/crd_devices_iothub_test.go
+++ b/v2/internal/controllers/crd_devices_iothub_test.go
@@ -51,7 +51,8 @@ func Test_Devices_IotHub_CRUD(t *testing.T) {
 			Test: func(tc *testcommon.KubePerTestContext) {
 				IotHub_WriteSecrets(tc, iothub)
 			},
-		})
+		},
+	)
 
 	tc.DeleteResourceAndWait(iothub)
 
@@ -92,5 +93,6 @@ func IotHub_WriteSecrets(tc *testcommon.KubePerTestContext, iotHub *devices.IotH
 		"registryReadWritePrimaryKey",
 		"registryReadWriteSecondaryKey",
 		"servicePrimaryKey",
-		"serviceSecondaryKey")
+		"serviceSecondaryKey",
+	)
 }

--- a/v2/internal/controllers/crd_machinelearningservices_20210701_test.go
+++ b/v2/internal/controllers/crd_machinelearningservices_20210701_test.go
@@ -47,7 +47,8 @@ func Test_MachineLearning_Workspaces_CRUD(t *testing.T) {
 			Test: func(tc *testcommon.KubePerTestContext) {
 				Workspaces_WriteSecrets(tc, workspace)
 			},
-		})
+		},
+	)
 
 	tc.RunParallelSubtests(
 		testcommon.Subtest{
@@ -83,7 +84,8 @@ func Workspaces_WriteSecrets(tc *testcommon.KubePerTestContext, workspace *machi
 		workspaceKeysSecret,
 		"primaryNotebookAccessKey",
 		"secondaryNotebookAccessKey",
-		"userStorageKey")
+		"userStorageKey",
+	)
 }
 
 func newWorkspace(tc *testcommon.KubePerTestContext, owner *genruntime.KnownResourceReference, sa *storage.StorageAccount, kv *keyvault.Vault, location *string) *machinelearningservices.Workspace {

--- a/v2/internal/controllers/crd_redhatopenshift_openshiftcluster_20230401_test.go
+++ b/v2/internal/controllers/crd_redhatopenshift_openshiftcluster_20230401_test.go
@@ -135,7 +135,8 @@ func Test_RedHatOpenShift_OpenShiftCluster_CRUD(t *testing.T) {
 		roleAssingmentFromRPtoVnet,
 		workerSubnet,
 		masterSubnet,
-		cluster)
+		cluster,
+	)
 
 	tc.Expect(cluster.Status.Id).ToNot(BeNil())
 	armId := *cluster.Status.Id

--- a/v2/internal/controllers/crd_resources_resourcegroup_test.go
+++ b/v2/internal/controllers/crd_resources_resourcegroup_test.go
@@ -42,7 +42,8 @@ func Test_Resources_ResourceGroup_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		"2020-06-01")
+		"2020-06-01",
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/crd_search_searchservice_test.go
+++ b/v2/internal/controllers/crd_search_searchservice_test.go
@@ -51,7 +51,8 @@ func Test_Search_SearchService_CRUD(t *testing.T) {
 			Test: func(tc *testcommon.KubePerTestContext) {
 				SearchService_WriteSecrets(tc, service)
 			},
-		})
+		},
+	)
 
 	old := service.DeepCopy()
 	key := "foo"
@@ -85,5 +86,6 @@ func SearchService_WriteSecrets(tc *testcommon.KubePerTestContext, service *sear
 		searchKeysSecret,
 		"adminPrimaryKey",
 		"adminSecondaryKey",
-		"queryKey")
+		"queryKey",
+	)
 }

--- a/v2/internal/controllers/crd_sql_server_failover_group_test.go
+++ b/v2/internal/controllers/crd_sql_server_failover_group_test.go
@@ -99,7 +99,8 @@ func Test_SQL_Server_FailoverGroup_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(sql.APIVersion_Value))
+		string(sql.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/dataprotection_backupinstance_crud_20231101_test.go
+++ b/v2/internal/controllers/dataprotection_backupinstance_crud_20231101_test.go
@@ -186,7 +186,8 @@ func Test_DataProtection_BackupInstance_20231101_CRUD(t *testing.T) {
 		clusterRoleAssignment,
 		clusterMSIRoleAssignment,
 		snapshotRGRoleAssignment,
-		backupInstance)
+		backupInstance,
+	)
 
 	objectKey := client.ObjectKeyFromObject(backupInstance)
 

--- a/v2/internal/controllers/dataprotection_backupvault_crud_v20230101_test.go
+++ b/v2/internal/controllers/dataprotection_backupvault_crud_v20230101_test.go
@@ -88,7 +88,8 @@ func Test_Dataprotection_Backupvault_20230101_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(dataprotection.APIVersion_Value))
+		string(dataprotection.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/dataprotection_backupvault_crud_v20231101_test.go
+++ b/v2/internal/controllers/dataprotection_backupvault_crud_v20231101_test.go
@@ -94,7 +94,8 @@ func Test_Dataprotection_Backupvault_20231101_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(dataprotection.APIVersion_Value))
+		string(dataprotection.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/dbforpostgresql_flexibleserver_crud_v1api20230601preview_test.go
+++ b/v2/internal/controllers/dbforpostgresql_flexibleserver_crud_v1api20230601preview_test.go
@@ -167,7 +167,8 @@ func FlexibleServer_20230601Preview_ConfigValuesWrittenToSameConfigMap(tc *testc
 	tc.ExpectConfigMapHasKeysAndValues(
 		flexibleServerConfigMap,
 		flexibleServerConfigMapKey,
-		*flexibleServer.Status.FullyQualifiedDomainName)
+		*flexibleServer.Status.FullyQualifiedDomainName,
+	)
 }
 
 func FlexibleServer_Database_20230601Preview_CRUD(tc *testcommon.KubePerTestContext, flexibleServer *postgresql.FlexibleServer) {

--- a/v2/internal/controllers/dbforpostgresql_flexibleserver_crud_v1api20240801_test.go
+++ b/v2/internal/controllers/dbforpostgresql_flexibleserver_crud_v1api20240801_test.go
@@ -227,7 +227,8 @@ func FlexibleServer_20240801_ConfigValuesWrittenToSameConfigMap(tc *testcommon.K
 	tc.ExpectConfigMapHasKeysAndValues(
 		flexibleServerConfigMap,
 		flexibleServerConfigMapKey,
-		*flexibleServer.Status.FullyQualifiedDomainName)
+		*flexibleServer.Status.FullyQualifiedDomainName,
+	)
 }
 
 func FlexibleServer_VirtualEndpoint_20240801_CRUD(tc *testcommon.KubePerTestContext, flexibleServer *postgresql.FlexibleServer) {

--- a/v2/internal/controllers/dbforpostgresql_flexibleserver_crud_v1api20250801_test.go
+++ b/v2/internal/controllers/dbforpostgresql_flexibleserver_crud_v1api20250801_test.go
@@ -195,7 +195,8 @@ func FlexibleServer_20250801_ConfigValuesWrittenToSameConfigMap(tc *testcommon.K
 	tc.ExpectConfigMapHasKeysAndValues(
 		flexibleServerConfigMap,
 		flexibleServerConfigMapKey,
-		*flexibleServer.Status.FullyQualifiedDomainName)
+		*flexibleServer.Status.FullyQualifiedDomainName,
+	)
 }
 
 func FlexibleServer_Database_20250801_CRUD(tc *testcommon.KubePerTestContext, flexibleServer *postgresql.FlexibleServer) {

--- a/v2/internal/controllers/documentdb_cassandracluster_crud_v1api20251015_test.go
+++ b/v2/internal/controllers/documentdb_cassandracluster_crud_v1api20251015_test.go
@@ -88,7 +88,8 @@ func Test_DocumentDB_CassandraCluster_v1api20251015_CRUD(t *testing.T) {
 		mgmtSubnetRoleAssignment,
 		dcSubnetRoleAssignment,
 		cassandraCluster,
-		dataCenter)
+		dataCenter,
+	)
 
 	// Perform some assertions on the cluster we just created
 	tc.Expect(cassandraCluster.Status.Id).ToNot(BeNil())
@@ -120,7 +121,8 @@ func Test_DocumentDB_CassandraCluster_v1api20251015_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(documentdb.APIVersion_Value))
+		string(documentdb.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/documentdb_mongocluster_crud_v1api20240701_test.go
+++ b/v2/internal/controllers/documentdb_mongocluster_crud_v1api20240701_test.go
@@ -148,7 +148,8 @@ func Test_DocumentDB_MongoCluster_v1api20240701_CRUD(t *testing.T) {
 			Test: func(tc *testcommon.KubePerTestContext) {
 				DocumentDB_MongoCluster_FirewallRule_v1api20240701_CRUD(tc, &mongoCluster)
 			},
-		})
+		},
+	)
 
 	// Delete the cluster and make sure it goes away
 	armId := *mongoCluster.Status.Id
@@ -157,7 +158,8 @@ func Test_DocumentDB_MongoCluster_v1api20240701_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(documentdb.APIVersion_Value))
+		string(documentdb.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/documentdb_mongodb_crud_v20210515_test.go
+++ b/v2/internal/controllers/documentdb_mongodb_crud_v20210515_test.go
@@ -98,7 +98,8 @@ func Test_CosmosDB_MongoDatabase_CRUD(t *testing.T) {
 			Test: func(tc *testcommon.KubePerTestContext) {
 				CosmosDB_MongoDB_Database_ThroughputSettings_CRUD(tc, &db)
 			},
-		})
+		},
+	)
 }
 
 func CosmosDB_MongoDB_Collection_CRUD(tc *testcommon.KubePerTestContext, db client.Object) {
@@ -156,7 +157,8 @@ func CosmosDB_MongoDB_Collection_CRUD(tc *testcommon.KubePerTestContext, db clie
 			Test: func(tc *testcommon.KubePerTestContext) {
 				CosmosDB_MongoDB_Database_Collections_ThroughputSettings_CRUD(tc, &collection)
 			},
-		})
+		},
+	)
 
 	tc.T.Log("cleaning up collection")
 }

--- a/v2/internal/controllers/documentdb_mongodb_crud_v20231115_test.go
+++ b/v2/internal/controllers/documentdb_mongodb_crud_v20231115_test.go
@@ -98,7 +98,8 @@ func Test_DocumentDB_MongoDatabase_v20231115_CRUD(t *testing.T) {
 			Test: func(tc *testcommon.KubePerTestContext) {
 				DocumentDB_MongoDB_Database_ThroughputSettings_v20231115_CRUD(tc, &db)
 			},
-		})
+		},
+	)
 
 	// Delete the database and make sure it goes away
 	armId := *db.Status.Id
@@ -107,7 +108,8 @@ func Test_DocumentDB_MongoDatabase_v20231115_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(documentdb.APIVersion_Value))
+		string(documentdb.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 
@@ -118,7 +120,8 @@ func Test_DocumentDB_MongoDatabase_v20231115_CRUD(t *testing.T) {
 	exists, _, err = tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(documentdb.APIVersion_Value))
+		string(documentdb.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }
@@ -181,7 +184,8 @@ func DocumentDB_MongoDB_Collection_v20231115_CRUD(tc *testcommon.KubePerTestCont
 			Test: func(tc *testcommon.KubePerTestContext) {
 				DocumentDB_MongoDB_Database_Collections_ThroughputSettings_v20231515_CRUD(tc, &collection)
 			},
-		})
+		},
+	)
 }
 
 func DocumentDB_MongoDB_Database_ThroughputSettings_v20231115_CRUD(tc *testcommon.KubePerTestContext, db client.Object) {

--- a/v2/internal/controllers/documentdb_mongodb_crud_v20240815_test.go
+++ b/v2/internal/controllers/documentdb_mongodb_crud_v20240815_test.go
@@ -130,7 +130,8 @@ func Test_DocumentDB_MongoDatabase_v20240815_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(documentdb.APIVersion_Value))
+		string(documentdb.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 
@@ -141,7 +142,8 @@ func Test_DocumentDB_MongoDatabase_v20240815_CRUD(t *testing.T) {
 	exists, _, err = tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(documentdb.APIVersion_Value))
+		string(documentdb.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }
@@ -204,7 +206,8 @@ func DocumentDB_MongoDB_Collection_v20240815_CRUD(tc *testcommon.KubePerTestCont
 			Test: func(tc *testcommon.KubePerTestContext) {
 				DocumentDB_MongoDB_Database_Collections_ThroughputSettings_v20240815_CRUD(tc, &collection)
 			},
-		})
+		},
+	)
 }
 
 func DocumentDB_MongoDB_Database_ThroughputSettings_v20240815_CRUD(tc *testcommon.KubePerTestContext, db client.Object) {

--- a/v2/internal/controllers/documentdb_sql_crud_v20231115_test.go
+++ b/v2/internal/controllers/documentdb_sql_crud_v20231115_test.go
@@ -94,7 +94,8 @@ func Test_DocumentDB_SQLDatabase_v20231115_CRUD(t *testing.T) {
 			Test: func(tc *testcommon.KubePerTestContext) {
 				CosmosDB_SQL_Database_ThroughputSettings_v20231115_CRUD(tc, db)
 			},
-		})
+		},
+	)
 
 	// There aren't any attributes to update for databases, other than
 	// throughput settings once they're available.
@@ -105,7 +106,8 @@ func Test_DocumentDB_SQLDatabase_v20231115_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		acctId,
-		string(documentdb.APIVersion_Value))
+		string(documentdb.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }
@@ -175,7 +177,8 @@ func CosmosDB_SQL_Container_v20231115_CRUD(tc *testcommon.KubePerTestContext, db
 			Test: func(tc *testcommon.KubePerTestContext) {
 				CosmosDB_SQL_Database_Container_ThroughputSettings_v20231115_CRUD(tc, container)
 			},
-		})
+		},
+	)
 
 	tc.LogSubsectionf("Updating the default TTL on container %q", name)
 	old := container.DeepCopy()
@@ -416,7 +419,8 @@ func CosmosDB_SQL_RoleAssignment_v20231115_CRUD(tc *testcommon.KubePerTestContex
 		"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DocumentDB/databaseAccounts/%s/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002",
 		tc.AzureSubscription,
 		rg.AzureName(),
-		acct.AzureName())
+		acct.AzureName(),
+	)
 
 	scope := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DocumentDB/databaseAccounts/%s",
 		tc.AzureSubscription,

--- a/v2/internal/controllers/documentdb_sql_crud_v20240815_test.go
+++ b/v2/internal/controllers/documentdb_sql_crud_v20240815_test.go
@@ -94,7 +94,8 @@ func Test_DocumentDB_SQLDatabase_v20240815_CRUD(t *testing.T) {
 			Test: func(tc *testcommon.KubePerTestContext) {
 				CosmosDB_SQL_Database_ThroughputSettings_v20240815_CRUD(tc, db)
 			},
-		})
+		},
+	)
 
 	// There aren't any attributes to update for databases, other than
 	// throughput settings once they're available.
@@ -105,7 +106,8 @@ func Test_DocumentDB_SQLDatabase_v20240815_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		acctId,
-		string(documentdb.APIVersion_Value))
+		string(documentdb.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }
@@ -174,7 +176,8 @@ func CosmosDB_SQL_Container_v20240815_CRUD(tc *testcommon.KubePerTestContext, db
 			Test: func(tc *testcommon.KubePerTestContext) {
 				CosmosDB_SQL_Database_Container_ThroughputSettings_v20240815_CRUD(tc, &container)
 			},
-		})
+		},
+	)
 
 	tc.LogSubsectionf("Updating the default TTL on container %q", name)
 	old := container.DeepCopy()
@@ -415,7 +418,8 @@ func CosmosDB_SQL_RoleAssignment_v20240815_CRUD(tc *testcommon.KubePerTestContex
 		"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DocumentDB/databaseAccounts/%s/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002",
 		tc.AzureSubscription,
 		rg.AzureName(),
-		acct.AzureName())
+		acct.AzureName(),
+	)
 
 	scope := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DocumentDB/databaseAccounts/%s",
 		tc.AzureSubscription,

--- a/v2/internal/controllers/eventgrid_domain_v20200601_test.go
+++ b/v2/internal/controllers/eventgrid_domain_v20200601_test.go
@@ -97,7 +97,8 @@ func Test_EventGrid_Domain(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(eventgrid.APIVersion_Value))
+		string(eventgrid.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/eventgrid_topic_v20200601_test.go
+++ b/v2/internal/controllers/eventgrid_topic_v20200601_test.go
@@ -66,7 +66,8 @@ func Test_EventGrid_Topic(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(eventgrid.APIVersion_Value))
+		string(eventgrid.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/insights_component_crud_20200202_test.go
+++ b/v2/internal/controllers/insights_component_crud_20200202_test.go
@@ -69,7 +69,8 @@ func Test_Insights_Component_v20200202_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(insights20200202.APIVersion_Value))
+		string(insights20200202.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }
@@ -133,7 +134,8 @@ func Insights_WebTest_20220615_CRUD(tc *testcommon.KubePerTestContext, rg *resou
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(insightswebtest20220615.APIVersion_Value))
+		string(insightswebtest20220615.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }
@@ -229,7 +231,8 @@ func Insights_WebTest_20180501preview_CRUD(tc *testcommon.KubePerTestContext, rg
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(insightswebtest20180501preview.APIVersion_Value))
+		string(insightswebtest20180501preview.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }
@@ -261,7 +264,8 @@ func Test_Insights_Component_ExportConfigMap(t *testing.T) {
 			Test: func(tc *testcommon.KubePerTestContext) {
 				Component_ConfigValuesWrittenToDifferentConfigMap(tc, component)
 			},
-		})
+		},
+	)
 
 	tc.DeleteResourceAndWait(component)
 
@@ -269,7 +273,8 @@ func Test_Insights_Component_ExportConfigMap(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(insights20200202.APIVersion_Value))
+		string(insights20200202.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }
@@ -289,7 +294,8 @@ func Component_ConfigValuesWrittenToSameConfigMap(tc *testcommon.KubePerTestCont
 	tc.ExpectConfigMapHasKeysAndValues(
 		componentConfigMap,
 		"connectionString", *component.Status.ConnectionString,
-		"instrumentationKey", *component.Status.InstrumentationKey)
+		"instrumentationKey", *component.Status.InstrumentationKey,
+	)
 }
 
 func Component_ConfigValuesWrittenToDifferentConfigMap(tc *testcommon.KubePerTestContext, component *insights20200202.Component) {

--- a/v2/internal/controllers/insights_datacollectionrule_20230311_test.go
+++ b/v2/internal/controllers/insights_datacollectionrule_20230311_test.go
@@ -98,7 +98,8 @@ func Test_Insights_DataCollectionRule_v20210601_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(insights.APIVersion_Value))
+		string(insights.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 

--- a/v2/internal/controllers/insights_datacollectionrule_20240311_test.go
+++ b/v2/internal/controllers/insights_datacollectionrule_20240311_test.go
@@ -98,7 +98,8 @@ func Test_Insights_DataCollectionRule_v20240311_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(insights.APIVersion_Value))
+		string(insights.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 

--- a/v2/internal/controllers/machinelearning_workspaces_20240401_test.go
+++ b/v2/internal/controllers/machinelearning_workspaces_20240401_test.go
@@ -48,7 +48,8 @@ func Test_MachineLearning_Workspaces_20240401_CRUD(t *testing.T) {
 			Test: func(tc *testcommon.KubePerTestContext) {
 				Workspaces_WriteSecrets_20240401(tc, workspace)
 			},
-		})
+		},
+	)
 
 	tc.RunParallelSubtests(
 		testcommon.Subtest{
@@ -82,7 +83,8 @@ func Workspaces_WriteSecrets_20240401(tc *testcommon.KubePerTestContext, workspa
 		workspaceKeysSecret,
 		"primaryNotebookAccessKey",
 		"secondaryNotebookAccessKey",
-		"userStorageKey")
+		"userStorageKey",
+	)
 }
 
 func newWorkspace_20240401(tc *testcommon.KubePerTestContext, owner *genruntime.KnownResourceReference, sa *storage.StorageAccount, kv *keyvault.Vault, location *string) *machinelearningservices.Workspace {

--- a/v2/internal/controllers/machinelearningservices_registry_20240401_test.go
+++ b/v2/internal/controllers/machinelearningservices_registry_20240401_test.go
@@ -68,7 +68,8 @@ func Test_MachineLearning_Registry_20240401_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(machinelearningservices.APIVersion_Value))
+		string(machinelearningservices.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/managedidentity_userassignedidentity_crud_v20181130_test.go
+++ b/v2/internal/controllers/managedidentity_userassignedidentity_crud_v20181130_test.go
@@ -171,7 +171,8 @@ func UserManagedIdentity_ConfigValuesWrittenToSameConfigMap(tc *testcommon.KubeP
 		identityConfigMap,
 		"principalId", *identity.Status.PrincipalId,
 		"clientId", *identity.Status.ClientId,
-		"tenantId", *identity.Status.TenantId)
+		"tenantId", *identity.Status.TenantId,
+	)
 }
 
 func UserManagedIdentity_ConfigValuesWrittenToDifferentConfigMap(tc *testcommon.KubePerTestContext, identity *managedidentity2018.UserAssignedIdentity) {

--- a/v2/internal/controllers/managedidentity_userassignedidentity_crud_v20230131_test.go
+++ b/v2/internal/controllers/managedidentity_userassignedidentity_crud_v20230131_test.go
@@ -170,7 +170,8 @@ func UserManagedIdentity_20230131_ConfigValuesWrittenToSameConfigMap(tc *testcom
 		identityConfigMap,
 		"principalId", *identity.Status.PrincipalId,
 		"clientId", *identity.Status.ClientId,
-		"tenantId", *identity.Status.TenantId)
+		"tenantId", *identity.Status.TenantId,
+	)
 }
 
 func UserManagedIdentity_20230131_ConfigValuesWrittenToDifferentConfigMap(tc *testcommon.KubePerTestContext, identity *managedidentity.UserAssignedIdentity) {

--- a/v2/internal/controllers/networkfrontdoor_webapplicationfirewall_test.go
+++ b/v2/internal/controllers/networkfrontdoor_webapplicationfirewall_test.go
@@ -53,7 +53,8 @@ func Test_NetworkFrontDoorFirewallPolicy_CRUD(t *testing.T) {
 					},
 				},
 			},
-		})
+		},
+	)
 	tc.PatchResourceAndWait(old, afdFirewall)
 	tc.Expect(afdFirewall.Status.CustomRules.Rules).To(HaveLen(2))
 
@@ -63,7 +64,8 @@ func Test_NetworkFrontDoorFirewallPolicy_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armID,
-		string(frontdoor.APIVersion_Value))
+		string(frontdoor.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/networking_helpers_20201101_test.go
+++ b/v2/internal/controllers/networking_helpers_20201101_test.go
@@ -67,5 +67,6 @@ func getFrontendIPConfigurationARMID(tc *testcommon.KubePerTestContext, rg *reso
 		"loadBalancers",
 		lbName,
 		"frontendIPConfigurations",
-		lbFrontendName)
+		lbFrontendName,
+	)
 }

--- a/v2/internal/controllers/networking_trafficmanagerprofile_crud_v20220401_test.go
+++ b/v2/internal/controllers/networking_trafficmanagerprofile_crud_v20220401_test.go
@@ -82,7 +82,8 @@ func Test_Networking_TrafficManagerProfile(t *testing.T) {
 			Test: func(tc *testcommon.KubePerTestContext) {
 				Networking_TrafficManagerProfiles_NestedEndpoint(tc, rg, tmp)
 			},
-		})
+		},
+	)
 
 	tc.DeleteResourceAndWait(tmp)
 

--- a/v2/internal/controllers/notificationhubs_Namespace_20230901_test.go
+++ b/v2/internal/controllers/notificationhubs_Namespace_20230901_test.go
@@ -49,7 +49,8 @@ func Test_Notificationhubs_Namespace_20230901_CRUD(t *testing.T) {
 			Test: func(tc *testcommon.KubePerTestContext) {
 				Namespace_WriteSecrets(tc, namespace)
 			},
-		})
+		},
+	)
 
 	tc.RunParallelSubtests(
 		testcommon.Subtest{
@@ -116,7 +117,8 @@ func NotificationHub_CRUD(tc *testcommon.KubePerTestContext, owner *genruntime.K
 			Test: func(tc *testcommon.KubePerTestContext) {
 				NotificationHub_WriteSecrets(tc, notificationHub)
 			},
-		})
+		},
+	)
 
 	tc.RunParallelSubtests(
 		testcommon.Subtest{

--- a/v2/internal/controllers/operationalinsights_workspace_crud_20210601_test.go
+++ b/v2/internal/controllers/operationalinsights_workspace_crud_20210601_test.go
@@ -68,7 +68,8 @@ func Test_OperationalInsights_Workspace_v1api20210601_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(operationalinsights.APIVersion_Value))
+		string(operationalinsights.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/operationalinsights_workspace_crud_20250701_test.go
+++ b/v2/internal/controllers/operationalinsights_workspace_crud_20250701_test.go
@@ -68,7 +68,8 @@ func Test_OperationalInsights_Workspace_v1api20250701_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(operationalinsights.APIVersion_Value))
+		string(operationalinsights.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/owner_arm_id_negative_test.go
+++ b/v2/internal/controllers/owner_arm_id_negative_test.go
@@ -80,7 +80,8 @@ func Test_OwnerIsKubernetesResourceFromDifferentSubscription_ResourceFails(t *te
 		cfg.ClientID,
 		"1234", // We're not expecting to make it all the way to provision the resource, so it's OK to use a fake client secret here
 		scopedCredentialName,
-		tc.Namespace)
+		tc.Namespace,
+	)
 	tc.CreateResource(scopedCredentialSecret)
 
 	tc.CreateResourceAndWaitForFailure(acct)

--- a/v2/internal/controllers/owner_arm_id_test.go
+++ b/v2/internal/controllers/owner_arm_id_test.go
@@ -50,7 +50,8 @@ func Test_OwnerIsARMIDOfResourceGroup_ResourceSuccessfullyReconciled(t *testing.
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		acctARMID,
-		string(storage.APIVersion_Value))
+		string(storage.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }
@@ -104,7 +105,8 @@ func Test_OwnerIsARMIDOfParent_ChildResourceSuccessfullyReconciled(t *testing.T)
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		containerARMID,
-		string(storage.APIVersion_Value))
+		string(storage.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }
@@ -171,7 +173,8 @@ func Test_OwnerIsARMID_ExtensionResourceSuccessfullyReconciled(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(authorization.APIVersion_Value))
+		string(authorization.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/reconcile_policy_test.go
+++ b/v2/internal/controllers/reconcile_policy_test.go
@@ -114,7 +114,8 @@ func Test_ReconcilePolicy_SkipsDelete(t *testing.T) {
 				deleteSkippedOptions{
 					policy:      tc.policy,
 					onNamespace: tc.onNamespace,
-				})
+				},
+			)
 		})
 	}
 }
@@ -198,7 +199,8 @@ func Test_ReconcilePolicy_SkippedParentDeleted_ChildIssuesDeleteToAzure(t *testi
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		resourceId,
-		string(storage.APIVersion_Value))
+		string(storage.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }
@@ -324,7 +326,8 @@ func testDeleteSkipped(t *testing.T, opts deleteSkippedOptions) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		"2020-06-01")
+		"2020-06-01",
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeTrue())
 
@@ -354,7 +357,8 @@ func testDeleteSkipped(t *testing.T, opts deleteSkippedOptions) {
 	exists, _, err = tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		"2020-06-01")
+		"2020-06-01",
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/references_test.go
+++ b/v2/internal/controllers/references_test.go
@@ -42,10 +42,12 @@ func Test_MissingCrossResourceReference_ReturnsError(t *testing.T) {
 	tc.Expect(message).To(
 		ContainSubstring("%s/%s does not exist",
 			tc.Namespace,
-			networkInterface.Name))
+			networkInterface.Name),
+	)
 	tc.Expect(message).To(
 		ContainSubstring(`(networkinterfaces.network.azure.com "%s" not found)`,
-			networkInterface.Name))
+			networkInterface.Name),
+	)
 
 	// Delete VM and resources.
 	tc.DeleteResourcesAndWait(vm)

--- a/v2/internal/controllers/secrets_from_azure_test.go
+++ b/v2/internal/controllers/secrets_from_azure_test.go
@@ -83,7 +83,8 @@ func Test_WhenObjectPullSecretsAndSecretAlreadyExists_WarningConditionIsSet(t *t
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(storage.APIVersion_Value))
+		string(storage.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/servicebus_namespace_basic_v1api20221001preview_test.go
+++ b/v2/internal/controllers/servicebus_namespace_basic_v1api20221001preview_test.go
@@ -48,7 +48,8 @@ func Test_ServiceBus_Namespace_Basic_v1api20221001preview_CRUD(t *testing.T) {
 			Test: func(tc *testcommon.KubePerTestContext) {
 				ServiceBus_Namespace_Secrets_v1api20221001preview(tc, namespace)
 			},
-		})
+		},
+	)
 
 	tc.DeleteResourceAndWait(namespace)
 

--- a/v2/internal/controllers/servicebus_namespace_basic_v1api20240101_test.go
+++ b/v2/internal/controllers/servicebus_namespace_basic_v1api20240101_test.go
@@ -48,7 +48,8 @@ func Test_ServiceBus_Namespace_Basic_v1api20240101_CRUD(t *testing.T) {
 			Test: func(tc *testcommon.KubePerTestContext) {
 				ServiceBus_Namespace_Secrets_v1api20240101(tc, namespace)
 			},
-		})
+		},
+	)
 
 	tc.DeleteResourceAndWait(namespace)
 

--- a/v2/internal/controllers/servicebus_namespace_standard_v1api20210101preview_test.go
+++ b/v2/internal/controllers/servicebus_namespace_standard_v1api20210101preview_test.go
@@ -61,7 +61,8 @@ func Test_ServiceBus_Namespace_Standard_v1api20210101preview_CRUD(t *testing.T) 
 			Test: func(tc *testcommon.KubePerTestContext) {
 				ServiceBus_Namespace_Secrets_v1api20210101preview(tc, namespace)
 			},
-		})
+		},
+	)
 
 	tc.DeleteResourceAndWait(namespace)
 

--- a/v2/internal/controllers/servicebus_namespace_standard_v1api20221001preview_test.go
+++ b/v2/internal/controllers/servicebus_namespace_standard_v1api20221001preview_test.go
@@ -61,7 +61,8 @@ func Test_ServiceBus_Namespace_Standard_v1api20221001preview_CRUD(t *testing.T) 
 			Test: func(tc *testcommon.KubePerTestContext) {
 				ServiceBus_Namespace_Secrets_v1api20221001preview(tc, namespace)
 			},
-		})
+		},
+	)
 
 	tc.DeleteResourceAndWait(namespace)
 

--- a/v2/internal/controllers/servicebus_namespace_standard_v1api20240101_test.go
+++ b/v2/internal/controllers/servicebus_namespace_standard_v1api20240101_test.go
@@ -61,7 +61,8 @@ func Test_ServiceBus_Namespace_Standard_v1api20240101_CRUD(t *testing.T) {
 			Test: func(tc *testcommon.KubePerTestContext) {
 				ServiceBus_Namespace_Secrets_v1api20240101(tc, namespace)
 			},
-		})
+		},
+	)
 
 	tc.DeleteResourceAndWait(namespace)
 
@@ -241,5 +242,6 @@ func ServiceBus_Topic_AuthorizationRule_v1api20240101_CRUD(tc *testcommon.KubePe
 		"primaryKey",
 		"secondaryKey",
 		"primaryConnectionString",
-		"secondaryConnectionString")
+		"secondaryConnectionString",
+	)
 }

--- a/v2/internal/controllers/sql_server_crud_v20211101_test.go
+++ b/v2/internal/controllers/sql_server_crud_v20211101_test.go
@@ -64,7 +64,8 @@ func Test_SQL_Server_CRUD(t *testing.T) {
 	tc.ExpectConfigMapHasKeysAndValues(
 		configMap,
 		configMapKey,
-		*server.Status.FullyQualifiedDomainName)
+		*server.Status.FullyQualifiedDomainName,
+	)
 
 	storageDetails := makeStorageAccountForSQLVulnerabilityAssessment(tc, rg)
 
@@ -128,7 +129,8 @@ func Test_SQL_Server_CRUD(t *testing.T) {
 			Test: func(tc *testcommon.KubePerTestContext) {
 				SQL_Server_AuditingSetting_CRUD(tc, server, storageDetails)
 			},
-		})
+		},
+	)
 
 	armId := *server.Status.Id
 	tc.DeleteResourceAndWait(server)
@@ -305,7 +307,8 @@ func SQL_Server_OutboundFirewallRule_CRUD(tc *testcommon.KubePerTestContext, ser
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(sql.APIVersion_Value))
+		string(sql.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/storage_storageaccount_crud_20210401_test.go
+++ b/v2/internal/controllers/storage_storageaccount_crud_20210401_test.go
@@ -65,7 +65,8 @@ func Test_Storage_StorageAccount_20210401_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(storage.APIVersion_Value))
+		string(storage.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }
@@ -90,7 +91,8 @@ func StorageAccount_BlobServices_20210401_CRUD(tc *testcommon.KubePerTestContext
 			Test: func(tc *testcommon.KubePerTestContext) {
 				StorageAccount_BlobServices_Container_20210401_CRUD(tc, blobService)
 			},
-		})
+		},
+	)
 }
 
 func StorageAccount_BlobServices_Container_20210401_CRUD(tc *testcommon.KubePerTestContext, blobService *storage.StorageAccountsBlobService) {
@@ -266,7 +268,8 @@ func StorageAccount_20210401_ConfigMapsWritten(tc *testcommon.KubePerTestContext
 		"blob",
 		*acct.Status.PrimaryEndpoints.Blob,
 		"dfs",
-		*acct.Status.PrimaryEndpoints.Dfs)
+		*acct.Status.PrimaryEndpoints.Dfs,
+	)
 }
 
 func StorageAccount_ManagementPolicy_20210401_CRUD(tc *testcommon.KubePerTestContext, blobService client.Object) {

--- a/v2/internal/controllers/storage_storageaccount_crud_20230101_test.go
+++ b/v2/internal/controllers/storage_storageaccount_crud_20230101_test.go
@@ -77,7 +77,8 @@ func Test_Storage_StorageAccount_20230101_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(storage.APIVersion_Value))
+		string(storage.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }
@@ -102,7 +103,8 @@ func StorageAccount_BlobServices_20230101_CRUD(tc *testcommon.KubePerTestContext
 			Test: func(tc *testcommon.KubePerTestContext) {
 				StorageAccount_BlobServices_Container_20230101_CRUD(tc, blobService)
 			},
-		})
+		},
+	)
 }
 
 func StorageAccount_BlobServices_Container_20230101_CRUD(tc *testcommon.KubePerTestContext, blobService *storage.StorageAccountsBlobService) {
@@ -173,7 +175,8 @@ func StorageAccount_TableServices_20230101_CRUD(tc *testcommon.KubePerTestContex
 			Test: func(tc *testcommon.KubePerTestContext) {
 				StorageAccount_TableServices_Table_20230101_CRUD(tc, tableService)
 			},
-		})
+		},
+	)
 }
 
 func StorageAccount_TableServices_Table_20230101_CRUD(tc *testcommon.KubePerTestContext, tableService *storage.StorageAccountsTableService) {
@@ -208,7 +211,8 @@ func StorageAccount_FileServices_20230101_CRUD(tc *testcommon.KubePerTestContext
 			Test: func(tc *testcommon.KubePerTestContext) {
 				StorageAccount_FileServices_Share_20230101_CRUD(tc, fileService)
 			},
-		})
+		},
+	)
 }
 
 func StorageAccount_FileServices_Share_20230101_CRUD(tc *testcommon.KubePerTestContext, fileService *storage.StorageAccountsFileService) {
@@ -347,7 +351,8 @@ func StorageAccount_ConfigMapsWritten20230101(tc *testcommon.KubePerTestContext,
 		"blob",
 		*acct.Status.PrimaryEndpoints.Blob,
 		"dfs",
-		*acct.Status.PrimaryEndpoints.Dfs)
+		*acct.Status.PrimaryEndpoints.Dfs,
+	)
 }
 
 func StorageAccount_ManagementPolicy_20230101_CRUD(tc *testcommon.KubePerTestContext, blobService client.Object) {

--- a/v2/internal/controllers/storage_storageaccount_crud_20250601_test.go
+++ b/v2/internal/controllers/storage_storageaccount_crud_20250601_test.go
@@ -77,7 +77,8 @@ func Test_Storage_StorageAccount_20250601_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(storage.APIVersion_Value))
+		string(storage.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }
@@ -102,7 +103,8 @@ func StorageAccount_BlobServices_20250601_CRUD(tc *testcommon.KubePerTestContext
 			Test: func(tc *testcommon.KubePerTestContext) {
 				StorageAccount_BlobServices_Container_20250601_CRUD(tc, blobService)
 			},
-		})
+		},
+	)
 }
 
 func StorageAccount_BlobServices_Container_20250601_CRUD(tc *testcommon.KubePerTestContext, blobService *storage.StorageAccountsBlobService) {
@@ -173,7 +175,8 @@ func StorageAccount_TableServices_20250601_CRUD(tc *testcommon.KubePerTestContex
 			Test: func(tc *testcommon.KubePerTestContext) {
 				StorageAccount_TableServices_Table_20250601_CRUD(tc, tableService)
 			},
-		})
+		},
+	)
 }
 
 func StorageAccount_TableServices_Table_20250601_CRUD(tc *testcommon.KubePerTestContext, tableService *storage.StorageAccountsTableService) {
@@ -208,7 +211,8 @@ func StorageAccount_FileServices_20250601_CRUD(tc *testcommon.KubePerTestContext
 			Test: func(tc *testcommon.KubePerTestContext) {
 				StorageAccount_FileServices_Share_20250601_CRUD(tc, fileService)
 			},
-		})
+		},
+	)
 }
 
 func StorageAccount_FileServices_Share_20250601_CRUD(tc *testcommon.KubePerTestContext, fileService *storage.StorageAccountsFileService) {
@@ -347,7 +351,8 @@ func StorageAccount_ConfigMapsWritten20250601(tc *testcommon.KubePerTestContext,
 		"blob",
 		*acct.Status.PrimaryEndpoints.Blob,
 		"dfs",
-		*acct.Status.PrimaryEndpoints.Dfs)
+		*acct.Status.PrimaryEndpoints.Dfs,
+	)
 }
 
 func StorageAccount_ManagementPolicy_20250601_CRUD(tc *testcommon.KubePerTestContext, blobService client.Object) {

--- a/v2/internal/controllers/suite_test.go
+++ b/v2/internal/controllers/suite_test.go
@@ -53,14 +53,16 @@ func setup() error {
 		testcommon.ResourcePrefix,
 		"-",
 		6,
-		testcommon.ResourceNamerModeRandomBasedOnTestName)
+		testcommon.ResourceNamerModeRandomBasedOnTestName,
+	)
 
 	// set global context var
 	newGlobalTestContext, err := testcommon.NewKubeContext(
 		options.useEnvTest,
 		options.recordReplay,
 		testcommon.DefaultTestRegion,
-		nameConfig)
+		nameConfig,
+	)
 	if err != nil {
 		return err
 	}

--- a/v2/internal/controllers/synapse_workspace_20210601_crud_test.go
+++ b/v2/internal/controllers/synapse_workspace_20210601_crud_test.go
@@ -85,7 +85,8 @@ func Test_Workspace_BigDataPool(t *testing.T) {
 			Test: func(tc *testcommon.KubePerTestContext) {
 				WorkspacesBigDataPool_CRUD(tc, ws)
 			},
-		})
+		},
+	)
 
 	tc.DeleteResourceAndWait(ws)
 
@@ -93,7 +94,8 @@ func Test_Workspace_BigDataPool(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		wsArmId,
-		string(synapse.APIVersion_Value))
+		string(synapse.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 }

--- a/v2/internal/controllers/to_azure_configmaps_test.go
+++ b/v2/internal/controllers/to_azure_configmaps_test.go
@@ -183,7 +183,8 @@ func Test_MissingConfigMapKey_ReturnsError(t *testing.T) {
 	// We expect the ready condition to include details of the error
 	tc.Expect(roleAssignment.Status.Conditions[0].Reason).To(Equal(conditions.ReasonConfigMapNotFound.Name))
 	tc.Expect(roleAssignment.Status.Conditions[0].Message).To(
-		ContainSubstring("ConfigMap \"%s/%s\" does not contain key \"%s\"", tc.Namespace, configMap.Name, principalIdKey))
+		ContainSubstring("ConfigMap \"%s/%s\" does not contain key \"%s\"", tc.Namespace, configMap.Name, principalIdKey),
+	)
 
 	tc.DeleteResourceAndWait(rg)
 }

--- a/v2/internal/controllers/to_azure_secrets_test.go
+++ b/v2/internal/controllers/to_azure_secrets_test.go
@@ -93,7 +93,8 @@ func Test_MissingSecretKey_ReturnsError(t *testing.T) {
 	// We expect the ready condition to include details of the error
 	tc.Expect(vm.Status.Conditions[0].Reason).To(Equal(conditions.ReasonSecretNotFound.Name))
 	tc.Expect(vm.Status.Conditions[0].Message).To(
-		ContainSubstring("Secret \"%s/%s\" does not contain key \"%s\"", tc.Namespace, secret.Name, secret.Key))
+		ContainSubstring("Secret \"%s/%s\" does not contain key \"%s\"", tc.Namespace, secret.Name, secret.Key),
+	)
 
 	// Delete VM and resources.
 	tc.DeleteResourceAndWait(rg)

--- a/v2/internal/controllers/web_serverfarm_crud_v20220301_test.go
+++ b/v2/internal/controllers/web_serverfarm_crud_v20220301_test.go
@@ -41,7 +41,8 @@ func Test_Web_ServerFarm_v20220301_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(v20220301.APIVersion_Value))
+		string(v20220301.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(gomega.HaveOccurred())
 	tc.Expect(exists).To(gomega.BeFalse())
 }

--- a/v2/internal/controllers/web_site_crud_v20220301_test.go
+++ b/v2/internal/controllers/web_site_crud_v20220301_test.go
@@ -53,7 +53,8 @@ func Test_Web_Site_v20220301_CRUD(t *testing.T) {
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(web.APIVersion_Value))
+		string(web.APIVersion_Value),
+	)
 	tc.Expect(err).ToNot(gomega.HaveOccurred())
 	tc.Expect(exists).To(gomega.BeFalse())
 }

--- a/v2/internal/controllers/web_sitesourcecontrol_crud_v20220301_test.go
+++ b/v2/internal/controllers/web_sitesourcecontrol_crud_v20220301_test.go
@@ -62,7 +62,8 @@ func Test_Web_SitesSourcecontrol_v20220301_CRUD(t *testing.T) {
 	_, retryAfter, er := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armId,
-		string(web.APIVersion_Value))
+		string(web.APIVersion_Value),
+	)
 	tc.Expect(er).ToNot(HaveOccurred())
 	tc.Expect(retryAfter).To(BeZero())
 }

--- a/v2/internal/crdmanagement/helpers.go
+++ b/v2/internal/crdmanagement/helpers.go
@@ -55,7 +55,8 @@ func FilterStorageTypesByReadyCRDs(
 		if !includeKinds.Contains(gvk.GroupKind()) {
 			logger.V(0).Info(
 				"Skipping reconciliation of resource because CRD was not installed or did not match the expected shape",
-				"groupKind", gvk.GroupKind().String())
+				"groupKind", gvk.GroupKind().String(),
+			)
 			continue
 		}
 
@@ -87,7 +88,8 @@ func FilterKnownTypesByReadyCRDs(
 		if !includeKinds.Contains(gvk.GroupKind()) {
 			logger.V(0).Info(
 				"Skipping webhooks of resource because CRD was not installed or did not match the expected shape",
-				"groupKind", gvk.GroupKind().String())
+				"groupKind", gvk.GroupKind().String(),
+			)
 			continue
 		}
 

--- a/v2/internal/crdmanagement/helpers_test.go
+++ b/v2/internal/crdmanagement/helpers_test.go
@@ -195,5 +195,6 @@ func (t *testData) getKnownStorageTypes() ([]*registration.StorageType, error) {
 		nil, // Not used for this test
 		nil, // Not used for this test
 		nil, // Not used for this test
-		generic.Options{})
+		generic.Options{},
+	)
 }

--- a/v2/internal/crdmanagement/manager.go
+++ b/v2/internal/crdmanagement/manager.go
@@ -65,7 +65,8 @@ func NewLeaderElector(
 			LeaderElection:             ctrlOptions.LeaderElection,
 			LeaderElectionResourceLock: ctrlOptions.LeaderElectionResourceLock,
 			LeaderElectionID:           ctrlOptions.LeaderElectionID,
-		})
+		},
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -268,7 +269,8 @@ func (m *Manager) FindNonMatchingCRDs(
 			invertedComparators,
 			func(a apiextensions.CustomResourceDefinition, b apiextensions.CustomResourceDefinition) bool {
 				return !c(a, b)
-			})
+			},
+		)
 	}
 
 	return m.FindMatchingCRDs(existing, goal, invertedComparators...)
@@ -385,7 +387,8 @@ func (m *Manager) applyCRDs(
 		m.logger.V(Verbose).Info(
 			"Applying CRD",
 			"progress", fmt.Sprintf("%d/%d", i, len(instructionsToApply)),
-			"crd", instruction.CRD.Name)
+			"crd", instruction.CRD.Name,
+		)
 
 		result, err := controllerutil.CreateOrUpdate(ctx, m.kubeClient, toApply, func() error {
 			resourceVersion := toApply.ResourceVersion
@@ -514,14 +517,16 @@ func (m *Manager) filterInstallationInstructions(instructions []*CRDInstallation
 					"crd", item.CRD.Name,
 					"diffResult", item.DiffResult,
 					"filterReason", item.FilterReason,
-					"reason", reason)
+					"reason", reason,
+				)
 			}
 		} else {
 			if log {
 				m.logger.V(Verbose).Info(
 					"Will NOT update CRD",
 					"crd", item.CRD.Name,
-					"reason", reason)
+					"reason", reason,
+				)
 			}
 		}
 	}

--- a/v2/internal/genericarmclient/generic_client.go
+++ b/v2/internal/genericarmclient/generic_client.go
@@ -98,7 +98,8 @@ func NewGenericClient(
 
 	rpRegistrationPolicy, err := NewRPRegistrationPolicy(
 		creds,
-		&opts.ClientOptions)
+		&opts.ClientOptions,
+	)
 	if err != nil {
 		return nil, eris.Wrapf(err, "failed to create rp registration policy")
 	}
@@ -401,7 +402,8 @@ func ListByContainerID[T any](
 
 				return *nextPage, nil
 			},
-		})
+		},
+	)
 
 	var result []T
 	for pager.More() {

--- a/v2/internal/genericarmclient/suite_test.go
+++ b/v2/internal/genericarmclient/suite_test.go
@@ -43,7 +43,8 @@ func setup() error {
 		testcommon.ResourcePrefix,
 		"-",
 		6,
-		testcommon.ResourceNamerModeRandomBasedOnTestName)
+		testcommon.ResourceNamerModeRandomBasedOnTestName,
+	)
 
 	// set global test context
 	testContext = testcommon.NewTestContext(testcommon.DefaultTestRegion, recordReplay, nameConfig)

--- a/v2/internal/identity/client_certificate_credential.go
+++ b/v2/internal/identity/client_certificate_credential.go
@@ -27,7 +27,8 @@ func NewClientCertificateCredential(
 		clientID,
 		certs,
 		key,
-		options)
+		options,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/v2/internal/identity/credential_provider.go
+++ b/v2/internal/identity/credential_provider.go
@@ -246,7 +246,8 @@ func (c *credentialProvider) newCredentialFromSecret(secret *v1.Secret) (*Creden
 			eris.Errorf(
 				"credential Secret %q does not contain key %q",
 				nsName,
-				config.AzureSubscriptionID),
+				config.AzureSubscriptionID,
+			),
 		)
 		errs = append(errs, err)
 	}
@@ -258,7 +259,8 @@ func (c *credentialProvider) newCredentialFromSecret(secret *v1.Secret) (*Creden
 			eris.Errorf(
 				"credential Secret %q does not contain key %q",
 				nsName,
-				config.AzureTenantID),
+				config.AzureTenantID,
+			),
 		)
 		errs = append(errs, err)
 	}
@@ -270,7 +272,8 @@ func (c *credentialProvider) newCredentialFromSecret(secret *v1.Secret) (*Creden
 			eris.Errorf(
 				"credential Secret %q does not contain key %q",
 				nsName,
-				config.AzureClientID),
+				config.AzureClientID,
+			),
 		)
 		errs = append(errs, err)
 	}
@@ -312,7 +315,8 @@ func (c *credentialProvider) newCredentialFromSecret(secret *v1.Secret) (*Creden
 					Cloud: cloudConfig,
 				},
 				AdditionallyAllowedTenants: additionalTenants,
-			})
+			},
+		)
 		if err != nil {
 			return nil, eris.Wrap(err, eris.Errorf("invalid Client Secret Credential for %q encountered", nsName).Error())
 		}
@@ -343,7 +347,8 @@ func (c *credentialProvider) newCredentialFromSecret(secret *v1.Secret) (*Creden
 					Cloud: cloudConfig,
 				},
 				AdditionallyAllowedTenants: additionalTenants,
-			})
+			},
+		)
 		if err != nil {
 			return nil, eris.Wrap(err, eris.Errorf("invalid Client Certificate Credential for %q encountered", nsName).Error())
 		}
@@ -419,7 +424,8 @@ func (c *credentialProvider) newCredentialFromSecret(secret *v1.Secret) (*Creden
 			TenantID:                   tenantID,
 			TokenFilePath:              FederatedTokenFilePath,
 			AdditionallyAllowedTenants: additionalTenants,
-		})
+		},
+	)
 	if err != nil {
 		err = eris.Wrapf(
 			err,
@@ -427,7 +433,8 @@ func (c *credentialProvider) newCredentialFromSecret(secret *v1.Secret) (*Creden
 			nsName,
 			config.AzureClientSecret,
 			clientID,
-			FederatedTokenFilePath)
+			FederatedTokenFilePath,
+		)
 
 		return nil, err
 	}
@@ -448,7 +455,8 @@ func (c *credentialProvider) getSecret(ctx context.Context, namespace string, se
 	err := c.kubeClient.Get(
 		ctx,
 		types.NamespacedName{Namespace: namespace, Name: secretName},
-		secret)
+		secret,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -510,7 +518,8 @@ func (c *credentialProvider) extractCloudConfig(secret *v1.Secret) (*cloud.Confi
 				config.ResourceManagerEndpoint,
 				config.ResourceManagerAudience,
 				config.AzureAuthorityHost,
-				fieldsPresent),
+				fieldsPresent,
+			),
 		)
 	}
 
@@ -524,7 +533,8 @@ func (c *credentialProvider) extractCloudConfig(secret *v1.Secret) (*cloud.Confi
 				config.ResourceManagerEndpoint,
 				config.ResourceManagerAudience,
 				config.AzureAuthorityHost,
-				config.AllowMultiEnvManagement),
+				config.AllowMultiEnvManagement,
+			),
 		)
 	}
 

--- a/v2/internal/identity/credential_provider_test.go
+++ b/v2/internal/identity/credential_provider_test.go
@@ -77,7 +77,8 @@ func testCredentialProviderSetupWithMultiEnv(cloud *cloud.Configuration, allowMu
 			Cloud:         cloud,
 			// Feature under test
 			AllowMultiEnvManagement: allowMultiEnvManagement,
-		})
+		},
+	)
 
 	return &testCredentialProviderResources{
 		kubeClient:                  client,

--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -232,7 +232,8 @@ func (r *azureDeploymentReconcilerInstance) DeleteNotPossibleInAzure(ctx context
 	msg := fmt.Sprintf(
 		"Resource does not support deletion in Azure; set annotation '%s: %s' to permit deletion in Kubernetes",
 		annotations.ReconcilePolicy,
-		annotations.ReconcilePolicyDetachOnDelete)
+		annotations.ReconcilePolicyDetachOnDelete,
+	)
 	r.Log.V(Verbose).Info(msg)
 	r.Recorder.Event(r.Obj, v1.EventTypeNormal, string(DeleteActionNotPossibleInAzure), msg)
 
@@ -247,7 +248,8 @@ func (r *azureDeploymentReconcilerInstance) DeleteNotPossibleInAzure(ctx context
 		conditions.NewReadyConditionImpactingError(
 			err,
 			conditions.ConditionSeverityWarning,
-			conditions.ReasonDeletionNotSupported)
+			conditions.ReasonDeletionNotSupported,
+		)
 }
 
 func (r *azureDeploymentReconcilerInstance) BeginCreateOrUpdateResource(
@@ -256,11 +258,13 @@ func (r *azureDeploymentReconcilerInstance) BeginCreateOrUpdateResource(
 	if r.Obj.AzureName() == "" {
 		err := eris.Errorf(
 			"AzureName was not set on %s. A webhook should default this to .metadata.name if it was omitted. Is the ASO webhook service running?",
-			r.Obj.GetType())
+			r.Obj.GetType(),
+		)
 
 		return ctrl.Result{},
 			conditions.NewReadyConditionImpactingError(
-				err, conditions.ConditionSeverityError, conditions.ReasonFailed)
+				err, conditions.ConditionSeverityError, conditions.ReasonFailed,
+			)
 	}
 
 	// We want to set the latest reconciled generation annotation to keep a track of reconciles per generation.
@@ -277,7 +281,8 @@ func (r *azureDeploymentReconcilerInstance) BeginCreateOrUpdateResource(
 			impactingError = conditions.NewReadyConditionImpactingError(
 				err,
 				conditions.ConditionSeverityWarning,
-				conditions.ReasonFailed)
+				conditions.ReasonFailed,
+			)
 		}
 
 		return ctrl.Result{}, impactingError
@@ -438,7 +443,8 @@ func (r *azureDeploymentReconcilerInstance) checkSubscription(resourceID string)
 		err = eris.Wrapf(err, "parsing resource ID %q", resourceID)
 
 		return conditions.NewReadyConditionImpactingError(
-			err, conditions.ConditionSeverityError, conditions.ReasonFailed)
+			err, conditions.ConditionSeverityError, conditions.ReasonFailed,
+		)
 	}
 
 	if !genruntime.CheckARMIDMatchesSubscription(r.ARMConnection.SubscriptionID(), parsedRID) {
@@ -446,10 +452,12 @@ func (r *azureDeploymentReconcilerInstance) checkSubscription(resourceID string)
 			"SubscriptionID %q for %q resource does not match with Client Credential: %q",
 			parsedRID.SubscriptionID,
 			resourceID,
-			r.ARMConnection.SubscriptionID())
+			r.ARMConnection.SubscriptionID(),
+		)
 
 		return conditions.NewReadyConditionImpactingError(
-			err, conditions.ConditionSeverityError, conditions.ReasonSubscriptionMismatch)
+			err, conditions.ConditionSeverityError, conditions.ReasonSubscriptionMismatch,
+		)
 	}
 
 	return nil
@@ -459,7 +467,8 @@ func (r *azureDeploymentReconcilerInstance) handleCreateOrUpdateFailed(err error
 	r.Log.V(Debug).Info(
 		"Resource creation/update failure",
 		"resourceID", genruntime.GetResourceIDOrDefault(r.Obj),
-		"error", err.Error())
+		"error", err.Error(),
+	)
 
 	err = r.MakeReadyConditionImpactingErrorFromError(err)
 	ClearPollerResumeToken(r.Obj)
@@ -471,7 +480,8 @@ func (r *azureDeploymentReconcilerInstance) handleDeleteFailed(err error) error 
 	r.Log.V(Debug).Info(
 		"Resource deletion failure",
 		"resourceID", genruntime.GetResourceIDOrDefault(r.Obj),
-		"error", err.Error())
+		"error", err.Error(),
+	)
 
 	err = r.MakeReadyConditionImpactingErrorFromError(err)
 	// Force all delete errors to have severity Warning, as we don't want to block the deletion of the resource
@@ -495,7 +505,8 @@ const (
 func (r *azureDeploymentReconcilerInstance) handleCreateOrUpdateSuccess(ctx context.Context, mode CreateOrUpdateSuccessMode) error {
 	r.Log.V(Status).Info(
 		"Resource successfully created/updated",
-		"resourceID", genruntime.GetResourceIDOrDefault(r.Obj))
+		"resourceID", genruntime.GetResourceIDOrDefault(r.Obj),
+	)
 
 	err := r.updateStatus(ctx, r.Obj)
 	if err != nil {
@@ -521,7 +532,8 @@ func (r *azureDeploymentReconcilerInstance) handleCreateOrUpdateSuccess(ctx cont
 			impactingError = conditions.NewReadyConditionImpactingError(
 				err,
 				conditions.ConditionSeverityWarning,
-				conditions.ReasonFailed)
+				conditions.ReasonFailed,
+			)
 		}
 
 		return impactingError
@@ -613,7 +625,8 @@ func (r *azureDeploymentReconcilerInstance) resultBasedOnGenerationCount() ctrl.
 		r.Log.V(Debug).Info(
 			"Generation mismatch detected, requeue-ing the resource",
 			"resourceID",
-			genruntime.GetResourceIDOrDefault(r.Obj))
+			genruntime.GetResourceIDOrDefault(r.Obj),
+		)
 
 		return ctrl.Result{Requeue: true}
 	}

--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -517,7 +517,7 @@ func (r *azureDeploymentReconcilerInstance) handleCreateOrUpdateSuccess(ctx cont
 	r.Log.V(Status).Info(
 		"Resource successfully created/updated",
 		"resourceID", resourceID,
-  )
+	)
 
 	err := r.updateStatus(ctx, r.Obj)
 	if err != nil {

--- a/v2/internal/reconcilers/arm/errorclassification/ready_condition.go
+++ b/v2/internal/reconcilers/arm/errorclassification/ready_condition.go
@@ -37,7 +37,8 @@ func MakeReadyConditionImpactingErrorFromError(azureErr error, classifier extens
 		return conditions.NewReadyConditionImpactingError(
 			azureErr,
 			conditions.ConditionSeverityWarning,
-			conditions.MakeReason(core.UnknownErrorCode, retry.Slow))
+			conditions.MakeReason(core.UnknownErrorCode, retry.Slow),
+		)
 	}
 
 	details, err := classifier(cloudError)
@@ -45,7 +46,8 @@ func MakeReadyConditionImpactingErrorFromError(azureErr error, classifier extens
 		return eris.Wrapf(
 			err,
 			"Unable to classify cloud error (%s)",
-			cloudError.Error())
+			cloudError.Error(),
+		)
 	}
 
 	var severity conditions.ConditionSeverity
@@ -57,7 +59,8 @@ func MakeReadyConditionImpactingErrorFromError(azureErr error, classifier extens
 	default:
 		return eris.Errorf(
 			"unknown error classification %q while making Ready condition",
-			details.Classification)
+			details.Classification,
+		)
 	}
 
 	// Stick errorDetails.Message into an error so that it will be displayed as the message on the condition

--- a/v2/internal/reconcilers/arm/kubernetes_resource_exporter.go
+++ b/v2/internal/reconcilers/arm/kubernetes_resource_exporter.go
@@ -67,14 +67,16 @@ func (c *configMapExpressionExporter) parseConfigMaps(expressions []*core.Destin
 				&genruntime.ConfigMapDestination{
 					Name: expression.Name,
 					Key:  expression.Key,
-				}, value.Value)
+				}, value.Value,
+			)
 		} else if len(value.Values) > 0 {
 			for k, v := range value.Values {
 				collector.AddValue(
 					&genruntime.ConfigMapDestination{
 						Name: expression.Name,
 						Key:  k,
-					}, v)
+					}, v,
+				)
 			}
 		} else {
 			return nil, eris.Errorf("unexpected expression output")
@@ -134,14 +136,16 @@ func (s *secretExpressionExporter) parseSecrets(
 				&genruntime.SecretDestination{
 					Name: expression.Name,
 					Key:  expression.Key,
-				}, value.Value)
+				}, value.Value,
+			)
 		} else if len(value.Values) > 0 {
 			for k, v := range value.Values {
 				collector.AddValue(
 					&genruntime.SecretDestination{
 						Name: expression.Name,
 						Key:  k,
-					}, v)
+					}, v,
+				)
 			}
 		} else {
 			return nil, eris.Errorf("unexpected expression output")

--- a/v2/internal/reconcilers/azuresql/local_user.go
+++ b/v2/internal/reconcilers/azuresql/local_user.go
@@ -141,7 +141,8 @@ func (u *localUser) connectToDB(ctx context.Context, secrets genruntime.Resolved
 				details.fqdn,
 				details.database,
 				azuresqlutil.ServerPort,
-				adminUser)
+				adminUser,
+			)
 		}
 
 		return db, nil

--- a/v2/internal/reconcilers/common.go
+++ b/v2/internal/reconcilers/common.go
@@ -127,7 +127,8 @@ func (r *ARMOwnedResourceReconcilerCommon) ApplyOwnership(ctx context.Context, l
 	log.V(Info).Info(
 		"Set owner reference",
 		"ownerGvk", ownerDetails.Owner.GetObjectKind().GroupVersionKind(),
-		"ownerName", ownerDetails.Owner.GetName())
+		"ownerName", ownerDetails.Owner.GetName(),
+	)
 
 	return nil
 }

--- a/v2/internal/reconcilers/entra/entra_client_cache.go
+++ b/v2/internal/reconcilers/entra/entra_client_cache.go
@@ -102,7 +102,8 @@ func (c *EntraClientCache) getEntraClientFromCredential(
 		authProvider,
 		nil, // ParseNodeFactory
 		nil, // SerializationWriterFactory
-		c.httpClient)
+		c.httpClient,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/v2/internal/reconcilers/generic/generic_reconciler.go
+++ b/v2/internal/reconcilers/generic/generic_reconciler.go
@@ -285,7 +285,8 @@ func NewRateLimiter(minBackoff time.Duration, maxBackoff time.Duration, addition
 	limiters := make([]workqueue.TypedRateLimiter[reconcile.Request], 0, len(additionalLimiters)+1)
 	limiters = append(
 		limiters,
-		workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](minBackoff, maxBackoff))
+		workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](minBackoff, maxBackoff),
+	)
 	limiters = append(limiters, additionalLimiters...)
 	return workqueue.NewTypedMaxOfRateLimiter(limiters...)
 }
@@ -295,7 +296,8 @@ func (gr *GenericReconciler) WriteReadyConditionError(ctx context.Context, log l
 		err.Severity,
 		obj.GetGeneration(),
 		err.Reason,
-		err.Cause().Error())) // Don't use err.Error() here because it also includes details about Reason, Severity, which are getting displayed as part of the condition structure
+		err.Cause().Error(),
+	)) // Don't use err.Error() here because it also includes details about Reason, Severity, which are getting displayed as part of the condition structure
 	commitErr := gr.CommitUpdate(ctx, log, nil, obj, kubeclient.SpecAndStatus)
 	if commitErr != nil {
 		return eris.Wrap(commitErr, "updating resource error")
@@ -357,7 +359,8 @@ func (gr *GenericReconciler) handleSkipReconcile(ctx context.Context, log logr.L
 
 	log.V(Status).Info(
 		"Skipping creation/update of resource due to policy",
-		annotations.ReconcilePolicy, reconcilePolicy)
+		annotations.ReconcilePolicy, reconcilePolicy,
+	)
 
 	err := gr.Reconciler.UpdateStatus(ctx, log, gr.Recorder, obj)
 	if err != nil {
@@ -419,7 +422,8 @@ func (gr *GenericReconciler) mergeReconcilePolicy(ctx context.Context, log logr.
 			err,
 			"failed to get reconcile policy. Applying default policy instead",
 			"chosenPolicy", reconcilePolicy,
-			"policyAnnotation", policyStr)
+			"policyAnnotation", policyStr,
+		)
 	}
 	log.V(Verbose).Info("Retrieved reconcile policy", "policy", reconcilePolicy, "source", source)
 	return reconcilePolicy

--- a/v2/internal/reconcilers/migration/crd/reconciler_test.go
+++ b/v2/internal/reconcilers/migration/crd/reconciler_test.go
@@ -127,7 +127,8 @@ func TestReconcileCRDs(t *testing.T) {
 				types.NamespacedName{
 					Name: "managedclusters.containerservice.azure.com",
 				},
-				crd)).To(Succeed())
+				crd,
+			)).To(Succeed())
 
 			if tt.expectDeprecated {
 				g.Expect(crd.Status.StoredVersions).ToNot(ContainElement("v1api20240901storage"))

--- a/v2/internal/reconcilers/mysql/aad_user.go
+++ b/v2/internal/reconcilers/mysql/aad_user.go
@@ -143,7 +143,8 @@ func connectToDBAAD(ctx context.Context, credentialProvider identity.CredentialP
 			fqdn,
 			mysqlutil.SystemDatabase,
 			mysqlutil.ServerPort,
-			adminUser)
+			adminUser,
+		)
 	}
 
 	return db, nil

--- a/v2/internal/reconcilers/mysql/local_user.go
+++ b/v2/internal/reconcilers/mysql/local_user.go
@@ -147,7 +147,8 @@ func (u *localUser) connectToDB(ctx context.Context, secrets genruntime.Resolved
 				serverFQDN,
 				mysqlutil.SystemDatabase,
 				mysqlutil.ServerPort,
-				adminUser)
+				adminUser,
+			)
 		}
 
 		return db, nil

--- a/v2/internal/reconcilers/postgresql/postgresql_user_reconciler.go
+++ b/v2/internal/reconcilers/postgresql/postgresql_user_reconciler.go
@@ -270,7 +270,8 @@ func (r *PostgreSQLUserReconciler) connectToDB(ctx context.Context, _ logr.Logge
 			serverFQDN,
 			postgresqlutil.DefaultMaintanenceDatabase,
 			postgresqlutil.PSqlServerPort,
-			adminUser)
+			adminUser,
+		)
 	}
 
 	return db, nil

--- a/v2/internal/reconcilers/predicates.go
+++ b/v2/internal/reconcilers/predicates.go
@@ -20,7 +20,8 @@ func ARMReconcilerAnnotationChangedPredicate() predicate.Predicate {
 	return predicates.MakeSelectAnnotationChangedPredicate(
 		map[string]predicates.HasAnnotationChanged{
 			annotations.ReconcilePolicy: HasReconcilePolicyAnnotationChanged,
-		})
+		},
+	)
 }
 
 // ARMPerResourceSecretAnnotationChangedPredicate creates a predicate that emits events when annotations
@@ -29,7 +30,8 @@ func ARMPerResourceSecretAnnotationChangedPredicate() predicate.Predicate {
 	return predicates.MakeSelectAnnotationChangedPredicate(
 		map[string]predicates.HasAnnotationChanged{
 			annotations.PerResourceSecret: HasAnnotationChanged,
-		})
+		},
+	)
 }
 
 // HasAnnotationChanged returns true if the annotation has changed

--- a/v2/internal/reconcilers/reconcile_policy_test.go
+++ b/v2/internal/reconcilers/reconcile_policy_test.go
@@ -32,7 +32,7 @@ func TestParseReconcilePolicy(t *testing.T) {
 
 	// test default value
 	returnedPolicy, err := ParseReconcilePolicy("", annotations.ReconcilePolicySkip)
-	g.Expect(err).ToNot((HaveOccurred()))
+	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(returnedPolicy).Should(Equal(annotations.ReconcilePolicySkip))
 
 	// test error in case of any other value

--- a/v2/internal/resolver/config_map_resolver.go
+++ b/v2/internal/resolver/config_map_resolver.go
@@ -59,7 +59,8 @@ func (r *kubeConfigMapResolver) ResolveConfigMapReference(
 				"couldn't resolve config map reference %s/%s.%s",
 				ref.Namespace,
 				ref.Name,
-				ref.Key)
+				ref.Key,
+			)
 		}
 
 		return "", eris.Wrapf(err, "couldn't resolve config map reference %s", ref.String())

--- a/v2/internal/resolver/resolver.go
+++ b/v2/internal/resolver/resolver.go
@@ -59,7 +59,8 @@ func (r *Resolver) IndexStorageTypes(scheme *runtime.Scheme, objs []*registratio
 				gvk.Group,
 				gvk.Kind,
 				existing.Version,
-				gvk.Version)
+				gvk.Version,
+			)
 
 		}
 		r.reconciledResourceLookup[groupKind] = gvk
@@ -183,7 +184,8 @@ func (r *Resolver) ResolveReference(ctx context.Context, ref genruntime.Namespac
 				err,
 				"couldn't resolve reference %s/%s",
 				ref.Namespace,
-				ref.Name)
+				ref.Name,
+			)
 		}
 
 		return nil, eris.Wrapf(err, "couldn't resolve reference %s", ref.String())

--- a/v2/internal/resolver/resource_hierarchy.go
+++ b/v2/internal/resolver/resource_hierarchy.go
@@ -175,7 +175,8 @@ func (h ResourceHierarchy) fullyQualifiedARMIDImpl(subscriptionID string, origin
 				len(remainingNames),
 				len(resourceTypes),
 				remainingNames,
-				resourceTypes)
+				resourceTypes,
+			)
 		}
 
 		// Join them together
@@ -197,7 +198,8 @@ func (h ResourceHierarchy) fullyQualifiedARMIDImpl(subscriptionID string, origin
 				len(azureNames),
 				len(resourceTypes),
 				azureNames,
-				resourceTypes)
+				resourceTypes,
+			)
 		}
 		// Join them together
 		interleaved := genruntime.InterleaveStrSlice(resourceTypes, azureNames)

--- a/v2/internal/resolver/resource_hierarchy_test.go
+++ b/v2/internal/resolver/resource_hierarchy_test.go
@@ -96,7 +96,8 @@ func Test_ResourceHierarchy_ResourceGroup_NestedResource(t *testing.T) {
 		"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/blobServices/%s",
 		resourceGroupName,
 		resourceName,
-		hierarchy[2].AzureName())
+		hierarchy[2].AzureName(),
+	)
 
 	rg, err := hierarchy.ResourceGroup()
 	g.Expect(err).ToNot(HaveOccurred())
@@ -133,7 +134,8 @@ func Test_ResourceHierarchy_ExtensionOnResourceGroup(t *testing.T) {
 	expectedARMID := fmt.Sprintf(
 		"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s/providers/Microsoft.SimpleExtension/simpleExtensions/%s",
 		resourceGroupName,
-		extensionName)
+		extensionName,
+	)
 
 	g.Expect(hierarchy.ResourceGroup()).To(Equal(resourceGroupName))
 	g.Expect(hierarchy.FullyQualifiedARMID("00000000-0000-0000-0000-000000000000")).To(Equal(expectedARMID))
@@ -159,7 +161,8 @@ func Test_ResourceHierarchy_ExtensionOnTenantScopeResource(t *testing.T) {
 	expectedARMID := fmt.Sprintf(
 		"/providers/Microsoft.Subscription/aliases/%s/providers/Microsoft.SimpleExtension/simpleExtensions/%s",
 		subscriptionName,
-		extensionName)
+		extensionName,
+	)
 
 	g.Expect(hierarchy.FullyQualifiedARMID("00000000-0000-0000-0000-000000000000")).To(Equal(expectedARMID))
 	g.Expect(hierarchy.AzureName()).To(Equal(extensionName))
@@ -179,7 +182,8 @@ func Test_ResourceHierarchy_ExtensionOnResourceInResourceGroup(t *testing.T) {
 		"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s/providers/Microsoft.Batch/batchAccounts/%s/providers/Microsoft.SimpleExtension/simpleExtensions/%s",
 		resourceGroupName,
 		resourceName,
-		extensionName)
+		extensionName,
+	)
 
 	g.Expect(hierarchy.ResourceGroup()).To(Equal(resourceGroupName))
 	g.Expect(hierarchy.FullyQualifiedARMID("00000000-0000-0000-0000-000000000000")).To(Equal(expectedARMID))
@@ -202,7 +206,8 @@ func Test_ResourceHierarchy_ExtensionOnDeepHierarchy(t *testing.T) {
 		resourceGroupName,
 		resourceName,
 		hierarchy[2].AzureName(),
-		extensionName)
+		extensionName,
+	)
 
 	g.Expect(hierarchy.ResourceGroup()).To(Equal(resourceGroupName))
 	g.Expect(hierarchy.FullyQualifiedARMID("00000000-0000-0000-0000-000000000000")).To(Equal(expectedARMID))
@@ -223,7 +228,8 @@ func Test_ResourceHierarchy_OwnerARMIDResourceGroup(t *testing.T) {
 	expectedARMID := fmt.Sprintf(
 		"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s/providers/Microsoft.Batch/batchAccounts/%s",
 		resourceGroupName,
-		resourceName)
+		resourceName,
+	)
 
 	g.Expect(hierarchy.ResourceGroup()).To(Equal(resourceGroupName))
 	g.Expect(hierarchy.FullyQualifiedARMID("00000000-0000-0000-0000-000000000000")).To(Equal(expectedARMID))
@@ -245,7 +251,8 @@ func Test_ResourceHierarchy_OwnerARMIDParent(t *testing.T) {
 	expectedARMID := fmt.Sprintf(
 		"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/blobServices/default",
 		resourceGroupName,
-		parentName)
+		parentName,
+	)
 
 	g.Expect(hierarchy.ResourceGroup()).To(Equal(resourceGroupName))
 	g.Expect(hierarchy.FullyQualifiedARMID("00000000-0000-0000-0000-000000000000")).To(Equal(expectedARMID))
@@ -332,7 +339,8 @@ func Test_ResourceHierarchy_OwnerARMIDWithExtension(t *testing.T) {
 		"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/providers/Microsoft.SimpleExtension/simpleExtensions/%s",
 		resourceGroupName,
 		resourceName,
-		extensionName)
+		extensionName,
+	)
 
 	g.Expect(hierarchy.ResourceGroup()).To(Equal(resourceGroupName))
 	g.Expect(hierarchy.FullyQualifiedARMID("00000000-0000-0000-0000-000000000000")).To(Equal(expectedARMID))
@@ -356,7 +364,8 @@ func Test_ResourceHierarchy_OwnerARMIDWithExtensionOnDeepHierarchy(t *testing.T)
 		resourceGroupName,
 		resourceName,
 		hierarchy[0].AzureName(),
-		extensionName)
+		extensionName,
+	)
 
 	g.Expect(hierarchy.ResourceGroup()).To(Equal(resourceGroupName))
 	g.Expect(hierarchy.FullyQualifiedARMID("00000000-0000-0000-0000-000000000000")).To(Equal(expectedARMID))
@@ -401,7 +410,8 @@ func Test_ResourceHierarchy_ChildResourceIDOverride_ImpactsExtensionResource(t *
 
 	expectedARMID := fmt.Sprintf(
 		"/a/b/c/providers/Microsoft.SimpleExtension/simpleExtensions/%s",
-		extensionName)
+		extensionName,
+	)
 
 	g.Expect(hierarchy.FullyQualifiedARMID("00000000-0000-0000-0000-000000000000")).To(Equal(expectedARMID))
 	g.Expect(hierarchy.AzureName()).To(Equal(extensionName))

--- a/v2/internal/resolver/secret_map_resolver.go
+++ b/v2/internal/resolver/secret_map_resolver.go
@@ -68,7 +68,8 @@ func (r *kubeSecretMapResolver) ResolveSecretMapReference(
 				err,
 				"couldn't resolve secret collection %s/%s",
 				ref.Namespace,
-				ref.Name)
+				ref.Name,
+			)
 		}
 
 		return nil, eris.Wrapf(err, "couldn't resolve secret collection %s", ref.String())

--- a/v2/internal/resolver/secret_resolver.go
+++ b/v2/internal/resolver/secret_resolver.go
@@ -56,7 +56,8 @@ func (r *kubeSecretResolver) ResolveSecretReference(ctx context.Context, ref gen
 				"couldn't resolve secret reference %s/%s.%s",
 				ref.Namespace,
 				ref.Name,
-				ref.Key)
+				ref.Key,
+			)
 		}
 	}
 

--- a/v2/internal/testcommon/azure_be_provisioned_matcher.go
+++ b/v2/internal/testcommon/azure_be_provisioned_matcher.go
@@ -72,7 +72,8 @@ func (m *AzureBeProvisionedMatcher) message(actual interface{}, expectedMatch bo
 
 	return gomegaformat.Message(
 		m.err,
-		fmt.Sprintf("long running operation %sbe successful.", notStr))
+		fmt.Sprintf("long running operation %sbe successful.", notStr),
+	)
 }
 
 func (m *AzureBeProvisionedMatcher) FailureMessage(actual interface{}) string {

--- a/v2/internal/testcommon/be_provisioned_matcher.go
+++ b/v2/internal/testcommon/be_provisioned_matcher.go
@@ -64,12 +64,14 @@ func (m *DesiredStateMatcher) FailureMessage(actual interface{}) string {
 	if !ok {
 		return gomegaformat.Message(
 			ready,
-			fmt.Sprintf("%q condition to exist", conditions.ConditionTypeReady))
+			fmt.Sprintf("%q condition to exist", conditions.ConditionTypeReady),
+		)
 	}
 
 	return gomegaformat.Message(
 		ready,
-		fmt.Sprintf("status to be %q, severity to be %q.", string(m.readyGoalStatus), string(m.readyGoalSeverity)))
+		fmt.Sprintf("status to be %q, severity to be %q.", string(m.readyGoalStatus), string(m.readyGoalSeverity)),
+	)
 }
 
 func (m *DesiredStateMatcher) NegatedFailureMessage(actual interface{}) string {
@@ -86,12 +88,14 @@ func (m *DesiredStateMatcher) NegatedFailureMessage(actual interface{}) string {
 	if !ok {
 		return gomegaformat.Message(
 			ready,
-			fmt.Sprintf("%q condition to exist", conditions.ConditionTypeReady))
+			fmt.Sprintf("%q condition to exist", conditions.ConditionTypeReady),
+		)
 	}
 
 	return gomegaformat.Message(
 		ready,
-		fmt.Sprintf("status not to be %q, severity not to be %q.", string(m.readyGoalStatus), string(m.readyGoalSeverity)))
+		fmt.Sprintf("status not to be %q, severity not to be %q.", string(m.readyGoalStatus), string(m.readyGoalSeverity)),
+	)
 }
 
 // MatchMayChangeInTheFuture implements OracleMatcher which of course isn't exported so we can't type-assert we implement it

--- a/v2/internal/testcommon/crd.go
+++ b/v2/internal/testcommon/crd.go
@@ -22,7 +22,8 @@ func CheckBundledCRDsDirectory(crdPath string) error {
 		return fmt.Errorf(
 			"CRD path %q does not exist or is not readable (has the task target `bundle-crds` been run?): %w",
 			crdPath,
-			err)
+			err,
+		)
 	}
 
 	crdCount := 0
@@ -39,7 +40,8 @@ func CheckBundledCRDsDirectory(crdPath string) error {
 		return fmt.Errorf(
 			"CRD path %q contains only %d CRD files; expected many more (has the task target `bundle-crds` been run?)",
 			crdPath,
-			crdCount)
+			crdCount,
+		)
 	}
 
 	return nil

--- a/v2/internal/testcommon/kube_per_test_context.go
+++ b/v2/internal/testcommon/kube_per_test_context.go
@@ -382,11 +382,13 @@ func (tc *KubePerTestContext) CreateResource(obj client.Object) {
 		tc.LogSubsectionf(
 			"Creating %s resource %s",
 			arm.GetType(),
-			obj.GetName())
+			obj.GetName(),
+		)
 	} else {
 		tc.LogSubsectionf(
 			"Creating resource %s",
-			obj.GetName())
+			obj.GetName(),
+		)
 	}
 
 	tc.CreateResourceUntracked(obj)
@@ -451,7 +453,8 @@ func (tc *KubePerTestContext) CreateResourcesAndWait(objs ...client.Object) {
 
 	tc.LogSubsectionf(
 		"Creating %d resources",
-		len(objs))
+		len(objs),
+	)
 
 	for _, obj := range objs {
 		tc.CreateResource(obj)
@@ -583,7 +586,8 @@ func (tc *KubePerTestContext) PatchAndExpectError(old client.Object, new client.
 func (tc *KubePerTestContext) DeleteResourceAndWait(obj client.Object) {
 	tc.LogSubsectionf(
 		"Deleting resource %s",
-		obj.GetName())
+		obj.GetName(),
+	)
 	tc.DeleteResource(obj)
 	tc.Eventually(obj).Should(tc.Match.BeDeleted())
 }

--- a/v2/internal/testcommon/kube_test_context_envtest.go
+++ b/v2/internal/testcommon/kube_test_context_envtest.go
@@ -262,7 +262,8 @@ func createSharedEnvTest(
 				ErrorMaxSlowDelay:    maxBackoff,
 				ErrorVerySlowDelay:   maxBackoff,
 				RequeueDelayOverride: requeueDelay,
-			}),
+			},
+		),
 	}
 	positiveConditions := conditions.NewPositiveConditionBuilder(clock.New())
 
@@ -280,7 +281,8 @@ func createSharedEnvTest(
 			credentialProviderWrapper,
 			positiveConditions,
 			expressionEvaluator,
-			options)
+			options,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -292,7 +294,8 @@ func createSharedEnvTest(
 			kubeClient,
 			positiveConditions,
 			objs,
-			options)
+			options,
+		)
 		if err != nil {
 			stopEnvironment()
 			return nil, eris.Wrapf(err, "registering reconcilers")
@@ -379,7 +382,8 @@ func cfgToKey(cfg testConfig) string {
 	return fmt.Sprintf(
 		"%s/Replaying:%t",
 		cfg.Values,
-		cfg.Replaying)
+		cfg.Replaying,
+	)
 }
 
 func (set *sharedEnvTests) stopAll() {
@@ -551,11 +555,13 @@ func createEnvtestContext() (BaseTestContextFactory, context.CancelFunc) {
 				credentialProvider,
 				cfg.Cloud(),
 				perTestContext.HTTPClient,
-				metrics.NewARMClientMetrics())
+				metrics.NewARMClientMetrics(),
+			)
 
 			entraClientCache := entra.NewEntraClientCache(
 				credentialProvider,
-				perTestContext.HTTPClient)
+				perTestContext.HTTPClient,
+			)
 
 			resources := &perNamespace{
 				armClientCache:     armClientCache,

--- a/v2/internal/testcommon/matchers/be_deleted_in_azure_matcher.go
+++ b/v2/internal/testcommon/matchers/be_deleted_in_azure_matcher.go
@@ -52,7 +52,8 @@ func (m *BeDeletedInAzureMatcher) Match(actual interface{}) (bool, error) {
 	exists, _, err := m.client.CheckExistenceWithGetByID(
 		m.ctx,
 		id,
-		m.apiVersion)
+		m.apiVersion,
+	)
 	if err != nil {
 		return false, err
 	}

--- a/v2/internal/testcommon/vcr/v1/error_translating_roundtripper.go
+++ b/v2/internal/testcommon/vcr/v1/error_translating_roundtripper.go
@@ -100,7 +100,8 @@ func (w errorTranslation) RoundTrip(req *http.Request) (*http.Response, error) {
 				req.Header.Get(CountHeader)),
 
 			conditions.ConditionSeverityError,
-			conditions.ReasonReconciliationFailedPermanently)
+			conditions.ReasonReconciliationFailedPermanently,
+		)
 	}
 
 	// locate the request body with the shortest diff from the sent body
@@ -121,7 +122,8 @@ func (w errorTranslation) RoundTrip(req *http.Request) (*http.Response, error) {
 			shortestDiff),
 
 		conditions.ConditionSeverityError,
-		conditions.ReasonReconciliationFailedPermanently)
+		conditions.ReasonReconciliationFailedPermanently,
+	)
 }
 
 // finds bodies for interactions where request method, URL, and vcr.COUNT_HEADER match

--- a/v2/internal/testcommon/vcr/v3/error_translating_roundtripper.go
+++ b/v2/internal/testcommon/vcr/v3/error_translating_roundtripper.go
@@ -106,10 +106,12 @@ func (w errorTranslation) RoundTrip(req *http.Request) (*http.Response, error) {
 				w.cassetteName,
 				req.Method,
 				req.URL.String(),
-				discriminator),
+				discriminator,
+			),
 
 			conditions.ConditionSeverityError,
-			conditions.ReasonReconciliationFailedPermanently)
+			conditions.ReasonReconciliationFailedPermanently,
+		)
 	}
 
 	// locate the request body with the shortest diff from the sent body
@@ -129,7 +131,8 @@ func (w errorTranslation) RoundTrip(req *http.Request) (*http.Response, error) {
 			w.t.Name(),
 			w.cassetteName,
 			req.Method,
-			req.URL.String())
+			req.URL.String(),
+		)
 	} else {
 		err = eris.Errorf(
 			"cannot find go-vcr recording for request from test %q (cassette: %q) (body mismatch): %s %s\nShortest body diff:\n---\n%s\n---\n",
@@ -137,13 +140,15 @@ func (w errorTranslation) RoundTrip(req *http.Request) (*http.Response, error) {
 			w.cassetteName,
 			req.Method,
 			req.URL.String(),
-			shortestDiff)
+			shortestDiff,
+		)
 	}
 
 	return nil, conditions.NewReadyConditionImpactingError(
 		err,
 		conditions.ConditionSeverityError,
-		conditions.ReasonReconciliationFailedPermanently)
+		conditions.ReasonReconciliationFailedPermanently,
+	)
 }
 
 // finds bodies for interactions where request method, URL, and COUNT_HEADER match

--- a/v2/internal/testcommon/vcr/v3/replay_roundtripper_test.go
+++ b/v2/internal/testcommon/vcr/v3/replay_roundtripper_test.go
@@ -133,19 +133,22 @@ func TestReplayRoundTripperRoundTrip_GivenMultiplePUTsToSameURL_ReturnsExpectedB
 	alphaRequest, alphaResponse := createPutRequestAndResponse(
 		"/foo",
 		"Alpha goes here",
-		200)
+		200,
+	)
 
 	//nolint:bodyclose // response body is a string, no need to close
 	betaRequest, betaResponse := createPutRequestAndResponse(
 		"/foo",
 		"Beta goes here",
-		203)
+		203,
+	)
 
 	//nolint:bodyclose // response body is a string, no need to close
 	gammaRequest, gammaResponse := createPutRequestAndResponse(
 		"/foo",
 		"Gamma goes here",
-		200)
+		200,
+	)
 
 	fake := vcr.NewFakeRoundTripper(cassette.ErrInteractionNotFound)
 	fake.AddResponse(alphaRequest, alphaResponse)
@@ -184,14 +187,16 @@ func Test_ReplayRoundTripper_WhenCombinedWithTrackingRoundTripper_GivesDesiredRe
 	creationRequest, creationResponse := createPutRequestAndResponse(
 		"/sub/id/resource/A",
 		"create resource A",
-		200)
+		200,
+	)
 
 	// Arrange - Request and response to update the resource
 	//nolint:bodyclose // there's no actual body in this response to close
 	updateRequest, updateResponse := createPutRequestAndResponse(
 		"/sub/id/resource/A",
 		"update resource A",
-		200)
+		200,
+	)
 
 	// Arrange - set up fake replayer
 	fake := vcr.NewFakeRoundTripper(cassette.ErrInteractionNotFound)
@@ -230,7 +235,8 @@ func createPutRequestAndResponse(
 		Body: io.NopCloser(
 			bytes.NewBufferString(
 				fmt.Sprintf("PUT for %s", body),
-			)),
+			),
+		),
 	}
 
 	res := &http.Response{
@@ -238,7 +244,8 @@ func createPutRequestAndResponse(
 		Body: io.NopCloser(
 			bytes.NewBufferString(
 				fmt.Sprintf("PUT response for %s", body),
-			)),
+			),
+		),
 	}
 
 	return req, res

--- a/v2/internal/testcommon/vcr/v4/error_translating_roundtripper.go
+++ b/v2/internal/testcommon/vcr/v4/error_translating_roundtripper.go
@@ -106,10 +106,12 @@ func (w *errorTranslation) RoundTrip(req *http.Request) (*http.Response, error) 
 				w.cassetteName,
 				req.Method,
 				req.URL.String(),
-				discriminator),
+				discriminator,
+			),
 
 			conditions.ConditionSeverityError,
-			conditions.ReasonReconciliationFailedPermanently)
+			conditions.ReasonReconciliationFailedPermanently,
+		)
 	}
 
 	// locate the request body with the shortest diff from the sent body
@@ -130,7 +132,8 @@ func (w *errorTranslation) RoundTrip(req *http.Request) (*http.Response, error) 
 			shortestDiff),
 
 		conditions.ConditionSeverityError,
-		conditions.ReasonReconciliationFailedPermanently)
+		conditions.ReasonReconciliationFailedPermanently,
+	)
 }
 
 // finds bodies for interactions where request method and URL match

--- a/v2/internal/testcommon/vcr/v4/replay_roundtripper_test.go
+++ b/v2/internal/testcommon/vcr/v4/replay_roundtripper_test.go
@@ -133,19 +133,22 @@ func TestReplayRoundTripperRoundTrip_GivenMultiplePUTsToSameURL_ReturnsExpectedB
 	alphaRequest, alphaResponse := createPutRequestAndResponse(
 		"/foo",
 		"Alpha goes here",
-		200)
+		200,
+	)
 
 	//nolint:bodyclose // response body is a string, no need to close
 	betaRequest, betaResponse := createPutRequestAndResponse(
 		"/foo",
 		"Beta goes here",
-		203)
+		203,
+	)
 
 	//nolint:bodyclose // response body is a string, no need to close
 	gammaRequest, gammaResponse := createPutRequestAndResponse(
 		"/foo",
 		"Gamma goes here",
-		200)
+		200,
+	)
 
 	fake := vcr.NewFakeRoundTripper(cassette.ErrInteractionNotFound)
 	fake.AddResponse(alphaRequest, alphaResponse)
@@ -184,14 +187,16 @@ func Test_ReplayRoundTripper_WhenCombinedWithTrackingRoundTripper_GivesDesiredRe
 	creationRequest, creationResponse := createPutRequestAndResponse(
 		"/sub/id/resource/A",
 		"create resource A",
-		200)
+		200,
+	)
 
 	// Arrange - Request and response to update the resource
 	//nolint:bodyclose // there's no actual body in this response to close
 	updateRequest, updateResponse := createPutRequestAndResponse(
 		"/sub/id/resource/A",
 		"update resource A",
-		200)
+		200,
+	)
 
 	// Arrange - set up fake replayer
 	fake := vcr.NewFakeRoundTripper(cassette.ErrInteractionNotFound)
@@ -434,7 +439,8 @@ func createPutRequestAndResponse(
 		Body: io.NopCloser(
 			bytes.NewBufferString(
 				fmt.Sprintf("PUT for %s", body),
-			)),
+			),
+		),
 	}
 
 	res := &http.Response{
@@ -442,7 +448,8 @@ func createPutRequestAndResponse(
 		Body: io.NopCloser(
 			bytes.NewBufferString(
 				fmt.Sprintf("PUT response for %s", body),
-			)),
+			),
+		),
 	}
 
 	return req, res

--- a/v2/internal/tests/api_linting_test.go
+++ b/v2/internal/tests/api_linting_test.go
@@ -165,7 +165,8 @@ func validateConsistency(
 		strings.Join(passingTypes, ", "),
 		len(passingTypes),
 		strings.Join(failingTypes, ", "),
-		len(failingTypes))
+		len(failingTypes),
+	)
 }
 
 func Test_APILinting_Defaulter_Consistency(t *testing.T) {

--- a/v2/internal/tests/azure_generic_arm_reconciler_test.go
+++ b/v2/internal/tests/azure_generic_arm_reconciler_test.go
@@ -126,7 +126,8 @@ func Test_Conversion_DiscoversConfigMapsNotOnStorageVersion(t *testing.T) {
 			Group:   dbforpostgresqlstorage.GroupVersion.Group,
 			Version: dbforpostgresqlstorage.GroupVersion.Version,
 			Kind:    "FlexibleServer",
-		})
+		},
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	g.Expect(genruntime.GetOriginalGVK(storageVersion)).To(Equal(schema.GroupVersionKind{

--- a/v2/internal/testsamples/samples_test.go
+++ b/v2/internal/testsamples/samples_test.go
@@ -83,7 +83,8 @@ func runGroupTest(tc *testcommon.KubePerTestContext, groupVersionPath string) {
 		useRandomName,
 		rg.Name,
 		tc.AzureSubscription,
-		tc.AzureTenant).
+		tc.AzureTenant,
+	).
 		LoadSamples()
 
 	tc.Expect(err).To(BeNil())

--- a/v2/internal/testsamples/suite_test.go
+++ b/v2/internal/testsamples/suite_test.go
@@ -49,14 +49,16 @@ func setup() error {
 		testcommon.ResourcePrefix,
 		"-",
 		6,
-		testcommon.ResourceNamerModeRandomBasedOnTestName)
+		testcommon.ResourceNamerModeRandomBasedOnTestName,
+	)
 
 	// set global context var
 	newGlobalTestContext, err := testcommon.NewKubeContext(
 		options.useEnvTest,
 		options.recordReplay,
 		testcommon.DefaultTestRegion,
-		nameConfig)
+		nameConfig,
+	)
 	if err != nil {
 		return err
 	}

--- a/v2/internal/util/azuresql/azuresql.go
+++ b/v2/internal/util/azuresql/azuresql.go
@@ -37,7 +37,8 @@ func ConnectToDB(
 		database,
 		user,
 		password,
-		port)
+		port,
+	)
 
 	db, err := sql.Open(driverName, connString)
 	if err != nil {

--- a/v2/internal/util/azuresql/role.go
+++ b/v2/internal/util/azuresql/role.go
@@ -61,7 +61,8 @@ where m.name = @user
 	rows, err := db.QueryContext(
 		ctx,
 		tsql,
-		sql.Named("user", user))
+		sql.Named("user", user),
+	)
 	if err != nil {
 		return nil, eris.Wrapf(err, "listing roles for user %s", user)
 	}

--- a/v2/internal/util/cel/cel.go
+++ b/v2/internal/util/cel/cel.go
@@ -391,7 +391,8 @@ func makeUnexpectedResultError(ast *cel.Ast, allowed ...*cel.Type) error {
 		allowed,
 		func(item *cel.Type, _ int) string {
 			return item.String()
-		})
+		},
+	)
 	expectedTypesStr := strings.Join(expectedTypes, ",")
 	return eris.Errorf("expression %q must return one of [%s], but was %s", ast.Source().Content(), expectedTypesStr, ast.OutputType().String())
 }

--- a/v2/internal/util/cel/cel_test.go
+++ b/v2/internal/util/cel/cel_test.go
@@ -165,7 +165,8 @@ func Test_CompileAndRunAndCheck(t *testing.T) {
 							Raw: []byte(`"Test"`),
 						},
 					}
-				}),
+				},
+			),
 			expression:  `string(self.spec.untyped.mode)`, // Needs string cast here because output is dyn
 			expectedStr: "Test",
 		},
@@ -178,7 +179,8 @@ func Test_CompileAndRunAndCheck(t *testing.T) {
 							Raw: []byte(`["foo","bar","baz"]`),
 						},
 					}
-				}),
+				},
+			),
 			expression:  `string(self.spec.untyped.nestedArray[0])`, // Needs string cast here because output is dyn
 			expectedStr: "foo",
 		},
@@ -191,7 +193,8 @@ func Test_CompileAndRunAndCheck(t *testing.T) {
 							Raw: []byte(`{"innerMode": "Test", "value": 7}`),
 						},
 					}
-				}),
+				},
+			),
 			expression:  `string(self.spec.untyped.nestedStruct.innerMode)`, // Needs string cast here because output is dyn
 			expectedStr: "Test",
 		},
@@ -204,7 +207,8 @@ func Test_CompileAndRunAndCheck(t *testing.T) {
 							Raw: []byte(`{"innerMode": "Test", "value": 7}`),
 						},
 					}
-				}),
+				},
+			),
 			expression:  `string(self.spec.untyped.nestedStruct.value)`, // Needs string cast here because output is dyn
 			expectedStr: "7",
 		},
@@ -217,7 +221,8 @@ func Test_CompileAndRunAndCheck(t *testing.T) {
 							Raw: []byte(`{"innerMode": "Test", "value": 7}`),
 						},
 					}
-				}),
+				},
+			),
 			expression:  `string(self.spec.untyped.nestedStruct.mode)`, // There is no mode type
 			expectedErr: "failed to eval CEL expression: \"string(self.spec.untyped.nestedStruct.mode)\": no such key: mode",
 		},
@@ -230,7 +235,8 @@ func Test_CompileAndRunAndCheck(t *testing.T) {
 						"world",
 						"help",
 					}
-				}),
+				},
+			),
 			expression:  `self.spec.slice.filter(a, a.startsWith("hel")).join("-")`,
 			expectedStr: "hello-help",
 		},
@@ -266,7 +272,8 @@ func Test_CompileAndRunAndCheck(t *testing.T) {
 			self: newSimpleResource2Customized(
 				func(r *SimpleResource2) {
 					r.Spec.UnderscoreField = "hello"
-				}),
+				},
+			),
 			expression:  `self.spec.underscore_field`,
 			expectedStr: "hello",
 		},
@@ -275,7 +282,8 @@ func Test_CompileAndRunAndCheck(t *testing.T) {
 			self: newSimpleResource2Customized(
 				func(r *SimpleResource2) {
 					r.Spec.DoubleUnderscoreField = "hello"
-				}),
+				},
+			),
 			expression:  `self.spec.underscore__underscores__field`,
 			expectedStr: "hello",
 		},
@@ -284,7 +292,8 @@ func Test_CompileAndRunAndCheck(t *testing.T) {
 			self: newSimpleResource2Customized(
 				func(r *SimpleResource2) {
 					r.Spec.DoubleDoubleUnderscoreField = "hello"
-				}),
+				},
+			),
 			expression:  `self.spec.underscore__underscores__field__underscores__`,
 			expectedStr: "hello",
 		},
@@ -293,7 +302,8 @@ func Test_CompileAndRunAndCheck(t *testing.T) {
 			self: newSimpleResource2Customized(
 				func(r *SimpleResource2) {
 					r.Spec.UnderscoreStartField = "hello"
-				}),
+				},
+			),
 			expression:  `self.spec._underscoreStartField`,
 			expectedStr: "hello",
 		},
@@ -302,7 +312,8 @@ func Test_CompileAndRunAndCheck(t *testing.T) {
 			self: newSimpleResource2Customized(
 				func(r *SimpleResource2) {
 					r.Spec.DashField = "hello"
-				}),
+				},
+			),
 			expression:  `self.spec.dash__dash__field`,
 			expectedStr: "hello",
 		},
@@ -311,7 +322,8 @@ func Test_CompileAndRunAndCheck(t *testing.T) {
 			self: newSimpleResource2Customized(
 				func(r *SimpleResource2) {
 					r.Spec.DashUnderscoreField = "hello"
-				}),
+				},
+			),
 			expression:  `self.spec.dash__dash____underscores__field`,
 			expectedStr: "hello",
 		},
@@ -320,7 +332,8 @@ func Test_CompileAndRunAndCheck(t *testing.T) {
 			self: newSimpleResource2Customized(
 				func(r *SimpleResource2) {
 					r.Spec.DotField = "hello"
-				}),
+				},
+			),
 			expression:  `self.spec.dot__dot__field`,
 			expectedStr: "hello",
 		},
@@ -329,7 +342,8 @@ func Test_CompileAndRunAndCheck(t *testing.T) {
 			self: newSimpleResource2Customized(
 				func(r *SimpleResource2) {
 					r.Spec.SlashField = "hello"
-				}),
+				},
+			),
 			expression:  `self.spec.slash__slash__field`,
 			expectedStr: "hello",
 		},
@@ -347,7 +361,8 @@ func Test_CompileAndRunAndCheck(t *testing.T) {
 					r.Spec.String = " hope"
 					r.Spec.Int = " it"
 					r.Spec.Namespace = " works."
-				}),
+				},
+			),
 			expression:  `self.spec.const + self.spec.break + self.spec.__false__ + self.spec.__true__ + self.spec.__in__ + self.spec.__null__ + self.spec.endsWith + self.spec.string + self.spec.int + self.spec.namespace`,
 			expectedStr: "hello! hello! This is a test. I hope it works.",
 		},
@@ -360,7 +375,8 @@ func Test_CompileAndRunAndCheck(t *testing.T) {
 						"fruit is good for you":   "yes",
 						"cookies are bad for you": "yes",
 					}
-				}),
+				},
+			),
 			expression: `self.metadata.annotations.transformMapEntry(k, v, {k.replace(" ", "-"): v})`,
 			expectedMap: map[string]string{
 				"pizza":                   "no",
@@ -373,7 +389,8 @@ func Test_CompileAndRunAndCheck(t *testing.T) {
 			self: newSimpleResource2Customized(
 				func(r *SimpleResource2) {
 					r.Spec.TransformMapField = "test"
-				}),
+				},
+			),
 			expression:  `self.spec.transformMap`,
 			expectedStr: "test",
 		},

--- a/v2/internal/util/cel/env_cache.go
+++ b/v2/internal/util/cel/env_cache.go
@@ -45,11 +45,13 @@ func NewEnvCache(
 	cache.OnInsertion(
 		func(ctx context.Context, item *ttlcache.Item[string, envCacheItem]) {
 			log.V(Debug).Info("Env cache item inserted", "key", item.Key(), "expiry", item.ExpiresAt())
-		})
+		},
+	)
 	cache.OnEviction(
 		func(ctx context.Context, reason ttlcache.EvictionReason, item *ttlcache.Item[string, envCacheItem]) {
 			log.V(Debug).Info("Env cache item evicted", "key", item.Key(), "expiry", item.ExpiresAt(), "reason", reason)
-		})
+		},
+	)
 
 	return &EnvCache{
 		cache:   cache,

--- a/v2/internal/util/cel/program_cache.go
+++ b/v2/internal/util/cel/program_cache.go
@@ -62,11 +62,13 @@ func NewProgramCache(
 	cache.OnInsertion(
 		func(ctx context.Context, item *ttlcache.Item[string, *programCacheItem]) {
 			log.V(Debug).Info("Program cache item inserted", "key", item.Key(), "expiry", item.ExpiresAt())
-		})
+		},
+	)
 	cache.OnEviction(
 		func(ctx context.Context, reason ttlcache.EvictionReason, item *ttlcache.Item[string, *programCacheItem]) {
 			log.V(Debug).Info("Program cache item evicted", "key", item.Key(), "expiry", item.ExpiresAt(), "reason", reason)
-		})
+		},
+	)
 	return &ProgramCache{
 		cache:    cache,
 		envCache: envCache,

--- a/v2/internal/util/interval/interval_calculator_test.go
+++ b/v2/internal/util/interval/interval_calculator_test.go
@@ -44,7 +44,8 @@ func Test_Success_WithoutSyncPeriod_ReturnsEmptyResult(t *testing.T) {
 			ErrorMaxFastDelay:  5 * time.Second,
 			ErrorMaxSlowDelay:  10 * time.Second,
 			ErrorVerySlowDelay: 20 * time.Second,
-		})
+		},
+	)
 
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"}}
 
@@ -67,7 +68,8 @@ func Test_Success_WithSyncPeriod_ReturnsSyncPeriod(t *testing.T) {
 			ErrorMaxSlowDelay:  10 * time.Second,
 			ErrorVerySlowDelay: 20 * time.Second,
 			SyncPeriod:         &syncPeriod,
-		})
+		},
+	)
 
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"}}
 
@@ -94,7 +96,8 @@ func Test_Requeue_ReturnsResultUnmodified(t *testing.T) {
 			ErrorMaxSlowDelay:  10 * time.Second,
 			ErrorVerySlowDelay: 20 * time.Second,
 			SyncPeriod:         &syncPeriod,
-		})
+		},
+	)
 
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"}}
 
@@ -118,7 +121,8 @@ func Test_RequeueWithDelayOverride_ReturnsResultWithDelay(t *testing.T) {
 			ErrorVerySlowDelay:   20 * time.Second,
 			SyncPeriod:           &syncPeriod,
 			RequeueDelayOverride: 77 * time.Second,
-		})
+		},
+	)
 
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"}}
 
@@ -139,7 +143,8 @@ func Test_Error_ReturnedAsIs(t *testing.T) {
 			ErrorMaxFastDelay:  5 * time.Second,
 			ErrorMaxSlowDelay:  10 * time.Second,
 			ErrorVerySlowDelay: 20 * time.Second,
-		})
+		},
+	)
 
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"}}
 
@@ -161,7 +166,8 @@ func Test_ErrorFollowedBySuccess_ClearsFailureTracking(t *testing.T) {
 			ErrorMaxFastDelay:  5 * time.Second,
 			ErrorMaxSlowDelay:  10 * time.Second,
 			ErrorVerySlowDelay: 20 * time.Second,
-		})
+		},
+	)
 
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"}}
 
@@ -187,7 +193,8 @@ func Test_ReadyConditionErrorWithErrorSeverity_ReturnsSuccess(t *testing.T) {
 			ErrorMaxFastDelay:  5 * time.Second,
 			ErrorMaxSlowDelay:  10 * time.Second,
 			ErrorVerySlowDelay: 20 * time.Second,
-		})
+		},
+	)
 
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"}}
 
@@ -209,14 +216,16 @@ func Test_ReadyConditionErrorWithSlowBackoff_UsesSlowBackoff(t *testing.T) {
 			ErrorMaxFastDelay:  5 * time.Second,
 			ErrorMaxSlowDelay:  10 * time.Second,
 			ErrorVerySlowDelay: 20 * time.Second,
-		})
+		},
+	)
 
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"}}
 
 	inputErr := conditions.NewReadyConditionImpactingError(
 		eris.New("problem"),
 		conditions.ConditionSeverityWarning,
-		conditions.Reason{Name: "Abc", RetryClassification: retry.Slow})
+		conditions.Reason{Name: "Abc", RetryClassification: retry.Slow},
+	)
 
 	expectedDelaySec := []int64{1, 2, 4, 8, 10, 10, 10}
 
@@ -246,14 +255,16 @@ func Test_ReadyConditionErrorWithFastBackoff_UsesFastBackoff(t *testing.T) {
 			ErrorMaxFastDelay:  5 * time.Second,
 			ErrorMaxSlowDelay:  10 * time.Second,
 			ErrorVerySlowDelay: 20 * time.Second,
-		})
+		},
+	)
 
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"}}
 
 	inputErr := conditions.NewReadyConditionImpactingError(
 		eris.New("problem"),
 		conditions.ConditionSeverityWarning,
-		conditions.Reason{Name: "Abc", RetryClassification: retry.Fast})
+		conditions.Reason{Name: "Abc", RetryClassification: retry.Fast},
+	)
 
 	expectedDelaySec := []int64{1, 2, 4, 5, 5, 5, 5}
 
@@ -283,14 +294,16 @@ func Test_ReadyConditionErrorWithVerySlowBackoff_UsesVerySlowBackoff(t *testing.
 			ErrorMaxFastDelay:  5 * time.Second,
 			ErrorMaxSlowDelay:  10 * time.Second,
 			ErrorVerySlowDelay: 20 * time.Second,
-		})
+		},
+	)
 
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"}}
 
 	inputErr := conditions.NewReadyConditionImpactingError(
 		eris.New("problem"),
 		conditions.ConditionSeverityWarning,
-		conditions.Reason{Name: "Abc", RetryClassification: retry.VerySlow})
+		conditions.Reason{Name: "Abc", RetryClassification: retry.VerySlow},
+	)
 
 	result, err := calc.NextInterval(req, ctrl.Result{}, inputErr)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -322,7 +335,8 @@ func Test_KubeClientNotFoundError_ReturnsSuccess(t *testing.T) {
 			ErrorMaxFastDelay:  5 * time.Second,
 			ErrorMaxSlowDelay:  10 * time.Second,
 			ErrorVerySlowDelay: 20 * time.Second,
-		})
+		},
+	)
 
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"}}
 
@@ -349,7 +363,8 @@ func Test_KubeClientConflict_ReturnsBackoff(t *testing.T) {
 			ErrorMaxFastDelay:  5 * time.Second,
 			ErrorMaxSlowDelay:  10 * time.Second,
 			ErrorVerySlowDelay: 20 * time.Second,
-		})
+		},
+	)
 
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"}}
 

--- a/v2/internal/util/match/glob_matcher.go
+++ b/v2/internal/util/match/glob_matcher.go
@@ -69,7 +69,8 @@ func (gm *globMatcher) WasMatched() error {
 	return eris.Errorf(
 		"no match for %q (available candidates were %s)",
 		gm.glob,
-		strings.Join(choices, ", "))
+		strings.Join(choices, ", "),
+	)
 }
 
 // IsRestrictive returns false if we are blank or a universal wildcard, true otherwise.

--- a/v2/internal/util/match/glob_matcher_test.go
+++ b/v2/internal/util/match/glob_matcher_test.go
@@ -36,7 +36,8 @@ func TestGlobMatcher_GivenTerms_MatchesExpectedStrings(t *testing.T) {
 				matcher := newGlobMatcher(c.glob)
 
 				g.Expect(matcher.Matches(c.term).Matched).To(Equal(c.expectedMatch))
-			})
+			},
+		)
 	}
 }
 
@@ -62,6 +63,7 @@ func TestGlobMatcher_IsRestrictive_GivesExpectedResults(t *testing.T) {
 				matcher := newGlobMatcher(c.glob)
 
 				g.Expect(matcher.IsRestrictive()).To(Equal(c.restrictive))
-			})
+			},
+		)
 	}
 }

--- a/v2/internal/util/match/literal_matcher_test.go
+++ b/v2/internal/util/match/literal_matcher_test.go
@@ -40,7 +40,8 @@ func TestLiteralMatcher_Matches_GivesExpectedResults(t *testing.T) {
 				g := NewGomegaWithT(t)
 				matcher := newLiteralMatcher(c.literal)
 				g.Expect(matcher.Matches(c.value).Matched).To(Equal(c.expected))
-			})
+			},
+		)
 	}
 }
 
@@ -66,6 +67,7 @@ func TestLiteralMatcher_IsRestrictive_GivesExpectedResults(t *testing.T) {
 				g := NewGomegaWithT(t)
 				matcher := newLiteralMatcher(c.literal)
 				g.Expect(matcher.IsRestrictive()).To(Equal(c.restrictive))
-			})
+			},
+		)
 	}
 }

--- a/v2/internal/util/match/multi_matcher.go
+++ b/v2/internal/util/match/multi_matcher.go
@@ -66,7 +66,8 @@ func (mm *multiMatcher) WasMatched() error {
 		kerrors.NewAggregate(errs),
 		"%d of %d did not match",
 		count,
-		len(mm.matchers))
+		len(mm.matchers),
+	)
 }
 
 // IsRestrictive returns true if any of our contained matchers are restrictive

--- a/v2/internal/util/match/multi_matcher_test.go
+++ b/v2/internal/util/match/multi_matcher_test.go
@@ -135,6 +135,7 @@ func TestMultiMatcher_IsRestrictive_GivesExpectedResults(t *testing.T) {
 				matcher := newMultiMatcher(c.matcher)
 
 				g.Expect(matcher.IsRestrictive()).To(Equal(c.restrictive))
-			})
+			},
+		)
 	}
 }

--- a/v2/internal/util/match/string_matcher_test.go
+++ b/v2/internal/util/match/string_matcher_test.go
@@ -40,6 +40,7 @@ func TestStringMatcher_GivenMatcher_ReturnsExpectedResults(t *testing.T) {
 				matcher := NewStringMatcher(c.matcher)
 
 				g.Expect(matcher.Matches(c.value).Matched).To(Equal(c.expected))
-			})
+			},
+		)
 	}
 }

--- a/v2/internal/util/mysql/privilege.go
+++ b/v2/internal/util/mysql/privilege.go
@@ -77,7 +77,8 @@ func GetUserDatabasePrivileges(ctx context.Context, db *sql.DB, user string, hos
 	rows, err := db.QueryContext(
 		ctx,
 		"SELECT TABLE_SCHEMA, PRIVILEGE_TYPE FROM INFORMATION_SCHEMA.SCHEMA_PRIVILEGES WHERE GRANTEE = ?",
-		formatUser(user, hostname))
+		formatUser(user, hostname),
+	)
 	if err != nil {
 		return nil, eris.Wrapf(err, "listing database grants for user %s", user)
 	}
@@ -119,7 +120,8 @@ func GetUserServerPrivileges(ctx context.Context, db *sql.DB, user string, hostn
 	rows, err := db.QueryContext(
 		ctx,
 		"SELECT PRIVILEGE_TYPE FROM INFORMATION_SCHEMA.USER_PRIVILEGES WHERE GRANTEE = ? AND PRIVILEGE_TYPE != 'USAGE'",
-		formatUser(user, hostname))
+		formatUser(user, hostname),
+	)
 	if err != nil {
 		return nil, eris.Wrapf(err, "listing grants for user %s", user)
 	}

--- a/v2/internal/util/postgresql/role_option.go
+++ b/v2/internal/util/postgresql/role_option.go
@@ -82,7 +82,8 @@ func GetUserRoleOptions(ctx context.Context, db *sql.DB, user SQLUser) (*RoleOpt
 	rows, err := db.QueryContext(
 		ctx,
 		"SELECT rolcanlogin, rolcreaterole, rolcreatedb, rolreplication FROM pg_roles WHERE rolname !~ '^pg_' AND rolname = $1",
-		user.Name)
+		user.Name,
+	)
 	if err != nil {
 		return nil, eris.Wrapf(err, "listing grants for user %s", user)
 	}

--- a/v2/internal/util/postgresql/roles.go
+++ b/v2/internal/util/postgresql/roles.go
@@ -50,7 +50,8 @@ func GetUserServerRoles(ctx context.Context, db *sql.DB, user SQLUser) (set.Set[
 	rows, err := db.QueryContext(
 		ctx,
 		"SELECT c.rolname as role_name FROM pg_roles a INNER JOIN pg_auth_members b on a.oid = b.member INNER JOIN pg_roles c ON b.roleid = c.oid WHERE a.rolname = $1",
-		user.Name)
+		user.Name,
+	)
 	if err != nil {
 		return nil, eris.Wrapf(err, "listing grants for user %s", user)
 	}

--- a/v2/internal/util/predicates/name_predicate_test.go
+++ b/v2/internal/util/predicates/name_predicate_test.go
@@ -70,25 +70,29 @@ func Test_NamePredicate(t *testing.T) {
 				event.UpdateEvent{
 					ObjectOld: tt.obj,
 					ObjectNew: tt.obj,
-				})
+				},
+			)
 			g.Expect(result).To(Equal(tt.expected))
 
 			result = predicate.Create(
 				event.CreateEvent{
 					Object: tt.obj,
-				})
+				},
+			)
 			g.Expect(result).To(Equal(tt.expected))
 
 			result = predicate.Delete(
 				event.DeleteEvent{
 					Object: tt.obj,
-				})
+				},
+			)
 			g.Expect(result).To(Equal(tt.expected))
 
 			result = predicate.Generic(
 				event.GenericEvent{
 					Object: tt.obj,
-				})
+				},
+			)
 			g.Expect(result).To(Equal(tt.expected))
 		})
 	}

--- a/v2/internal/util/predicates/namespace_predicate_test.go
+++ b/v2/internal/util/predicates/namespace_predicate_test.go
@@ -70,25 +70,29 @@ func Test_NamespacePredicate(t *testing.T) {
 				event.UpdateEvent{
 					ObjectOld: tt.obj,
 					ObjectNew: tt.obj,
-				})
+				},
+			)
 			g.Expect(result).To(Equal(tt.expected))
 
 			result = predicate.Create(
 				event.CreateEvent{
 					Object: tt.obj,
-				})
+				},
+			)
 			g.Expect(result).To(Equal(tt.expected))
 
 			result = predicate.Delete(
 				event.DeleteEvent{
 					Object: tt.obj,
-				})
+				},
+			)
 			g.Expect(result).To(Equal(tt.expected))
 
 			result = predicate.Generic(
 				event.GenericEvent{
 					Object: tt.obj,
-				})
+				},
+			)
 			g.Expect(result).To(Equal(tt.expected))
 		})
 	}

--- a/v2/internal/util/predicates/select_annotations_predicate_test.go
+++ b/v2/internal/util/predicates/select_annotations_predicate_test.go
@@ -38,7 +38,8 @@ func Test_SelectAnnotationsChangedPredicate_DetectsChanges(t *testing.T) {
 	predicate := predicates.MakeSelectAnnotationChangedPredicate(
 		map[string]predicates.HasAnnotationChanged{
 			annotationKey: predicates.HasBasicAnnotationChanged,
-		})
+		},
+	)
 
 	empty := &SampleObj{}
 	withWatchedAnnotation1 := &SampleObj{
@@ -138,7 +139,8 @@ func Test_SelectAnnotationsChangedPredicate_DetectsChanges(t *testing.T) {
 				event.UpdateEvent{
 					ObjectOld: tt.old,
 					ObjectNew: tt.new,
-				})
+				},
+			)
 			g.Expect(result).To(Equal(tt.expected))
 		})
 	}
@@ -152,7 +154,8 @@ func Test_SelectAnnotationsChangedPredicate_CreateEvent(t *testing.T) {
 	predicate := predicates.MakeSelectAnnotationChangedPredicate(
 		map[string]predicates.HasAnnotationChanged{
 			annotationKey: predicates.HasBasicAnnotationChanged,
-		})
+		},
+	)
 
 	watchedObj := &SampleObj{
 		ObjectMeta: metav1.ObjectMeta{
@@ -165,7 +168,8 @@ func Test_SelectAnnotationsChangedPredicate_CreateEvent(t *testing.T) {
 	result := predicate.Create(
 		event.CreateEvent{
 			Object: watchedObj,
-		})
+		},
+	)
 	g.Expect(result).To(BeFalse())
 }
 
@@ -177,7 +181,8 @@ func Test_SelectAnnotationsChangedPredicate_DeleteEvent(t *testing.T) {
 	predicate := predicates.MakeSelectAnnotationChangedPredicate(
 		map[string]predicates.HasAnnotationChanged{
 			annotationKey: predicates.HasBasicAnnotationChanged,
-		})
+		},
+	)
 
 	watchedObj := &SampleObj{
 		ObjectMeta: metav1.ObjectMeta{
@@ -190,7 +195,8 @@ func Test_SelectAnnotationsChangedPredicate_DeleteEvent(t *testing.T) {
 	result := predicate.Delete(
 		event.DeleteEvent{
 			Object: watchedObj,
-		})
+		},
+	)
 	g.Expect(result).To(BeFalse())
 }
 
@@ -202,7 +208,8 @@ func Test_SelectAnnotationsChangedPredicate_GenericEvent(t *testing.T) {
 	predicate := predicates.MakeSelectAnnotationChangedPredicate(
 		map[string]predicates.HasAnnotationChanged{
 			annotationKey: predicates.HasBasicAnnotationChanged,
-		})
+		},
+	)
 
 	watchedObj := &SampleObj{
 		ObjectMeta: metav1.ObjectMeta{
@@ -215,7 +222,8 @@ func Test_SelectAnnotationsChangedPredicate_GenericEvent(t *testing.T) {
 	result := predicate.Generic(
 		event.GenericEvent{
 			Object: watchedObj,
-		})
+		},
+	)
 	g.Expect(result).To(BeFalse())
 }
 
@@ -254,11 +262,13 @@ func testPredicateReceivesExpectedValue(handler predicates.HasAnnotationChanged,
 	predicate := predicates.MakeSelectAnnotationChangedPredicate(
 		map[string]predicates.HasAnnotationChanged{
 			annotationKey: handler,
-		})
+		},
+	)
 
 	predicate.Update(
 		event.UpdateEvent{
 			ObjectOld: old,
 			ObjectNew: new,
-		})
+		},
+	)
 }

--- a/v2/internal/util/randextensions/time_test.go
+++ b/v2/internal/util/randextensions/time_test.go
@@ -41,7 +41,9 @@ func Test_Jitter(t *testing.T) {
 				return result >= expectedLow && result <= expectedHigh
 			},
 			gen.Int64Range(0, math.MaxInt64),
-			gen.Float64Range(0.001, 1)))
+			gen.Float64Range(0.001, 1),
+		),
+	)
 
 	properties.TestingRun(t)
 }

--- a/v2/internal/util/typo/typo_advisor.go
+++ b/v2/internal/util/typo/typo_advisor.go
@@ -67,19 +67,22 @@ func (advisor *Advisor) Errorf(typo string, format string, args ...interface{}) 
 	suggestion, err := edlib.FuzzySearch(
 		strings.ToLower(typo),
 		set.AsSortedSlice(advisor.terms),
-		edlib.Levenshtein)
+		edlib.Levenshtein,
+	)
 	if err != nil {
 		// Can't offer a suggestion
 		return eris.Errorf(
 			"%s (unable to provide suggestion: %s)",
 			msg,
-			err)
+			err,
+		)
 	}
 
 	return eris.Errorf(
 		"%s (did you mean %s?)",
 		msg,
-		suggestion)
+		suggestion,
+	)
 }
 
 // Wrapf adds any guidance to the provided error, if possible
@@ -97,19 +100,22 @@ func (advisor *Advisor) Wrapf(originalError error, typo string, format string, a
 	suggestion, err := edlib.FuzzySearch(
 		strings.ToLower(typo),
 		set.AsSortedSlice(advisor.terms),
-		edlib.Levenshtein)
+		edlib.Levenshtein,
+	)
 	if err != nil {
 		// Can't offer a suggestion
 		return eris.Wrapf(
 			originalError,
 			"%s (unable to provide suggestion: %s)",
 			msg,
-			err)
+			err,
+		)
 	}
 
 	return eris.Wrapf(
 		originalError,
 		"%s (did you mean %s?)",
 		msg,
-		suggestion)
+		suggestion,
+	)
 }

--- a/v2/internal/version/version.go
+++ b/v2/internal/version/version.go
@@ -43,7 +43,8 @@ func versionCommand(cmd *cobra.Command, args []string) error {
 		"%s %s %s\n",
 		filepath.Base(path),
 		ver,
-		runtime.GOOS)
+		runtime.GOOS,
+	)
 
 	return nil
 }

--- a/v2/pkg/genruntime/admissions.go
+++ b/v2/pkg/genruntime/admissions.go
@@ -49,7 +49,8 @@ func ValidateWriteOnceProperties(oldObj ARMMetaObject, newObj ARMMetaObject) (ad
 		err := eris.Errorf(
 			"updating 'spec.azureName' is not allowed for '%s : %s",
 			oldObj.GetObjectKind().GroupVersionKind(),
-			oldObj.GetName())
+			oldObj.GetName(),
+		)
 		errs = append(errs, err)
 	}
 

--- a/v2/pkg/genruntime/conditions/conditions.go
+++ b/v2/pkg/genruntime/conditions/conditions.go
@@ -206,7 +206,8 @@ func (c Condition) String() string {
 		c.Severity,
 		c.Reason,
 		c.Message,
-		c.LastTransitionTime)
+		c.LastTransitionTime,
+	)
 }
 
 // SetCondition sets the provided Condition on the Conditioner. The condition is only

--- a/v2/pkg/genruntime/conditions/conditions_test.go
+++ b/v2/pkg/genruntime/conditions/conditions_test.go
@@ -62,7 +62,8 @@ func Test_SetCondition_ReadyTrueToReadyFalse_UpdatesConditionAndChangesTimestamp
 		conditions.ConditionSeverityError,
 		0,
 		"MyReason",
-		"a message")
+		"a message",
+	)
 	conditions.SetCondition(o, updatedCondition)
 
 	g.Expect(o.Conditions).To(HaveLen(1))
@@ -82,7 +83,8 @@ func Test_SetCondition_ChangeReason_TimestampChanged(t *testing.T) {
 		conditions.ConditionSeverityError,
 		0,
 		"MyReason",
-		"a message")
+		"a message",
+	)
 	conditions.SetCondition(o, initialCondition)
 
 	clk.Add(1 * time.Second)
@@ -93,7 +95,8 @@ func Test_SetCondition_ChangeReason_TimestampChanged(t *testing.T) {
 		conditions.ConditionSeverityError,
 		0,
 		"MyNewReason",
-		"a message")
+		"a message",
+	)
 	conditions.SetCondition(o, updatedCondition)
 
 	// Set the expected condition to the updated condition
@@ -113,7 +116,8 @@ func Test_SetCondition_SameConditionTimestampUnchanged(t *testing.T) {
 		conditions.ConditionSeverityError,
 		0,
 		"MyReason",
-		"a message")
+		"a message",
+	)
 	conditions.SetCondition(o, initialCondition)
 
 	clk.Add(1 * time.Second)
@@ -124,7 +128,8 @@ func Test_SetCondition_SameConditionTimestampUnchanged(t *testing.T) {
 		conditions.ConditionSeverityError,
 		0,
 		"MyReason",
-		"a message")
+		"a message",
+	)
 	conditions.SetCondition(o, updatedCondition)
 
 	// Set the expected condition to the updated condition
@@ -142,55 +147,64 @@ func Test_SetCondition_OverwritesAsExpected(t *testing.T) {
 		conditions.ConditionSeverityInfo,
 		1,
 		"InfoReason",
-		"a message")
+		"a message",
+	)
 	differentInfoGeneration1Condition := builder.MakeFalseCondition(
 		conditions.ConditionTypeReady,
 		conditions.ConditionSeverityInfo,
 		1,
 		"ADifferentInfoReason",
-		"a message")
+		"a message",
+	)
 	infoGeneration2Condition := builder.MakeFalseCondition(
 		conditions.ConditionTypeReady,
 		conditions.ConditionSeverityInfo,
 		2,
 		"InfoOtherReason",
-		"a message")
+		"a message",
+	)
 	warningGeneration1Condition := builder.MakeFalseCondition(
 		conditions.ConditionTypeReady,
 		conditions.ConditionSeverityWarning,
 		1,
 		"WarningReason",
-		"a message")
+		"a message",
+	)
 	differentWarningGeneration1Condition := builder.MakeFalseCondition(
 		conditions.ConditionTypeReady,
 		conditions.ConditionSeverityWarning,
 		1,
 		"ADifferentWarningReason",
-		"a message")
+		"a message",
+	)
 	warningGeneration2Condition := builder.MakeFalseCondition(
 		conditions.ConditionTypeReady,
 		conditions.ConditionSeverityWarning,
 		2,
 		"WarningOtherReason",
-		"a message")
+		"a message",
+	)
 	errorGeneration1Condition := builder.MakeFalseCondition(
 		conditions.ConditionTypeReady,
 		conditions.ConditionSeverityError,
 		1,
 		"MyReason",
-		"a message")
+		"a message",
+	)
 	differentErrorGeneration1Condition := builder.MakeFalseCondition(
 		conditions.ConditionTypeReady,
 		conditions.ConditionSeverityError,
 		1,
 		"ADifferentErrorReason",
-		"a message")
+		"a message",
+	)
 	errorGeneration2Condition := builder.MakeFalseCondition(
 		conditions.ConditionTypeReady,
 		conditions.ConditionSeverityError,
 		2,
 		"MyOtherReason",
-		"a message")
+		"a message",
+	)
 	trueGeneration1Condition := builder.MakeTrueCondition(conditions.ConditionTypeReady, 1)
 	trueGeneration2Condition := builder.MakeTrueCondition(conditions.ConditionTypeReady, 2)
 
@@ -198,12 +212,14 @@ func Test_SetCondition_OverwritesAsExpected(t *testing.T) {
 		conditions.ConditionTypeReady,
 		1,
 		"UnknownReason",
-		"a message")
+		"a message",
+	)
 	unknownGeneration2Condition := builder.MakeUnknownCondition(
 		conditions.ConditionTypeReady,
 		2,
 		"UnknownOtherReason",
-		"a message")
+		"a message",
+	)
 
 	gen1List := []conditions.Condition{
 		trueGeneration1Condition,
@@ -271,7 +287,8 @@ func Test_SetCondition_OverwritesAsExpected(t *testing.T) {
 					initial:           &gen1,
 					new:               gen2,
 					expectedOverwrite: true,
-				})
+				},
+			)
 		}
 	}
 
@@ -306,49 +323,57 @@ func Test_SetConditionReasonAware_OverwritesAsExpected(t *testing.T) {
 		conditions.ConditionSeverityInfo,
 		1,
 		conditions.ReasonReconciling.Name,
-		"a message")
+		"a message",
+	)
 	referenceNotFoundCondition := builder.MakeFalseCondition(
 		conditions.ConditionTypeReady,
 		conditions.ConditionSeverityWarning,
 		1,
 		conditions.ReasonReferenceNotFound.Name,
-		"a message")
+		"a message",
+	)
 	secretNotFoundCondition := builder.MakeFalseCondition(
 		conditions.ConditionTypeReady,
 		conditions.ConditionSeverityWarning,
 		1,
 		conditions.ReasonSecretNotFound.Name,
-		"a message")
+		"a message",
+	)
 	azureResourceNotFound := builder.MakeFalseCondition(
 		conditions.ConditionTypeReady,
 		conditions.ConditionSeverityError,
 		1,
 		conditions.ReasonAzureResourceNotFound.Name,
-		"a message")
+		"a message",
+	)
 	arbitraryInfoCondition := builder.MakeFalseCondition(
 		conditions.ConditionTypeReady,
 		conditions.ConditionSeverityInfo,
 		1,
 		"InfoReason",
-		"a message")
+		"a message",
+	)
 	arbitraryWarningCondition := builder.MakeFalseCondition(
 		conditions.ConditionTypeReady,
 		conditions.ConditionSeverityWarning,
 		1,
 		"WarningReason",
-		"a message")
+		"a message",
+	)
 	arbitraryErrorCondition := builder.MakeFalseCondition(
 		conditions.ConditionTypeReady,
 		conditions.ConditionSeverityError,
 		1,
 		"ErrorReason",
-		"a message")
+		"a message",
+	)
 	waitingForOwnerWarningCondition := builder.MakeFalseCondition(
 		conditions.ConditionTypeReady,
 		conditions.ConditionSeverityWarning,
 		1,
 		conditions.ReasonWaitingForOwner.Name,
-		"a message")
+		"a message",
+	)
 	successCondition := builder.MakeTrueCondition(conditions.ConditionTypeReady, 1)
 
 	type testStruct struct {

--- a/v2/pkg/genruntime/conditions/ready_condition_builder.go
+++ b/v2/pkg/genruntime/conditions/ready_condition_builder.go
@@ -69,7 +69,8 @@ func (b *ReadyConditionBuilder) ReadyCondition(severity ConditionSeverity, obser
 		severity,
 		observedGeneration,
 		reason,
-		message)
+		message,
+	)
 }
 
 func (b *ReadyConditionBuilder) Reconciling(observedGeneration int64) Condition {
@@ -78,7 +79,8 @@ func (b *ReadyConditionBuilder) Reconciling(observedGeneration int64) Condition 
 		ConditionSeverityInfo,
 		observedGeneration,
 		ReasonReconciling.Name,
-		"The resource is in the process of being reconciled by the operator")
+		"The resource is in the process of being reconciled by the operator",
+	)
 }
 
 func (b *ReadyConditionBuilder) Deleting(observedGeneration int64) Condition {
@@ -87,7 +89,8 @@ func (b *ReadyConditionBuilder) Deleting(observedGeneration int64) Condition {
 		ConditionSeverityInfo,
 		observedGeneration,
 		ReasonDeleting.Name,
-		"The resource is being deleted")
+		"The resource is being deleted",
+	)
 }
 
 func (b *ReadyConditionBuilder) Succeeded(observedGeneration int64) Condition {

--- a/v2/pkg/genruntime/configmaps/validation_unexported_test.go
+++ b/v2/pkg/genruntime/configmaps/validation_unexported_test.go
@@ -39,7 +39,8 @@ func Test_ValidateConfigMapDestination_MissingKey(t *testing.T) {
 				Name:  "my-configmap",
 				Value: `"hello"`,
 			},
-		})
+		},
+	)
 	g.Expect(warnings).To(BeNil())
 	g.Expect(err).To(MatchError(ContainSubstring("CEL expression with output type string must specify destination 'key'")))
 }
@@ -68,7 +69,8 @@ func Test_ValidateConfigMapDestination_UnneededKey(t *testing.T) {
 				Key:   "my-key",
 				Value: `{"test": "test"}`,
 			},
-		})
+		},
+	)
 	g.Expect(warnings).To(BeNil())
 	g.Expect(err).To(MatchError(ContainSubstring("CEL expression with output type map[string]string must not specify destination 'key'")))
 }

--- a/v2/pkg/genruntime/core/errors.go
+++ b/v2/pkg/genruntime/core/errors.go
@@ -208,7 +208,8 @@ func NewSubscriptionMismatchError(expectedSub string, actualSub string) *Subscri
 	err := eris.Errorf(
 		"resource subscription %q does not match parent subscription %q",
 		actualSub,
-		expectedSub)
+		expectedSub,
+	)
 
 	return &SubscriptionMismatch{
 		ExpectedSubscription: expectedSub,

--- a/v2/pkg/genruntime/enum_test.go
+++ b/v2/pkg/genruntime/enum_test.go
@@ -46,6 +46,7 @@ func Test_ToEnum_WhenCalled_ReturnsExpectedResult(t *testing.T) {
 				if actual != c.expected {
 					t.Errorf("Expected %s, but got %s", c.expected, actual)
 				}
-			})
+			},
+		)
 	}
 }

--- a/v2/pkg/genruntime/extensions/error_classifier.go
+++ b/v2/pkg/genruntime/extensions/error_classifier.go
@@ -56,13 +56,15 @@ func CreateErrorClassifier(
 			"Classifying CloudError",
 			"Message", cloudError.Message(),
 			"Code", cloudError.Code(),
-			"Target", cloudError.Target())
+			"Target", cloudError.Target(),
+		)
 
 		result, err := impl.ClassifyError(cloudError, apiVersion, log, classifier)
 		if err != nil {
 			log.V(Status).Info(
 				"CloudError classification failed",
-				"Error", err.Error())
+				"Error", err.Error(),
+			)
 
 			return core.CloudErrorDetails{}, err
 		}
@@ -72,7 +74,8 @@ func CreateErrorClassifier(
 			"Classification", result.Classification,
 			"Retry", result.Retry,
 			"Code", result.Code,
-			"Message", result.Message)
+			"Message", result.Message,
+		)
 
 		return result, nil
 	}

--- a/v2/pkg/genruntime/extensions/kubernetes_secret_exporter.go
+++ b/v2/pkg/genruntime/extensions/kubernetes_secret_exporter.go
@@ -54,7 +54,8 @@ func CreateKubernetesSecretExporter(
 
 		log.V(Info).Info(
 			"Successfully retrieved Kubernetes secrets for export",
-			"ResourcesToWrite", len(objs), "RawSecrets", len(rawSecrets))
+			"ResourcesToWrite", len(objs), "RawSecrets", len(rawSecrets),
+		)
 
 		return result, nil
 	}

--- a/v2/pkg/genruntime/extensions/postreconciliation_checker.go
+++ b/v2/pkg/genruntime/extensions/postreconciliation_checker.go
@@ -102,7 +102,8 @@ func (r PostReconcileCheckResult) CreateConditionError() error {
 	return conditions.NewReadyConditionImpactingError(
 		eris.New(r.message),
 		r.severity,
-		r.reason)
+		r.reason,
+	)
 }
 
 // postReconcileCheckResultType is the type of result returned by PreReconcileCheck.
@@ -140,7 +141,8 @@ func CreatePostReconciliationChecker(
 		if err != nil {
 			log.V(Status).Info(
 				"Extension post-reconcile check failed",
-				"Error", err.Error())
+				"Error", err.Error(),
+			)
 
 			// We choose to skip here so that things are definitely broken and the user will notice
 			// If we defaulted to always reconciling, the user might not notice that something is wrong

--- a/v2/pkg/genruntime/extensions/prereconcile_check_result.go
+++ b/v2/pkg/genruntime/extensions/prereconcile_check_result.go
@@ -65,7 +65,8 @@ func (r PreReconcileCheckResult) CreateConditionError() error {
 	return conditions.NewReadyConditionImpactingError(
 		eris.New(r.message),
 		r.severity,
-		r.reason)
+		r.reason,
+	)
 }
 
 // PreReconcileCheckResultType is the type of result returned by PreReconcileCheck.

--- a/v2/pkg/genruntime/extensions/prereconciliation_checker.go
+++ b/v2/pkg/genruntime/extensions/prereconciliation_checker.go
@@ -79,7 +79,8 @@ func CreatePreReconciliationChecker(
 		if err != nil {
 			log.V(Status).Info(
 				"Extension pre-reconcile check failed",
-				"Error", err.Error())
+				"Error", err.Error(),
+			)
 
 			// We choose to skip here so that things are definitely broken and the user will notice
 			// If we defaulted to always reconciling, the user might not notice that something is wrong
@@ -88,7 +89,8 @@ func CreatePreReconciliationChecker(
 
 		log.V(Status).Info(
 			"Extension pre-reconcile check succeeded",
-			"Result", result)
+			"Result", result,
+		)
 
 		return result, nil
 	}, true

--- a/v2/pkg/genruntime/extensions/prereconciliation_owner_checker.go
+++ b/v2/pkg/genruntime/extensions/prereconciliation_owner_checker.go
@@ -84,7 +84,8 @@ func CreatePreReconciliationOwnerChecker(
 		if err != nil {
 			log.V(Status).Info(
 				"Extension pre-reconcile owner check failed",
-				"Error", err.Error())
+				"Error", err.Error(),
+			)
 
 			// We choose to skip here so that things are definitely broken and the user will notice
 			// If we defaulted to always reconciling, the user might not notice that something is wrong
@@ -93,7 +94,8 @@ func CreatePreReconciliationOwnerChecker(
 
 		log.V(Status).Info(
 			"Extension pre-reconcile owner check succeeded",
-			"Result", result)
+			"Result", result,
+		)
 
 		return result, nil
 	}, true

--- a/v2/pkg/genruntime/merger/merger.go
+++ b/v2/pkg/genruntime/merger/merger.go
@@ -65,14 +65,16 @@ func mergeSecrets(namespace string, s []*v1.Secret) ([]*v1.Secret, error) {
 				&genruntime.SecretDestination{
 					Name: secret.Name,
 					Key:  key,
-				}, value)
+				}, value,
+			)
 		}
 		for key, value := range secret.Data {
 			collector.AddBinaryValue(
 				&genruntime.SecretDestination{
 					Name: secret.Name,
 					Key:  key,
-				}, value)
+				}, value,
+			)
 		}
 	}
 
@@ -87,14 +89,16 @@ func mergeConfigMaps(namespace string, c []*v1.ConfigMap) ([]*v1.ConfigMap, erro
 				&genruntime.ConfigMapDestination{
 					Name: configMap.Name,
 					Key:  key,
-				}, value)
+				}, value,
+			)
 		}
 		for key, value := range configMap.BinaryData {
 			collector.AddBinaryValue(
 				&genruntime.ConfigMapDestination{
 					Name: configMap.Name,
 					Key:  key,
-				}, value)
+				}, value,
+			)
 		}
 	}
 

--- a/v2/pkg/genruntime/owner.go
+++ b/v2/pkg/genruntime/owner.go
@@ -36,7 +36,8 @@ func CheckTargetOwnedByObj(obj client.Object, target client.Object) error {
 			target.GetName(),
 			target.GetObjectKind().GroupVersionKind(),
 			obj.GetName(),
-			obj.GetObjectKind().GroupVersionKind())
+			obj.GetObjectKind().GroupVersionKind(),
+		)
 	}
 
 	return nil

--- a/v2/pkg/genruntime/resource_reference.go
+++ b/v2/pkg/genruntime/resource_reference.go
@@ -314,21 +314,24 @@ func VerifyResourceOwnerARMID(resource ARMMetaObject) error {
 			return eris.Errorf(
 				"expected owner ARM ID to be from provider %q, but was %q",
 				provider,
-				armID.ResourceType.Namespace)
+				armID.ResourceType.Namespace,
+			)
 		}
 		expectedARMIDType := strings.Join(expectedResourceTypesIncludedInARMID, "/")
 		if !strings.EqualFold(armID.ResourceType.Type, expectedARMIDType) {
 			return eris.Errorf(
 				"expected owner ARM ID to be of type %q, but was %q",
 				fmt.Sprintf("%s/%s", provider, expectedARMIDType),
-				armID.ResourceType.String())
+				armID.ResourceType.String(),
+			)
 		}
 	} else if len(expectedResourceTypesIncludedInARMID) == 0 {
 		scope := resource.GetResourceScope()
 		if scope == ResourceScopeResourceGroup && armID.ResourceType.String() != "Microsoft.Resources/resourceGroups" {
 			return eris.Errorf(
 				"expected owner ARM ID to be for a resource group, but was %q",
-				armID.ResourceType.String())
+				armID.ResourceType.String(),
+			)
 		}
 	}
 

--- a/v2/pkg/genruntime/secrets/validation_unexported_test.go
+++ b/v2/pkg/genruntime/secrets/validation_unexported_test.go
@@ -39,7 +39,8 @@ func Test_ValidateConfigMapDestination_MissingKey(t *testing.T) {
 				Name:  "my-configmap",
 				Value: `"hello"`,
 			},
-		})
+		},
+	)
 	g.Expect(warnings).To(BeNil())
 	g.Expect(err).To(MatchError(ContainSubstring("CEL expression with output type string must specify destination 'key'")))
 }
@@ -68,7 +69,8 @@ func Test_ValidateConfigMapDestination_UnneededKey(t *testing.T) {
 				Key:   "my-key",
 				Value: `{"test": "test"}`,
 			},
-		})
+		},
+	)
 	g.Expect(warnings).To(BeNil())
 	g.Expect(err).To(MatchError(ContainSubstring("CEL expression with output type map[string]string must not specify destination 'key'")))
 }

--- a/v2/pkg/genruntime/test/suite_test.go
+++ b/v2/pkg/genruntime/test/suite_test.go
@@ -51,14 +51,16 @@ func setup() error {
 		testcommon.ResourcePrefix,
 		"-",
 		6,
-		testcommon.ResourceNamerModeRandomBasedOnTestName)
+		testcommon.ResourceNamerModeRandomBasedOnTestName,
+	)
 
 	// set global context var
 	newGlobalTestContext, err := testcommon.NewKubeContext(
 		options.useEnvTest,
 		options.recordReplay,
 		testcommon.DefaultTestRegion,
-		nameConfig)
+		nameConfig,
+	)
 	if err != nil {
 		return err
 	}

--- a/v2/test/azuresql_test.go
+++ b/v2/test/azuresql_test.go
@@ -59,7 +59,8 @@ func Test_AzureSQL_Combined(t *testing.T) {
 				database.AzureName(),
 				azuresqlutil.ServerPort,
 				adminUsername,
-				adminPassword)
+				adminPassword,
+			)
 			if err != nil {
 				return err
 			}
@@ -105,7 +106,8 @@ func AzureSQL_AdminSecret_Rollover(tc *testcommon.KubePerTestContext, fqdn strin
 		database,
 		azuresqlutil.ServerPort,
 		adminUsername,
-		adminPassword)
+		adminPassword,
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	// Close the connection
 	tc.Expect(db.Close()).To(Succeed())
@@ -130,7 +132,8 @@ func AzureSQL_AdminSecret_Rollover(tc *testcommon.KubePerTestContext, fqdn strin
 				database,
 				azuresqlutil.ServerPort,
 				adminUsername,
-				newAdminPassword)
+				newAdminPassword,
+			)
 			if err != nil {
 				return err
 			}
@@ -151,7 +154,8 @@ func AzureSQL_User_Helpers(tc *testcommon.KubePerTestContext, fqdn string, datab
 		database,
 		azuresqlutil.ServerPort,
 		adminUsername,
-		adminPassword)
+		adminPassword,
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	defer db.Close()
 
@@ -227,7 +231,8 @@ func AzureSQL_User_CRUD(tc *testcommon.KubePerTestContext, server *sql.Server, d
 		database.AzureName(),
 		azuresqlutil.ServerPort,
 		to.Value(server.Spec.AdministratorLogin),
-		adminPassword)
+		adminPassword,
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	defer conn.Close()
 
@@ -260,7 +265,8 @@ func AzureSQL_User_CRUD(tc *testcommon.KubePerTestContext, server *sql.Server, d
 		database.AzureName(),
 		azuresqlutil.ServerPort,
 		user.Spec.AzureName,
-		password)
+		password,
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	// Close the connection
 	tc.Expect(conn.Close()).To(Succeed())
@@ -284,7 +290,8 @@ func AzureSQL_User_CRUD(tc *testcommon.KubePerTestContext, server *sql.Server, d
 				database.AzureName(),
 				azuresqlutil.ServerPort,
 				user.Spec.AzureName,
-				newPassword)
+				newPassword,
+			)
 			if err != nil {
 				return err
 			}
@@ -320,7 +327,8 @@ func AzureSQL_User_CRUD(tc *testcommon.KubePerTestContext, server *sql.Server, d
 		database.AzureName(),
 		azuresqlutil.ServerPort,
 		to.Value(server.Spec.AdministratorLogin),
-		adminPassword)
+		adminPassword,
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	defer conn.Close()
 

--- a/v2/test/multitenant/suite_test.go
+++ b/v2/test/multitenant/suite_test.go
@@ -46,14 +46,16 @@ func setup() error {
 		testcommon.LiveResourcePrefix,
 		"-",
 		6,
-		testcommon.ResourceNamerModeRandom)
+		testcommon.ResourceNamerModeRandom,
+	)
 
 	// set global context var
 	newGlobalTestContext, err := testcommon.NewKubeContext(
 		false,
 		false,
 		testcommon.DefaultTestRegion,
-		nameConfig)
+		nameConfig,
+	)
 	if err != nil {
 		return err
 	}

--- a/v2/test/mysql_aad_test.go
+++ b/v2/test/mysql_aad_test.go
@@ -73,7 +73,8 @@ func Test_MySQL_AADUser(t *testing.T) {
 		"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/%s",
 		tc.AzureSubscription,
 		identityResourceGroup,
-		identityName)
+		identityName,
+	)
 
 	server := newMySQLServer(tc, rg, adminUsername, adminPasswordKey, secret.Name)
 	server.Spec.Identity = &mysql.Identity{
@@ -188,7 +189,8 @@ func MySQL_AADUser_CRUD(
 		mysqlutil.SystemDatabase,
 		mysqlutil.ServerPort,
 		to.Value(server.Spec.AdministratorLogin),
-		standardAdminPassword)
+		standardAdminPassword,
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	defer conn.Close()
 
@@ -299,7 +301,8 @@ func MySQL_LocalUser_AADAdmin_CRUD(
 		mysqlutil.SystemDatabase,
 		mysqlutil.ServerPort,
 		to.Value(server.Spec.AdministratorLogin),
-		standardAdminPassword)
+		standardAdminPassword,
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	defer conn.Close()
 
@@ -369,7 +372,8 @@ func MySQL_AADUserAndGroup_CRUD(
 		mysqlutil.SystemDatabase,
 		mysqlutil.ServerPort,
 		to.Value(server.Spec.AdministratorLogin),
-		standardAdminPassword)
+		standardAdminPassword,
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	defer conn.Close()
 

--- a/v2/test/mysql_test.go
+++ b/v2/test/mysql_test.go
@@ -80,7 +80,8 @@ func MySQL_AdminSecret_Rollover(tc *testcommon.KubePerTestContext, fqdn string, 
 		mysqlutil.SystemDatabase,
 		mysqlutil.ServerPort,
 		adminUsername,
-		adminPassword)
+		adminPassword,
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	// Close the connection
 	tc.Expect(conn.Close()).To(Succeed())
@@ -106,7 +107,8 @@ func MySQL_AdminSecret_Rollover(tc *testcommon.KubePerTestContext, fqdn string, 
 				mysqlutil.SystemDatabase,
 				mysqlutil.ServerPort,
 				adminUsername,
-				newAdminPassword)
+				newAdminPassword,
+			)
 			if err != nil {
 				return err
 			}
@@ -128,7 +130,8 @@ func MySQL_User_Helpers(tc *testcommon.KubePerTestContext, fqdn string, adminUse
 		mysqlutil.SystemDatabase,
 		mysqlutil.ServerPort,
 		adminUsername,
-		adminPassword)
+		adminPassword,
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	defer db.Close()
 
@@ -210,7 +213,8 @@ func MySQL_User_CRUD(tc *testcommon.KubePerTestContext, server *mysql.FlexibleSe
 		mysqlutil.SystemDatabase,
 		mysqlutil.ServerPort,
 		to.Value(server.Spec.AdministratorLogin),
-		adminPassword)
+		adminPassword,
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	defer conn.Close()
 
@@ -243,7 +247,8 @@ func MySQL_User_CRUD(tc *testcommon.KubePerTestContext, server *mysql.FlexibleSe
 		"",
 		mysqlutil.ServerPort,
 		user.Spec.AzureName,
-		password)
+		password,
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	// Close the connection
 	tc.Expect(conn.Close()).To(Succeed())
@@ -267,7 +272,8 @@ func MySQL_User_CRUD(tc *testcommon.KubePerTestContext, server *mysql.FlexibleSe
 				"",
 				mysqlutil.ServerPort,
 				user.Spec.AzureName,
-				newPassword)
+				newPassword,
+			)
 			if err != nil {
 				return err
 			}
@@ -314,7 +320,8 @@ func MySQL_User_CRUD(tc *testcommon.KubePerTestContext, server *mysql.FlexibleSe
 		mysqlutil.SystemDatabase,
 		mysqlutil.ServerPort,
 		to.Value(server.Spec.AdministratorLogin),
-		adminPassword)
+		adminPassword,
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 
 	exists, err := mysqlutil.DoesUserExist(ctx, conn, user.Name)

--- a/v2/test/operation_edge_case_test.go
+++ b/v2/test/operation_edge_case_test.go
@@ -215,7 +215,8 @@ func newLoadBalancerForVMSS(tc *testcommon.KubePerTestContext, rg *resources.Res
 		"loadBalancers",
 		lbName,
 		"frontendIPConfigurations",
-		lbFrontendName)
+		lbFrontendName,
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/v2/test/perf/suite_test.go
+++ b/v2/test/perf/suite_test.go
@@ -46,14 +46,16 @@ func setup() error {
 		testcommon.LiveResourcePrefix,
 		"-",
 		6,
-		testcommon.ResourceNamerModeRandom)
+		testcommon.ResourceNamerModeRandom,
+	)
 
 	// set global context var
 	newGlobalTestContext, err := testcommon.NewKubeContext(
 		false,
 		false,
 		testcommon.DefaultTestRegion,
-		nameConfig)
+		nameConfig,
+	)
 	if err != nil {
 		return err
 	}

--- a/v2/test/postgresql_test.go
+++ b/v2/test/postgresql_test.go
@@ -56,7 +56,8 @@ func Test_PostgreSQL_Combined(t *testing.T) {
 				postgresqlutil.DefaultMaintanenceDatabase,
 				postgresqlutil.PSqlServerPort,
 				adminUsername,
-				adminPassword)
+				adminPassword,
+			)
 			if err != nil {
 				return err
 			}
@@ -100,7 +101,8 @@ func PostgreSQL_AdminSecret_Rollover(tc *testcommon.KubePerTestContext, fqdn str
 		postgresqlutil.DefaultMaintanenceDatabase,
 		postgresqlutil.PSqlServerPort,
 		adminUsername,
-		adminPassword)
+		adminPassword,
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	// Close the connection
 	tc.Expect(conn.Close()).To(Succeed())
@@ -126,7 +128,8 @@ func PostgreSQL_AdminSecret_Rollover(tc *testcommon.KubePerTestContext, fqdn str
 				postgresqlutil.DefaultMaintanenceDatabase,
 				postgresqlutil.PSqlServerPort,
 				adminUsername,
-				newAdminPassword)
+				newAdminPassword,
+			)
 			if err != nil {
 				return err
 			}
@@ -148,7 +151,8 @@ func PostgreSQL_User_Helpers(tc *testcommon.KubePerTestContext, fqdn string, adm
 		postgresqlutil.DefaultMaintanenceDatabase,
 		postgresqlutil.PSqlServerPort,
 		adminUsername,
-		adminPassword)
+		adminPassword,
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	defer db.Close()
 
@@ -239,7 +243,8 @@ func PostgreSQL_User_CRUD(tc *testcommon.KubePerTestContext, server *postgresql.
 		postgresqlutil.DefaultMaintanenceDatabase,
 		postgresqlutil.PSqlServerPort,
 		to.Value(server.Spec.AdministratorLogin),
-		adminPassword)
+		adminPassword,
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	defer conn.Close()
 
@@ -271,7 +276,8 @@ func PostgreSQL_User_CRUD(tc *testcommon.KubePerTestContext, server *postgresql.
 		postgresqlutil.DefaultMaintanenceDatabase,
 		postgresqlutil.PSqlServerPort,
 		user.Spec.AzureName,
-		password)
+		password,
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	// Close the connection
 	tc.Expect(conn.Close()).To(Succeed())
@@ -295,7 +301,8 @@ func PostgreSQL_User_CRUD(tc *testcommon.KubePerTestContext, server *postgresql.
 				postgresqlutil.DefaultMaintanenceDatabase,
 				postgresqlutil.PSqlServerPort,
 				user.Spec.AzureName,
-				newPassword)
+				newPassword,
+			)
 			if err != nil {
 				return err
 			}

--- a/v2/test/pre-release/suite_test.go
+++ b/v2/test/pre-release/suite_test.go
@@ -46,14 +46,16 @@ func setup() error {
 		testcommon.LiveResourcePrefix,
 		"-",
 		6,
-		testcommon.ResourceNamerModeRandom)
+		testcommon.ResourceNamerModeRandom,
+	)
 
 	// set global context var
 	newGlobalTestContext, err := testcommon.NewKubeContext(
 		false,
 		false,
 		testcommon.DefaultTestRegion,
-		nameConfig)
+		nameConfig,
+	)
 	if err != nil {
 		return err
 	}

--- a/v2/test/reconcile_policy_test.go
+++ b/v2/test/reconcile_policy_test.go
@@ -47,7 +47,8 @@ func Test_ReconcilePolicy_SkipReconcile_DoesntCreateResourceInAzure(t *testing.T
 	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armID,
-		"2020-06-01")
+		"2020-06-01",
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
 
@@ -66,7 +67,8 @@ func Test_ReconcilePolicy_SkipReconcile_DoesntCreateResourceInAzure(t *testing.T
 	exists, _, err = tc.AzureClient.CheckExistenceWithGetByID(
 		tc.Ctx,
 		armID,
-		"2020-06-01")
+		"2020-06-01",
+	)
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeTrue())
 }

--- a/v2/test/suite_test.go
+++ b/v2/test/suite_test.go
@@ -46,14 +46,16 @@ func setup() error {
 		testcommon.LiveResourcePrefix,
 		"-",
 		6,
-		testcommon.ResourceNamerModeRandom)
+		testcommon.ResourceNamerModeRandom,
+	)
 
 	// set global context var
 	newGlobalTestContext, err := testcommon.NewKubeContext(
 		false,
 		false,
 		testcommon.DefaultTestRegion,
-		nameConfig)
+		nameConfig,
+	)
 	if err != nil {
 		return err
 	}

--- a/v2/tools/collect-metrics/main.go
+++ b/v2/tools/collect-metrics/main.go
@@ -79,7 +79,8 @@ func main() {
 			Namespace: *namespace,
 			PodPrefix: *podPrefix,
 			Interval:  *interval,
-		})
+		},
+	)
 	if err != nil {
 		log.Error(err, "Failed to create metrics collector")
 		os.Exit(1)

--- a/v2/tools/generator/gen_kustomize.go
+++ b/v2/tools/generator/gen_kustomize.go
@@ -41,7 +41,8 @@ func NewGenKustomizeCommand() (*cobra.Command, error) {
 
 			log.Info(
 				"Scanning for resources",
-				"basePath", basesPath)
+				"basePath", basesPath,
+			)
 
 			files, err := os.ReadDir(basesPath)
 			if err != nil {
@@ -65,7 +66,8 @@ func NewGenKustomizeCommand() (*cobra.Command, error) {
 
 				log.V(1).Info(
 					"Found resource file",
-					"file", f.Name())
+					"file", f.Name(),
+				)
 
 				patchFile := "webhook-conversion-" + f.Name()
 				var def *kustomization.ResourceDefinition
@@ -77,7 +79,8 @@ func NewGenKustomizeCommand() (*cobra.Command, error) {
 
 				log.V(1).Info(
 					"Loaded Resource",
-					"name", def.Name())
+					"name", def.Name(),
+				)
 
 				patch := kustomization.NewConversionPatchFile(def.Name())
 				err = patch.Save(filepath.Join(patchesPath, patchFile))
@@ -94,7 +97,8 @@ func NewGenKustomizeCommand() (*cobra.Command, error) {
 				err = kerrors.NewAggregate(errs)
 				log.Error(
 					err,
-					"Error creating conversion patches")
+					"Error creating conversion patches",
+				)
 				return err
 			}
 
@@ -102,7 +106,8 @@ func NewGenKustomizeCommand() (*cobra.Command, error) {
 				err = eris.Errorf("no files found in %q", basesPath)
 				log.Error(
 					err,
-					"No CRD files found")
+					"No CRD files found",
+				)
 				return err
 			}
 
@@ -111,7 +116,8 @@ func NewGenKustomizeCommand() (*cobra.Command, error) {
 				log.Error(
 					err,
 					"Error generating",
-					"destination", destination)
+					"destination", destination,
+				)
 				return err
 			}
 

--- a/v2/tools/generator/gen_types.go
+++ b/v2/tools/generator/gen_types.go
@@ -49,13 +49,15 @@ func NewGenTypesCommand() (*cobra.Command, error) {
 
 				log.Info(
 					"Debug output will be written",
-					"folder", tmpDir)
+					"folder", tmpDir,
+				)
 				cg.UseDebugMode(*debugMode, tmpDir)
 				defer func() {
 					// Write the debug folder again so the user doesn't have to scroll back
 					log.Info(
 						"Debug output available",
-						"folder", tmpDir)
+						"folder", tmpDir,
+					)
 				}()
 			}
 
@@ -73,7 +75,8 @@ func NewGenTypesCommand() (*cobra.Command, error) {
 		"debug",
 		"d",
 		"",
-		"Write debug logs to a temp folder for a group (e.g. compute), multiple groups (e.g. compute;network), or groups matching a wildcard (e.g. net*)")
+		"Write debug logs to a temp folder for a group (e.g. compute), multiple groups (e.g. compute;network), or groups matching a wildcard (e.g. net*)",
+	)
 
 	return cmd, nil
 }

--- a/v2/tools/generator/internal/armconversion/arm_conversion_function.go
+++ b/v2/tools/generator/internal/armconversion/arm_conversion_function.go
@@ -55,7 +55,8 @@ func (c *ARMConversionFunction) RequiredPackageReferences() *astmodel.PackageRef
 		c.armTypeName.PackageReference(),
 		astmodel.GenRuntimeReference,
 		astmodel.ErisReference,
-		astmodel.FmtReference)
+		astmodel.FmtReference,
+	)
 	result.Merge(c.armType.RequiredPackageReferences())
 	return result
 }
@@ -78,12 +79,14 @@ func (c *ConvertToARMFunction) AsFunc(
 		&c.ARMConversionFunction,
 		codeGenerationContext,
 		receiver,
-		c.Name())
+		c.Name(),
+	)
 	if err != nil {
 		return nil, eris.Wrapf(
 			err,
 			"error creating ConvertToARM function for %s",
-			receiver.Name())
+			receiver.Name(),
+		)
 	}
 
 	decl, err := builder.functionDeclaration()
@@ -91,7 +94,8 @@ func (c *ConvertToARMFunction) AsFunc(
 		return nil, eris.Wrapf(
 			err,
 			"error generating ConvertToARM function for %s",
-			c.Name())
+			c.Name(),
+		)
 	}
 
 	return decl, nil
@@ -105,12 +109,14 @@ func (c *PopulateFromARMFunction) AsFunc(
 		&c.ARMConversionFunction,
 		codeGenerationContext,
 		receiver,
-		c.Name())
+		c.Name(),
+	)
 	if err != nil {
 		return nil, eris.Wrapf(
 			err,
 			"error creating ConvertFromARM function for %s",
-			receiver.Name())
+			receiver.Name(),
+		)
 	}
 
 	decl, err := builder.functionDeclaration()
@@ -118,7 +124,8 @@ func (c *PopulateFromARMFunction) AsFunc(
 		return nil, eris.Wrapf(
 			err,
 			"error generating ConvertFromARM function for %s",
-			c.Name())
+			c.Name(),
+		)
 	}
 
 	return decl, nil

--- a/v2/tools/generator/internal/armconversion/arm_spec_interface.go
+++ b/v2/tools/generator/internal/armconversion/arm_spec_interface.go
@@ -42,7 +42,8 @@ func NewARMSpecInterfaceImpl(
 		"Get"+astmodel.NameProperty,
 		idFactory,
 		getNameFunction,
-		astmodel.GenRuntimeReference)
+		astmodel.GenRuntimeReference,
+	)
 
 	getTypeFunc := functions.NewGetTypeFunction(resource.ARMType(), idFactory, functions.ReceiverTypePtr)
 
@@ -52,7 +53,8 @@ func NewARMSpecInterfaceImpl(
 		astmodel.ARMResourceSpecType,
 		getNameFunc,
 		getTypeFunc,
-		getAPIVersionFunc)
+		getAPIVersionFunc,
+	)
 
 	return result, nil
 }
@@ -69,7 +71,8 @@ func getNameFunction(
 		receiver,
 		methodName,
 		"Name",
-		false)
+		false,
+	)
 }
 
 func armSpecInterfaceSimpleGetFunction(

--- a/v2/tools/generator/internal/armconversion/convert_from_arm_function_builder.go
+++ b/v2/tools/generator/internal/armconversion/convert_from_arm_function_builder.go
@@ -110,7 +110,8 @@ func (builder *convertFromARMBuilder) functionDeclaration() (*dst.FuncDecl, erro
 
 	fn.AddParameter(
 		builder.idFactory.CreateIdentifier(astmodel.OwnerProperty, astmodel.NotExported),
-		ownerReferenceExpr)
+		ownerReferenceExpr,
+	)
 
 	fn.AddParameter(builder.inputIdent, dst.NewIdent("interface{}"))
 	fn.AddReturns("error")
@@ -124,7 +125,8 @@ func (builder *convertFromARMBuilder) functionBodyStatements() ([]dst.Stmt, erro
 	conversionStmts, err := generateTypeConversionAssignments(
 		builder.sourceType,
 		builder.destinationType,
-		builder.propertyConversionHandler(promotions))
+		builder.propertyConversionHandler(promotions),
+	)
 	if err != nil {
 		return nil, eris.Wrapf(err, "unable to generate conversion statements for %s", builder.methodName)
 	}
@@ -140,7 +142,8 @@ func (builder *convertFromARMBuilder) functionBodyStatements() ([]dst.Stmt, erro
 	return astbuilder.Statements(
 		assertStmts,
 		conversionStmts,
-		astbuilder.ReturnNoError()), nil
+		astbuilder.ReturnNoError(),
+	), nil
 }
 
 func (builder *convertFromARMBuilder) propertyConversionHandler(
@@ -176,11 +179,14 @@ func (builder *convertFromARMBuilder) propertyConversionHandler(
 					assign := astbuilder.SimpleAssignment(
 						astbuilder.Selector(
 							dst.NewIdent(builder.receiverIdent),
-							promotion.crdProperty),
+							promotion.crdProperty,
+						),
 						astbuilder.Selector(
 							dst.NewIdent(builder.typedInputIdent),
 							string(toProp.PropertyName()),
-							promotion.armProperty))
+							promotion.armProperty,
+						),
+					)
 					promotionStmts = append(promotionStmts, assign)
 				}
 
@@ -212,7 +218,8 @@ func (builder *convertFromARMBuilder) assertInputTypeIsARM(needsResult bool) []d
 	typeAssert := astbuilder.TypeAssert(
 		dst.NewIdent(dest),
 		dst.NewIdent(builder.inputIdent),
-		builder.sourceTypeIdent())
+		builder.sourceTypeIdent(),
+	)
 
 	// Check the result of the type assert
 	// if !ok {
@@ -224,7 +231,9 @@ func (builder *convertFromARMBuilder) assertInputTypeIsARM(needsResult bool) []d
 			fmt.Sprintf("unexpected type supplied for %s() function. Expected %s, got %%T",
 				builder.methodName,
 				builder.sourceTypeString()),
-			dst.NewIdent(builder.inputIdent)))
+			dst.NewIdent(builder.inputIdent),
+		),
+	)
 
 	return astbuilder.Statements(typeAssert, returnIfNotOk)
 }
@@ -254,7 +263,9 @@ func (builder *convertFromARMBuilder) namePropertyHandler(
 		astbuilder.CallQualifiedFunc(
 			astmodel.GenRuntimeReference.PackageName(),
 			"ExtractKubernetesResourceNameFromARMName",
-			astbuilder.Selector(dst.NewIdent(builder.typedInputIdent), string(fromProp.PropertyName()))))
+			astbuilder.Selector(dst.NewIdent(builder.typedInputIdent), string(fromProp.PropertyName())),
+		),
+	)
 
 	return handleWith(setAzureName), nil
 }
@@ -339,7 +350,8 @@ func (builder *convertFromARMBuilder) ownerPropertyHandler(
 			eris.Errorf(
 				"owner property was not of type TypeName. Kube: %s, ARM: %s",
 				kubeDescription.String(),
-				armDescription.String())
+				armDescription.String(),
+			)
 
 	}
 
@@ -362,14 +374,16 @@ func (builder *convertFromARMBuilder) ownerPropertyHandler(
 		return notHandled,
 			eris.Errorf(
 				"found Owner property on spec with unexpected TypeName %s",
-				ownerNameType.String())
+				ownerNameType.String(),
+			)
 	}
 
 	setOwner := astbuilder.QualifiedAssignment(
 		dst.NewIdent(builder.receiverIdent),
 		string(toProp.PropertyName()),
 		token.ASSIGN,
-		convertedOwner)
+		convertedOwner,
+	)
 
 	return handleWith(setOwner), nil
 }
@@ -440,7 +454,8 @@ func (builder *convertFromARMBuilder) flattenedPropertyHandler(
 		eris.Errorf(
 			"couldn’t find source ARM property %q that k8s property %q was flattened from",
 			toProp.FlattenedFrom()[0],
-			toProp.PropertyName())
+			toProp.PropertyName(),
+		)
 }
 
 func (builder *convertFromARMBuilder) buildFlattenedAssignment(
@@ -460,7 +475,8 @@ func (builder *convertFromARMBuilder) buildFlattenedAssignment(
 				"need to implement multiple levels of flattening: property %q on %s was flattened from %q",
 				toProp.PropertyName(),
 				builder.receiverIdent,
-				strings.Join(props, "."))
+				strings.Join(props, "."),
+			)
 
 	}
 
@@ -479,7 +495,8 @@ func (builder *convertFromARMBuilder) buildFlattenedAssignment(
 			eris.Wrapf(
 				err,
 				"failed to resolve type for property %s",
-				fromProp.PropertyName())
+				fromProp.PropertyName(),
+			)
 	}
 
 	var fromPropObjType *astmodel.ObjectType
@@ -496,7 +513,8 @@ func (builder *convertFromARMBuilder) buildFlattenedAssignment(
 				eris.Wrapf(
 					err,
 					"failed to resolve type for property %s",
-					fromProp.PropertyName())
+					fromProp.PropertyName(),
+				)
 		}
 
 		// (4.) resolve the inner object type
@@ -512,7 +530,8 @@ func (builder *convertFromARMBuilder) buildFlattenedAssignment(
 			eris.Errorf(
 				"property %q marked as flattened from non-object type %T, which shouldn’t be possible",
 				toProp.PropertyName(),
-				fromPropType)
+				fromPropType,
+			)
 	}
 
 	// *** Now generate the code! ***
@@ -524,7 +543,8 @@ func (builder *convertFromARMBuilder) buildFlattenedAssignment(
 			eris.Errorf(
 				"couldn't find source of flattened property %q on %s",
 				toProp.PropertyName(),
-				builder.receiverIdent)
+				builder.receiverIdent,
+			)
 	}
 
 	// need to make a clone of builder.locals if we are going to nest in an if statement
@@ -545,13 +565,15 @@ func (builder *convertFromARMBuilder) buildFlattenedAssignment(
 			Locals:              locals,
 			SourceProperty:      fromProp,
 			DestinationProperty: toProp,
-		})
+		},
+	)
 	if err != nil {
 		return notHandled,
 			eris.Wrapf(
 				err,
 				"failed to generate conversion for flattened property %s",
-				toProp.PropertyName())
+				toProp.PropertyName(),
+			)
 	}
 
 	// we were unable to generate an inner conversion, so we cannot generate the overall conversion
@@ -562,12 +584,14 @@ func (builder *convertFromARMBuilder) buildFlattenedAssignment(
 	if generateNilCheck {
 		propToCheck := astbuilder.Selector(dst.NewIdent(builder.typedInputIdent), string(fromProp.PropertyName()))
 		stmts = astbuilder.Statements(
-			astbuilder.IfNotNil(propToCheck, stmts...))
+			astbuilder.IfNotNil(propToCheck, stmts...),
+		)
 	}
 
 	astbuilder.AddComment(
 		&stmts[0].Decorations().Start,
-		"// copying flattened property:")
+		"// copying flattened property:",
+	)
 
 	return handleWith(stmts), nil
 }
@@ -601,13 +625,15 @@ func (builder *convertFromARMBuilder) propertiesByNameHandler(
 			Locals:              builder.locals,
 			SourceProperty:      fromProp,
 			DestinationProperty: toProp,
-		})
+		},
+	)
 	if err != nil {
 		return notHandled,
 			eris.Wrapf(
 				err,
 				"failed to generate conversion for property %s",
-				toProp.PropertyName())
+				toProp.PropertyName(),
+			)
 	}
 
 	return handleWith(conversion), nil
@@ -655,7 +681,8 @@ func (builder *convertFromARMBuilder) convertComplexTypeNameProperty(
 		newVariable = astbuilder.NewVariableQualified(
 			propertyLocalVar,
 			packageName,
-			destinationType.Name())
+			destinationType.Name(),
+		)
 	}
 
 	tok := token.ASSIGN
@@ -672,18 +699,24 @@ func (builder *convertFromARMBuilder) convertComplexTypeNameProperty(
 			dst.NewIdent("err"),
 			tok,
 			astbuilder.CallQualifiedFunc(
-				propertyLocalVar, builder.methodName, dst.NewIdent(ownerName), params.GetSource())))
+				propertyLocalVar, builder.methodName, dst.NewIdent(ownerName), params.GetSource(),
+			),
+		),
+	)
 	results = append(results, astbuilder.CheckErrorAndReturn())
 	if params.AssignmentHandler == nil {
 		results = append(
 			results,
 			astbuilder.SimpleAssignment(
 				params.GetDestination(),
-				dst.NewIdent(propertyLocalVar)))
+				dst.NewIdent(propertyLocalVar),
+			),
+		)
 	} else {
 		results = append(
 			results,
-			params.AssignmentHandler(params.GetDestination(), dst.NewIdent(propertyLocalVar)))
+			params.AssignmentHandler(params.GetDestination(), dst.NewIdent(propertyLocalVar)),
+		)
 	}
 
 	return results, nil

--- a/v2/tools/generator/internal/armconversion/convert_to_arm_function_builder.go
+++ b/v2/tools/generator/internal/armconversion/convert_to_arm_function_builder.go
@@ -71,7 +71,8 @@ func newConvertToARMFunctionBuilder(
 		result.convertSecretProperty,
 		result.convertSecretMapProperty,
 		result.convertConfigMapProperty,
-		result.convertComplexTypeNameProperty)
+		result.convertComplexTypeNameProperty,
+	)
 
 	result.propertyConversionHandlers = []propertyConversionHandler{
 		// Handlers for specific properties come first
@@ -121,7 +122,8 @@ func (builder *convertToARMBuilder) functionBodyStatements() ([]dst.Stmt, error)
 
 	decl := astbuilder.ShortDeclaration(
 		builder.resultIdent,
-		astbuilder.AddrOf(astbuilder.NewCompositeLiteralBuilder(builder.destinationTypeIdent()).Build()))
+		astbuilder.AddrOf(astbuilder.NewCompositeLiteralBuilder(builder.destinationTypeIdent()).Build()),
+	)
 
 	// Find all (any!) properties where their values need to be demoted into the nested ARM type.
 	// The set of demotions is the same as the set of promotions (as ConvertToARM and
@@ -132,20 +134,23 @@ func (builder *convertToARMBuilder) functionBodyStatements() ([]dst.Stmt, error)
 	conversions, err := generateTypeConversionAssignments(
 		builder.sourceType,
 		builder.destinationType,
-		builder.propertyConversionHandler(demotions))
+		builder.propertyConversionHandler(demotions),
+	)
 	if err != nil {
 		return nil, eris.Wrapf(err, "unable to generate property conversions for %s", builder.methodName)
 	}
 
 	returnStatement := astbuilder.Returns(
 		dst.NewIdent(builder.resultIdent),
-		astbuilder.Nil())
+		astbuilder.Nil(),
+	)
 
 	return astbuilder.Statements(
 		returnIfNil,
 		decl,
 		conversions,
-		returnStatement), nil
+		returnStatement,
+	), nil
 }
 
 func (builder *convertToARMBuilder) propertyConversionHandler(
@@ -182,10 +187,13 @@ func (builder *convertToARMBuilder) propertyConversionHandler(
 						astbuilder.Selector(
 							dst.NewIdent(builder.resultIdent),
 							string(toProp.PropertyName()),
-							demotion.armProperty),
+							demotion.armProperty,
+						),
 						astbuilder.Selector(
 							dst.NewIdent(builder.receiverIdent),
-							demotion.crdProperty))
+							demotion.crdProperty,
+						),
+					)
 					demotionStmts = append(demotionStmts, assign)
 				}
 
@@ -222,7 +230,8 @@ func (builder *convertToARMBuilder) namePropertyHandler(
 		dst.NewIdent(builder.resultIdent),
 		string(toProp.PropertyName()),
 		token.ASSIGN,
-		astbuilder.Selector(dst.NewIdent(resolvedParameterString), "Name"))
+		astbuilder.Selector(dst.NewIdent(resolvedParameterString), "Name"),
+	)
 
 	return handleWith(result), nil
 }
@@ -627,7 +636,8 @@ func (builder *convertToARMBuilder) flattenedPropertyHandler(
 				eris.Errorf(
 					"unable to find expected property %s inside property %s",
 					fromProp.PropertyName(),
-					toPropName)
+					toPropName,
+				)
 		}
 
 		// generate conversion
@@ -644,7 +654,8 @@ func (builder *convertToARMBuilder) flattenedPropertyHandler(
 				Locals:              builder.locals,
 				SourceProperty:      fromProp,
 				DestinationProperty: toProp,
-			})
+			},
+		)
 		if err != nil {
 			return notHandled,
 				eris.Wrapf(err,
@@ -712,7 +723,9 @@ func (builder *convertToARMBuilder) buildToPropInitializer(
 				dst.NewIdent(builder.resultIdent),
 				string(toPropName),
 				token.ASSIGN,
-				astbuilder.AddrOf(literal.Build()))),
+				astbuilder.AddrOf(literal.Build()),
+			),
+		),
 	}, nil
 }
 
@@ -835,7 +848,8 @@ func (builder *convertToARMBuilder) convertUserAssignedIdentitiesCollection(
 		params.Destination,
 		token.ASSIGN,
 		astbuilder.MakeMapWithCapacity(keyTypeExpr, valueTypeExpr,
-			astbuilder.CallFunc("len", params.Source)))
+			astbuilder.CallFunc("len", params.Source)),
+	)
 
 	key := "key"
 
@@ -854,7 +868,8 @@ func (builder *convertToARMBuilder) convertUserAssignedIdentitiesCollection(
 			Locals:              locals,
 			SourceProperty:      params.SourceProperty,
 			DestinationProperty: params.DestinationProperty,
-		})
+		},
+	)
 	if err != nil {
 		return nil,
 			eris.Wrapf(err,
@@ -866,13 +881,15 @@ func (builder *convertToARMBuilder) convertUserAssignedIdentitiesCollection(
 
 	conversion = append(
 		conversion,
-		astbuilder.InsertMap(params.Destination, dst.NewIdent(key), valueBuilder.Build()))
+		astbuilder.InsertMap(params.Destination, dst.NewIdent(key), valueBuilder.Build()),
+	)
 
 	// Loop over the slice
 	loop := astbuilder.IterateOverSlice(
 		itemIdent,
 		params.Source,
-		conversion...)
+		conversion...,
+	)
 
 	return astbuilder.Statements(makeMapStatement, loop), nil
 }
@@ -907,7 +924,9 @@ func (builder *convertToARMBuilder) convertReferenceProperty(
 		astbuilder.CallExpr(
 			astbuilder.Selector(dst.NewIdent(resolvedParameterString), "ResolvedReferences"),
 			"Lookup",
-			params.Source))
+			params.Source,
+		),
+	)
 
 	returnIfNotNil := astbuilder.ReturnIfNotNil(dst.NewIdent("err"), astbuilder.Nil(), dst.NewIdent("err"))
 
@@ -958,7 +977,9 @@ func (builder *convertToARMBuilder) convertWellknownReferenceProperty(
 	assignWellKnownName := astbuilder.Statements(
 		astbuilder.SimpleAssignment(
 			dst.NewIdent(id),
-			wellKnownName))
+			wellKnownName,
+		),
+	)
 
 	// Lookup ARM ID by reference
 	armIDLookup := astbuilder.SimpleAssignmentWithErr(
@@ -967,14 +988,17 @@ func (builder *convertToARMBuilder) convertWellknownReferenceProperty(
 		astbuilder.CallExpr(
 			astbuilder.Selector(dst.NewIdent(resolvedParameterString), "ResolvedReferences"),
 			"Lookup",
-			astbuilder.Selector(params.Source, "ResourceReference")))
+			astbuilder.Selector(params.Source, "ResourceReference"),
+		),
+	)
 
 	returnIfNotNil := astbuilder.ReturnIfNotNil(dst.NewIdent("err"), astbuilder.Nil(), dst.NewIdent("err"))
 	returnIfNotNil.Decorations().After = dst.EmptyLine
 
 	assignArmID := astbuilder.SimpleAssignment(
 		dst.NewIdent(id),
-		dst.NewIdent("armID"))
+		dst.NewIdent("armID"),
+	)
 
 	lookupArmID := astbuilder.Statements(armIDLookup, returnIfNotNil, assignArmID)
 
@@ -1024,12 +1048,15 @@ func (builder *convertToARMBuilder) convertSecretProperty(
 		astbuilder.CallExpr(
 			astbuilder.Selector(dst.NewIdent(resolvedParameterString), "ResolvedSecrets"),
 			"Lookup",
-			params.Source))
+			params.Source,
+		),
+	)
 
 	wrappedError := astbuilder.WrapError(
 		errorsPackage,
 		"err",
-		fmt.Sprintf("looking up secret for property %s", params.NameHint))
+		fmt.Sprintf("looking up secret for property %s", params.NameHint),
+	)
 	returnIfNotNil := astbuilder.ReturnIfNotNil(dst.NewIdent("err"), astbuilder.Nil(), wrappedError)
 
 	result := params.AssignmentHandlerOrDefault()(params.Destination, dst.NewIdent(localVarName))
@@ -1068,12 +1095,15 @@ func (builder *convertToARMBuilder) convertSecretMapProperty(
 		astbuilder.CallExpr(
 			astbuilder.Selector(dst.NewIdent(resolvedParameterString), "ResolvedSecretMaps"),
 			"Lookup",
-			params.Source))
+			params.Source,
+		),
+	)
 
 	wrappedError := astbuilder.WrapError(
 		errorsPackage,
 		"err",
-		fmt.Sprintf("looking up secret for property %s", params.NameHint))
+		fmt.Sprintf("looking up secret for property %s", params.NameHint),
+	)
 	returnIfNotNil := astbuilder.ReturnIfNotNil(dst.NewIdent("err"), astbuilder.Nil(), wrappedError)
 
 	result := params.AssignmentHandlerOrDefault()(params.Destination, dst.NewIdent(localVarName))
@@ -1112,12 +1142,15 @@ func (builder *convertToARMBuilder) convertConfigMapProperty(
 		astbuilder.CallExpr(
 			astbuilder.Selector(dst.NewIdent(resolvedParameterString), "ResolvedConfigMaps"),
 			"Lookup",
-			params.Source))
+			params.Source,
+		),
+	)
 
 	wrappedError := astbuilder.WrapError(
 		errorsPackage,
 		"err",
-		fmt.Sprintf("looking up configmap for property %s", params.NameHint))
+		fmt.Sprintf("looking up configmap for property %s", params.NameHint),
+	)
 	returnIfNotNil := astbuilder.ReturnIfNotNil(dst.NewIdent("err"), astbuilder.Nil(), wrappedError)
 
 	result := params.AssignmentHandlerOrDefault()(params.Destination, dst.NewIdent(localVarName))
@@ -1196,9 +1229,11 @@ func callToARMFunction(source dst.Expr, destination dst.Expr, methodName string)
 			Args: []dst.Expr{
 				dst.NewIdent(resolvedParameterString),
 			},
-		})
+		},
+	)
 
 	return astbuilder.Statements(
 		propertyToARMInvocation,
-		astbuilder.CheckErrorAndReturn(astbuilder.Nil()))
+		astbuilder.CheckErrorAndReturn(astbuilder.Nil()),
+	)
 }

--- a/v2/tools/generator/internal/armconversion/shared.go
+++ b/v2/tools/generator/internal/armconversion/shared.go
@@ -119,7 +119,8 @@ func (builder conversionBuilder) propertyConversionHandler(
 		toProp.PropertyName(),
 		builder.methodName,
 		kubeDescription.String(),
-		armDescription.String())
+		armDescription.String(),
+	)
 
 	if err != nil {
 		return nil, eris.Wrap(err, message)
@@ -167,7 +168,8 @@ func initializeAzureName(idFactory astmodel.IdentifierFactory) {
 	azureNameProperty = astmodel.NewPropertyDefinition(
 		idFactory.CreatePropertyName(astmodel.AzureNameProperty, astmodel.Exported),
 		idFactory.CreateStringIdentifier(astmodel.AzureNameProperty, astmodel.NotExported),
-		astmodel.StringType).WithDescription(azureNameFieldDescription)
+		astmodel.StringType,
+	).WithDescription(azureNameFieldDescription)
 }
 
 // GetAzureNameProperty returns the special "AzureName" field
@@ -271,13 +273,15 @@ func NewARMConversionImplementation(
 			astmodel.MakeExternalTypeName(astmodel.GenRuntimeReference, "ARMTransformer"),
 			newEmptyARMValueFunc,
 			convertToARMFunc,
-			populateFromARMFunc)
+			populateFromARMFunc,
+		)
 	} else {
 		// can only convert in one direction with the FromARMConverter interface
 		return astmodel.NewInterfaceImplementation(
 			astmodel.MakeExternalTypeName(astmodel.GenRuntimeReference, "FromARMConverter"),
 			newEmptyARMValueFunc,
-			populateFromARMFunc)
+			populateFromARMFunc,
+		)
 	}
 }
 

--- a/v2/tools/generator/internal/astbuilder/builder.go
+++ b/v2/tools/generator/internal/astbuilder/builder.go
@@ -74,7 +74,8 @@ func WrapError(errorsPackage string, err string, message string, args ...dst.Exp
 	return CallQualifiedFunc(
 		errorsPackage,
 		funcName,
-		Expressions(dst.NewIdent(err), StringLiteral(message), args)...)
+		Expressions(dst.NewIdent(err), StringLiteral(message), args)...,
+	)
 }
 
 // NewVariableQualified creates a new declaration statement where a variable is declared
@@ -208,7 +209,8 @@ func ReturnIfNotOk(returns ...dst.Expr) *dst.IfStmt {
 			Op: token.NOT,
 			X:  dst.NewIdent("ok"),
 		},
-		returns...)
+		returns...,
+	)
 }
 
 // ReturnIfNil checks if a variable is nil and if it is returns
@@ -219,7 +221,8 @@ func ReturnIfNotOk(returns ...dst.Expr) *dst.IfStmt {
 func ReturnIfNil(toCheck dst.Expr, returns ...dst.Expr) dst.Stmt {
 	return ReturnIfExpr(
 		AreEqual(toCheck, Nil()),
-		returns...)
+		returns...,
+	)
 }
 
 // ReturnIfNotNil checks if a variable is not nil and if it is returns
@@ -230,7 +233,8 @@ func ReturnIfNil(toCheck dst.Expr, returns ...dst.Expr) dst.Stmt {
 func ReturnIfNotNil(toCheck dst.Expr, returns ...dst.Expr) dst.Stmt {
 	return ReturnIfExpr(
 		AreNotEqual(toCheck, Nil()),
-		returns...)
+		returns...,
+	)
 }
 
 // ReturnIfExpr returns if the expression evaluates as true
@@ -262,7 +266,8 @@ func FormatError(fmtPackage string, formatString string, args ...dst.Expr) dst.E
 	callArgs := make([]dst.Expr, 0, 1+len(args))
 	callArgs = append(
 		callArgs,
-		StringLiteral(formatString))
+		StringLiteral(formatString),
+	)
 	callArgs = append(callArgs, args...)
 	return CallQualifiedFunc(fmtPackage, "Errorf", callArgs...)
 }
@@ -347,7 +352,8 @@ func WrappedErrorf(errorsPackage string, template string, args ...interface{}) d
 		errorsPackage,
 		"Wrap",
 		dst.NewIdent("err"),
-		StringLiteralf(template, args...))
+		StringLiteralf(template, args...),
+	)
 }
 
 // WrappedError returns the err local, wrapped with additional information
@@ -360,7 +366,8 @@ func WrappedError(errorsPackage string, str string) dst.Expr {
 		errorsPackage,
 		"Wrap",
 		dst.NewIdent("err"),
-		StringLiteral(str))
+		StringLiteral(str),
+	)
 }
 
 // QualifiedTypeName generates a reference to a type within an imported package
@@ -401,7 +408,8 @@ func Selector(expr dst.Expr, names ...string) *dst.SelectorExpr {
 			return &dst.SelectorExpr{X: l, Sel: r.(*dst.Ident)}
 		},
 		dst.None,
-		exprs...).(*dst.SelectorExpr)
+		exprs...,
+	).(*dst.SelectorExpr)
 }
 
 // AreEqual generates a == comparison between the two expressions
@@ -533,7 +541,8 @@ func JoinBinaryOp(op token.Token, spaceType dst.SpaceType, exprs ...dst.Expr) ds
 			return &dst.BinaryExpr{X: x, Op: op, Y: y}
 		},
 		spaceType,
-		exprs...)
+		exprs...,
+	)
 }
 
 // Reduce combines a sequence of expressions using the provided function.

--- a/v2/tools/generator/internal/astbuilder/calls.go
+++ b/v2/tools/generator/internal/astbuilder/calls.go
@@ -28,7 +28,8 @@ func CallQualifiedFunc(qualifier string, funcName string, arguments ...dst.Expr)
 			X:   dst.NewIdent(qualifier),
 			Sel: dst.NewIdent(funcName),
 		},
-		arguments...)
+		arguments...,
+	)
 }
 
 // CallExpr creates an expression to call the named function with the specified arguments
@@ -51,7 +52,8 @@ func CallExpr(expr dst.Expr, funcName string, arguments ...dst.Expr) *dst.CallEx
 			X:   receiver,
 			Sel: dst.NewIdent(funcName),
 		},
-		arguments...)
+		arguments...,
+	)
 }
 
 func createCallExpr(expr dst.Expr, arguments ...dst.Expr) *dst.CallExpr {

--- a/v2/tools/generator/internal/astbuilder/func_details.go
+++ b/v2/tools/generator/internal/astbuilder/func_details.go
@@ -67,7 +67,8 @@ func (fn *FuncDetails) defineFunc(noBody bool) *dst.FuncDecl {
 		reason := fmt.Sprintf(
 			"ReceiverIdent and ReceiverType must both be specified, or both omitted. ReceiverIdent: %q, ReceiverType: %q",
 			fn.ReceiverIdent,
-			fn.ReceiverType)
+			fn.ReceiverType,
+		)
 		panic(reason)
 	}
 

--- a/v2/tools/generator/internal/astbuilder/maps.go
+++ b/v2/tools/generator/internal/astbuilder/maps.go
@@ -51,7 +51,8 @@ func InsertMap(mapExpr dst.Expr, key dst.Expr, rhs dst.Expr) *dst.AssignStmt {
 			X:     dst.Clone(mapExpr).(dst.Expr),
 			Index: dst.Clone(key).(dst.Expr),
 		},
-		dst.Clone(rhs).(dst.Expr))
+		dst.Clone(rhs).(dst.Expr),
+	)
 }
 
 // IterateOverMapWithValue creates a statement to iterate over the content of a map using the

--- a/v2/tools/generator/internal/astbuilder/maps_test.go
+++ b/v2/tools/generator/internal/astbuilder/maps_test.go
@@ -37,6 +37,7 @@ func TestGolden_MakeMap_GivenKeyAndValueTypes_GeneratesExpectedCode(t *testing.T
 
 				call := MakeMap(key, val)
 				assertExprExpected(t, call)
-			})
+			},
+		)
 	}
 }

--- a/v2/tools/generator/internal/astbuilder/slices.go
+++ b/v2/tools/generator/internal/astbuilder/slices.go
@@ -18,7 +18,8 @@ func MakeSlice(listType dst.Expr, capacity dst.Expr) *dst.CallExpr {
 	return CallFunc(
 		"make",
 		listType,
-		capacity)
+		capacity,
+	)
 }
 
 // MakeEmptySlice returns the call expression for making a slice with a specified length that can be
@@ -30,7 +31,8 @@ func MakeEmptySlice(listType dst.Expr, capacity dst.Expr) *dst.CallExpr {
 		"make",
 		listType,
 		IntLiteral(0),
-		capacity)
+		capacity,
+	)
 }
 
 // AppendItemToSlice returns a statement to append a single item to a slice
@@ -39,7 +41,8 @@ func MakeEmptySlice(listType dst.Expr, capacity dst.Expr) *dst.CallExpr {
 func AppendItemToSlice(lhs dst.Expr, rhs dst.Expr) dst.Stmt {
 	return SimpleAssignment(
 		dst.Clone(lhs).(dst.Expr),
-		CallFunc("append", dst.Clone(lhs).(dst.Expr), dst.Clone(rhs).(dst.Expr)))
+		CallFunc("append", dst.Clone(lhs).(dst.Expr), dst.Clone(rhs).(dst.Expr)),
+	)
 }
 
 // AppendItemsToSlice returns a statement to append many individual items to a slice
@@ -54,7 +57,8 @@ func AppendItemsToSlice(lhs dst.Expr, rhs ...dst.Expr) dst.Stmt {
 
 	return SimpleAssignment(
 		dst.Clone(lhs).(dst.Expr),
-		CallFunc("append", args...))
+		CallFunc("append", args...),
+	)
 }
 
 // AppendSliceToSlice returns a statement to append a slice to another slice
@@ -65,7 +69,8 @@ func AppendSliceToSlice(lhs dst.Expr, rhs dst.Expr) dst.Stmt {
 	f.Ellipsis = true
 	return SimpleAssignment(
 		dst.Clone(lhs).(dst.Expr),
-		f)
+		f,
+	)
 }
 
 // IterateOverSlice creates a statement to iterate over the content of a list using the specified

--- a/v2/tools/generator/internal/astmodel/conversion_function_builder.go
+++ b/v2/tools/generator/internal/astmodel/conversion_function_builder.go
@@ -204,7 +204,8 @@ func (builder *ConversionFunctionBuilder) BuildConversion(params ConversionParam
 	msg := fmt.Sprintf(
 		"don't know how to perform conversion for %s -> %s",
 		DebugDescription(params.SourceType),
-		DebugDescription(params.DestinationType))
+		DebugDescription(params.DestinationType),
+	)
 	panic(msg)
 }
 
@@ -244,7 +245,8 @@ func IdentityConvertComplexOptionalProperty(
 			Locals:              locals,
 			SourceProperty:      params.SourceProperty,
 			DestinationProperty: params.DestinationProperty,
-		})
+		},
+	)
 	if err != nil {
 		return nil, eris.Wrap(err, "unable to build conversion for optional element")
 	}
@@ -254,11 +256,14 @@ func IdentityConvertComplexOptionalProperty(
 		conversion,
 		astbuilder.SimpleAssignment(
 			params.GetDestination(),
-			astbuilder.AddrOf(dst.NewIdent(tempVarIdent))))
+			astbuilder.AddrOf(dst.NewIdent(tempVarIdent)),
+		),
+	)
 
 	result := astbuilder.IfNotNil(
 		params.GetSource(),
-		conversion...)
+		conversion...,
+	)
 
 	return astbuilder.Statements(result), nil
 }
@@ -308,7 +313,9 @@ func IdentityConvertComplexArrayProperty(
 			astbuilder.LocalVariableDeclaration(
 				innerDestinationIdent,
 				destinationTypeExpr,
-				""))
+				"",
+			),
+		)
 	}
 
 	conversion, err := builder.BuildConversion(
@@ -323,7 +330,8 @@ func IdentityConvertComplexArrayProperty(
 			Locals:              locals,
 			SourceProperty:      params.SourceProperty,
 			DestinationProperty: params.DestinationProperty,
-		})
+		},
+	)
 	if err != nil {
 		return nil, eris.Wrap(err, "unable to build conversion for array element")
 	}
@@ -356,12 +364,14 @@ func IdentityConvertComplexArrayProperty(
 		assignEmpty := astbuilder.SimpleAssignment(params.GetDestination(), emptySlice)
 		astbuilder.AddComment(
 			&assignEmpty.Decs.Start,
-			"// Set property to empty map, as this resource is set to serialize all collections explicitly")
+			"// Set property to empty map, as this resource is set to serialize all collections explicitly",
+		)
 		assignEmpty.Decs.Before = dst.NewLine
 
 		ifNil := astbuilder.IfNil(
 			params.GetDestination(),
-			assignEmpty)
+			assignEmpty,
+		)
 		results = append(results, ifNil)
 	}
 
@@ -396,7 +406,8 @@ func IdentityConvertComplexMapProperty(
 	if _, ok := destinationType.KeyType().(*PrimitiveType); !ok {
 		msg := fmt.Sprintf(
 			"map had non-primitive key type: %s",
-			DebugDescription(destinationType.KeyType()))
+			DebugDescription(destinationType.KeyType()),
+		)
 		panic(msg)
 	}
 
@@ -437,7 +448,8 @@ func IdentityConvertComplexMapProperty(
 		destination,
 		makeMapToken,
 		astbuilder.MakeMapWithCapacity(keyTypeExpr, valueTypeExpr,
-			astbuilder.CallFunc("len", params.GetSource())))
+			astbuilder.CallFunc("len", params.GetSource())),
+	)
 
 	conversion, err := builder.BuildConversion(
 		ConversionParameters{
@@ -451,7 +463,8 @@ func IdentityConvertComplexMapProperty(
 			Locals:              locals,
 			SourceProperty:      params.SourceProperty,
 			DestinationProperty: params.DestinationProperty,
-		})
+		},
+	)
 	if err != nil {
 		return nil, eris.Wrap(err, "unable to build conversion for map value")
 	}
@@ -473,7 +486,8 @@ func IdentityConvertComplexMapProperty(
 		assignEmpty := astbuilder.SimpleAssignment(params.GetDestination(), emptyMap)
 		astbuilder.AddComment(
 			&assignEmpty.Decs.Start,
-			"// Set property to empty map, as this resource is set to serialize all collections explicitly")
+			"// Set property to empty map, as this resource is set to serialize all collections explicitly",
+		)
 		assignEmpty.Decs.Before = dst.NewLine
 
 		result = astbuilder.SimpleIfElse(
@@ -490,7 +504,8 @@ func IdentityConvertComplexMapProperty(
 		result = astbuilder.IfNotNil(
 			params.GetSource(),
 			makeMapStatement,
-			rangeStatement)
+			rangeStatement,
+		)
 	}
 
 	// If we have an assignment handler, we need to make sure to call it. This only happens in the case of nested
@@ -531,7 +546,9 @@ func IdentityAssignTypeName(
 	return astbuilder.Statements(
 		params.AssignmentHandlerOrDefault()(
 			params.GetDestination(),
-			params.GetSource())), nil
+			params.GetSource(),
+		),
+	), nil
 }
 
 // IdentityAssignPrimitiveType just assigns source to destination directly, no conversion needed.
@@ -552,7 +569,9 @@ func IdentityAssignPrimitiveType(
 	return astbuilder.Statements(
 		params.AssignmentHandlerOrDefault()(
 			params.GetDestination(),
-			params.GetSource())), nil
+			params.GetSource(),
+		),
+	), nil
 }
 
 // AssignToOptional assigns address of source to destination.
@@ -575,7 +594,9 @@ func AssignToOptional(
 		return astbuilder.Statements(
 			params.AssignmentHandlerOrDefault()(
 				params.GetDestination(),
-				astbuilder.AddrOf(params.GetSource()))), nil
+				astbuilder.AddrOf(params.GetSource()),
+			),
+		), nil
 	}
 
 	// a more complex conversion is needed
@@ -594,7 +615,8 @@ func AssignToOptional(
 			Locals:              params.Locals,
 			SourceProperty:      params.SourceProperty,
 			DestinationProperty: params.DestinationProperty,
-		})
+		},
+	)
 	if err != nil {
 		return nil, eris.Wrap(err, "unable to build inner conversion to optional")
 	}
@@ -613,7 +635,9 @@ func AssignToOptional(
 		conversion,
 		params.AssignmentHandlerOrDefault()(
 			params.GetDestination(),
-			astbuilder.AddrOf(dst.NewIdent(tmpLocal)))), nil
+			astbuilder.AddrOf(dst.NewIdent(tmpLocal)),
+		),
+	), nil
 }
 
 // AssignFromOptional assigns address of source to destination.
@@ -640,9 +664,11 @@ func AssignFromOptional(
 
 	if TypeEquals(optSrc.Element(), params.DestinationType) {
 		return astbuilder.Statements(
-			astbuilder.IfNotNil(params.GetSource(),
+			astbuilder.IfNotNil(
+				params.GetSource(),
 				params.AssignmentHandlerOrDefault()(params.GetDestination(), astbuilder.Dereference(params.GetSource())),
-			)), nil
+			),
+		), nil
 	}
 
 	// a more complex conversion is needed
@@ -662,7 +688,8 @@ func AssignFromOptional(
 			Locals:              locals,
 			SourceProperty:      params.SourceProperty,
 			DestinationProperty: params.DestinationProperty,
-		})
+		},
+	)
 	if err != nil {
 		return nil, eris.Wrap(err, "unable to build inner conversion from optional")
 	}
@@ -684,7 +711,9 @@ func AssignFromOptional(
 	return astbuilder.Statements(
 		astbuilder.IfNotNil(
 			params.GetSource(),
-			result...)), nil
+			result...,
+		),
+	), nil
 }
 
 // AssignToAliasOfPrimitive assigns a primitive value to an alias of that same type.
@@ -735,7 +764,10 @@ func AssignToAliasOfPrimitive(
 				params.GetDestination(),
 				astbuilder.CallFunc(
 					dstName.Name(),
-					params.GetSource()))),
+					params.GetSource(),
+				),
+			),
+		),
 		nil
 }
 
@@ -787,7 +819,10 @@ func AssignFromAliasOfPrimitive(
 				params.GetDestination(),
 				astbuilder.CallFunc(
 					dstPrim.String(),
-					params.GetSource()))),
+					params.GetSource(),
+				),
+			),
+		),
 		nil
 }
 
@@ -853,12 +888,15 @@ func AssignToAliasOfCollection(
 					lhs,
 					astbuilder.CallFunc(
 						dstName.Name(),
-						rhs))
+						rhs,
+					),
+				)
 			},
 			Locals:              params.Locals,
 			SourceProperty:      params.SourceProperty,
 			DestinationProperty: params.DestinationProperty,
-		})
+		},
+	)
 	if err != nil {
 		return nil, eris.Wrap(err, "unable to build conversion for array element")
 	}
@@ -922,12 +960,14 @@ func AssignFromAliasOfCollection(
 				// Use the existing assignment handler if there is one, but make sure we always assign
 				return params.AssignmentHandlerOrDefault()(
 					lhs,
-					rhs)
+					rhs,
+				)
 			},
 			Locals:              params.Locals,
 			SourceProperty:      params.SourceProperty,
 			DestinationProperty: params.DestinationProperty,
-		})
+		},
+	)
 	if err != nil {
 		return nil, eris.Wrap(err, "unable to build conversion for array element")
 	}
@@ -978,7 +1018,9 @@ func AssignToEnum(
 		return astbuilder.Statements(
 			params.AssignmentHandlerOrDefault()(
 				params.GetDestination(),
-				cast)), nil
+				cast,
+			),
+		), nil
 	}
 
 	// a more complex conversion is needed
@@ -997,7 +1039,8 @@ func AssignToEnum(
 			Locals:              params.Locals,
 			SourceProperty:      params.SourceProperty,
 			DestinationProperty: params.DestinationProperty,
-		})
+		},
+	)
 	if err != nil {
 		return nil, eris.Wrapf(err, "unable to build inner conversion to enum %s", itn.name)
 	}
@@ -1025,7 +1068,9 @@ func AssignToEnum(
 		conversion,
 		params.AssignmentHandlerOrDefault()(
 			params.GetDestination(),
-			cast)), nil
+			cast,
+		),
+	), nil
 }
 
 // AssignFromEnum reads a value from an enum type.
@@ -1068,7 +1113,8 @@ func AssignFromEnum(
 			Locals:              params.Locals,
 			SourceProperty:      params.SourceProperty,
 			DestinationProperty: params.DestinationProperty,
-		})
+		},
+	)
 	if err != nil {
 		return nil, eris.Wrapf(err, "unable to build inner conversion to enum %s", itn.name)
 	}
@@ -1127,10 +1173,12 @@ func IdentityDeepCopyJSON(
 		&dst.CallExpr{
 			Fun:  astbuilder.Selector(params.GetSource(), "DeepCopy"),
 			Args: []dst.Expr{},
-		})
+		},
+	)
 
 	return astbuilder.Statements(
-		params.AssignmentHandlerOrDefault()(params.GetDestination(), newSource)), nil
+		params.AssignmentHandlerOrDefault()(params.GetDestination(), newSource),
+	), nil
 }
 
 // AssignmentHandlerDefine is an assignment handler for definitions, using :=

--- a/v2/tools/generator/internal/astmodel/conversion_function_builder_test.go
+++ b/v2/tools/generator/internal/astmodel/conversion_function_builder_test.go
@@ -22,7 +22,8 @@ func TestConversionFunctionBuilderBuildConversion_GivenSourceAndDestinationTypes
 		MakeEnumValue("Alpha", "alpha"),
 		MakeEnumValue("Beta", "beta"),
 		MakeEnumValue("Gamma", "gamma"),
-		MakeEnumValue("Delta", "delta"))
+		MakeEnumValue("Delta", "delta"),
+	)
 	enumDef := MakeTypeDefinition(enumName, enumType)
 
 	pkgDef := NewPackageDefinition(pkg)

--- a/v2/tools/generator/internal/astmodel/enum_type.go
+++ b/v2/tools/generator/internal/astmodel/enum_type.go
@@ -62,7 +62,8 @@ func NewEnumType(baseType *PrimitiveType, options ...EnumValue) *EnumType {
 			}
 
 			return strings.Compare(left.Identifier, right.Identifier)
-		})
+		},
+	)
 
 	return &EnumType{
 		baseType:       baseType,
@@ -94,7 +95,8 @@ func (enum *EnumType) AsDeclarations(
 		codeGenerationContext,
 		declContext.Name,
 		declContext.Description,
-		declContext.Validations)
+		declContext.Validations,
+	)
 
 	valuesDeclaration := enum.createValuesDeclaration(declContext)
 	mapperDeclaration, err := enum.createMappingDeclaration(declContext.Name, codeGenerationContext)
@@ -184,7 +186,8 @@ func (enum *EnumType) createMappingDeclaration(
 
 	literal := astbuilder.NewMapLiteral(
 		baseTypeExpr,
-		nameExpr)
+		nameExpr,
+	)
 
 	for _, v := range enum.options {
 		key := astbuilder.TextLiteral(strings.ToLower(v.Value))
@@ -200,7 +203,8 @@ func (enum *EnumType) createMappingDeclaration(
 	decl.Decorations().Before = dst.EmptyLine
 	decl.Decorations().Start = append(
 		decl.Decorations().Start,
-		fmt.Sprintf("// Mapping from string to %s", name.Name()))
+		fmt.Sprintf("// Mapping from string to %s", name.Name()),
+	)
 
 	return decl, nil
 }

--- a/v2/tools/generator/internal/astmodel/errored_type_test.go
+++ b/v2/tools/generator/internal/astmodel/errored_type_test.go
@@ -33,7 +33,8 @@ func TestErroredTypeProperties(t *testing.T) {
 			gen.SliceOf(gen.AnyString()),
 			gen.SliceOf(gen.AnyString()),
 			gen.SliceOf(gen.AnyString()),
-			gen.SliceOf(gen.AnyString())))
+			gen.SliceOf(gen.AnyString()),
+		))
 
 	g.TestingRun(t)
 }

--- a/v2/tools/generator/internal/astmodel/file_definition.go
+++ b/v2/tools/generator/internal/astmodel/file_definition.go
@@ -167,7 +167,8 @@ func (file *FileDefinition) AsAst() (result *dst.File, err error) {
 	codeGenContext := NewCodeGenerationContext(
 		file.packageReference,
 		file.generateImports(),
-		file.generatedPackages)
+		file.generatedPackages,
+	)
 
 	// Create all definitions:
 	var declarations []dst.Decl

--- a/v2/tools/generator/internal/astmodel/interface_implementer.go
+++ b/v2/tools/generator/internal/astmodel/interface_implementer.go
@@ -107,7 +107,8 @@ func (i InterfaceImplementer) AsDeclarations(
 			return nil, eris.Wrapf(
 				kerrors.NewAggregate(errs),
 				"generating declarations for interface %s",
-				iface.name.Name())
+				iface.name.Name(),
+			)
 		}
 	}
 
@@ -170,7 +171,8 @@ func (i InterfaceImplementer) generateInterfaceImplAssertion(
 			&dst.ValueSpec{
 				Type: astbuilder.Selector(
 					dst.NewIdent(ifacePackageName),
-					iface.name.Name()),
+					iface.name.Name(),
+				),
 				Names: []*dst.Ident{
 					dst.NewIdent("_"),
 				},
@@ -178,7 +180,9 @@ func (i InterfaceImplementer) generateInterfaceImplAssertion(
 					astbuilder.AddrOf(
 						&dst.CompositeLit{
 							Type: dst.NewIdent(typeName.Name()),
-						})),
+						},
+					),
+				),
 			},
 		},
 	}

--- a/v2/tools/generator/internal/astmodel/interface_type.go
+++ b/v2/tools/generator/internal/astmodel/interface_type.go
@@ -72,7 +72,8 @@ func (i *InterfaceType) References() TypeNameSet {
 	i.functions.ForEach(
 		func(name string, method Function) {
 			result.AddAll(method.References())
-		})
+		},
+	)
 	return result
 }
 
@@ -153,7 +154,8 @@ func (i *InterfaceType) RequiredPackageReferences() *PackageReferenceSet {
 	i.functions.ForEach(
 		func(_ string, method Function) {
 			result.Merge(method.RequiredPackageReferences())
-		})
+		},
+	)
 
 	return result
 }

--- a/v2/tools/generator/internal/astmodel/internal_type_name.go
+++ b/v2/tools/generator/internal/astmodel/internal_type_name.go
@@ -76,7 +76,8 @@ func (tn InternalTypeName) AsTypeExpr(codeGenerationContext *CodeGenerationConte
 			"no reference for %s from %s available in package %s",
 			tn.Name(),
 			tn.packageReference,
-			codeGenerationContext.currentPackage))
+			codeGenerationContext.currentPackage,
+		))
 	}
 
 	return astbuilder.Selector(dst.NewIdent(packageName), tn.Name()), nil

--- a/v2/tools/generator/internal/astmodel/local_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/local_package_reference.go
@@ -163,7 +163,8 @@ func (pr LocalPackageReference) ImportAlias(style PackageImportStyle) string {
 		return fmt.Sprintf(
 			"%s%s",
 			pr.simplifiedGeneratorVersion(pr.generatorVersion),
-			pr.simplifiedAPIVersion(pr.apiVersion))
+			pr.simplifiedAPIVersion(pr.apiVersion),
+		)
 	case GroupOnly:
 		return pr.simplifiedGroup(pr.group)
 	case GroupAndVersion:
@@ -174,14 +175,16 @@ func (pr LocalPackageReference) ImportAlias(style PackageImportStyle) string {
 			"%s_%s%s",
 			pr.simplifiedGroup(pr.group),
 			pr.simplifiedGeneratorVersion(pr.generatorVersion),
-			pr.simplifiedAPIVersion(pr.apiVersion))
+			pr.simplifiedAPIVersion(pr.apiVersion),
+		)
 	case GroupAndFullVersion:
 		// As discussed above, it's not idiomatic but we do it anyway.
 		return fmt.Sprintf(
 			"%s_%s%s",
 			pr.simplifiedGroup(pr.group),
 			pr.generatorVersion,
-			pr.simplifiedAPIVersion(pr.apiVersion))
+			pr.simplifiedAPIVersion(pr.apiVersion),
+		)
 	default:
 		panic(fmt.Sprintf("didn't expect PackageImportStyle %q", style))
 	}

--- a/v2/tools/generator/internal/astmodel/object_type.go
+++ b/v2/tools/generator/internal/astmodel/object_type.go
@@ -104,7 +104,8 @@ func (objectType *ObjectType) AsDeclarations(
 	result := astbuilder.Declarations(
 		declaration,
 		interfaceDeclarations,
-		methodDeclarations)
+		methodDeclarations,
+	)
 
 	return result, nil
 }

--- a/v2/tools/generator/internal/astmodel/oneof_type_test.go
+++ b/v2/tools/generator/internal/astmodel/oneof_type_test.go
@@ -85,10 +85,12 @@ func TestOneOfType_WithAdditionalPropertiesFromObject_GivenProperties_ReturnsOne
 	oneOf := NewOneOfType("oneOf")
 	objA := NewObjectType().WithProperties(
 		NewPropertyDefinition("FullName", "fullName", StringType),
-		NewPropertyDefinition("KnownAs", "knownAs", StringType))
+		NewPropertyDefinition("KnownAs", "knownAs", StringType),
+	)
 	objB := NewObjectType().WithProperties(
 		NewPropertyDefinition("FullName", "fullName", StringType),
-		NewPropertyDefinition("KnownAs", "knownAs", StringType))
+		NewPropertyDefinition("KnownAs", "knownAs", StringType),
+	)
 
 	result := oneOf.WithAdditionalPropertyObject(objA).WithAdditionalPropertyObject(objB)
 	g.Expect(result).NotTo(BeNil())
@@ -103,7 +105,8 @@ func TestOneOfType_WithoutAnyPropertyObjects_GivenProperties_ReturnsOneOfWithNon
 	oneOf := NewOneOfType("oneOf")
 	obj := NewObjectType().WithProperties(
 		NewPropertyDefinition("FullName", "fullName", StringType),
-		NewPropertyDefinition("KnownAs", "knownAs", StringType))
+		NewPropertyDefinition("KnownAs", "knownAs", StringType),
+	)
 
 	oneOf = oneOf.WithAdditionalPropertyObject(obj)
 
@@ -116,9 +119,11 @@ func TestOneOfType_Equals_GivenChange_RecognisesDifference(t *testing.T) {
 	t.Parallel()
 
 	nameMixin := NewObjectType().WithProperties(
-		NewPropertyDefinition("Name", "name", StringType))
+		NewPropertyDefinition("Name", "name", StringType),
+	)
 	locationMixin := NewObjectType().WithProperties(
-		NewPropertyDefinition("Location", "location", StringType))
+		NewPropertyDefinition("Location", "location", StringType),
+	)
 
 	cases := map[string]struct {
 		change         func(*OneOfType) *OneOfType

--- a/v2/tools/generator/internal/astmodel/package_definition.go
+++ b/v2/tools/generator/internal/astmodel/package_definition.go
@@ -118,7 +118,8 @@ func (p *PackageDefinition) emitFiles(
 	for fileName, defs := range filesToGenerate {
 		codeFilePath := filepath.Join(
 			outputDir,
-			fmt.Sprintf("%s_types%s.go", fileName, CodeGeneratedFileSuffix))
+			fmt.Sprintf("%s_types%s.go", fileName, CodeGeneratedFileSuffix),
+		)
 
 		err := p.writeCodeFile(codeFilePath, defs, generatedPackages)
 		if err != nil {
@@ -127,7 +128,8 @@ func (p *PackageDefinition) emitFiles(
 
 		testFilePath := filepath.Join(
 			outputDir,
-			fmt.Sprintf("%s_types%s_test.go", fileName, CodeGeneratedFileSuffix))
+			fmt.Sprintf("%s_types%s_test.go", fileName, CodeGeneratedFileSuffix),
+		)
 
 		err = p.writeTestFile(testFilePath, defs, generatedPackages)
 		if err != nil {

--- a/v2/tools/generator/internal/astmodel/package_reference.go
+++ b/v2/tools/generator/internal/astmodel/package_reference.go
@@ -50,7 +50,8 @@ func SortPackageReferencesByPathAndVersion(packages []PackageReference) {
 		packages,
 		func(left PackageReference, right PackageReference) int {
 			return ComparePathAndVersion(left.ImportPath(), right.ImportPath())
-		})
+		},
+	)
 }
 
 // ComparePathAndVersion compares two paths containing versions

--- a/v2/tools/generator/internal/astmodel/property_definition.go
+++ b/v2/tools/generator/internal/astmodel/property_definition.go
@@ -289,7 +289,8 @@ func (property *PropertyDefinition) MakeRequired() *PropertyDefinition {
 		panic(eris.Errorf(
 			"property %s with non-optional type %T cannot be marked kubebuilder:validation:Required.",
 			property.PropertyName(),
-			property.PropertyType()))
+			property.PropertyType(),
+		))
 	}
 
 	result := property.copy()
@@ -481,7 +482,8 @@ func (property *PropertyDefinition) tagsEqual(f *PropertyDefinition) bool {
 		f.tags,
 		func(left []string, right []string) bool {
 			return slices.Equal(left, right)
-		})
+		},
+	)
 }
 
 // Equals tests to see if the specified PropertyDefinition specifies the same property

--- a/v2/tools/generator/internal/astmodel/property_definition_test.go
+++ b/v2/tools/generator/internal/astmodel/property_definition_test.go
@@ -317,7 +317,10 @@ func Test_PropertyDefinitionMakeRequired_WhenTypeIsOptional_Panics(t *testing.T)
 		PanicWith(
 			MatchError(
 				fmt.Sprintf("property %s with non-optional type *astmodel.PrimitiveType cannot be marked kubebuilder:validation:Required.",
-					propertyName))))
+					propertyName),
+			),
+		),
+	)
 }
 
 /*

--- a/v2/tools/generator/internal/astmodel/property_reference.go
+++ b/v2/tools/generator/internal/astmodel/property_reference.go
@@ -48,5 +48,6 @@ func (ref PropertyReference) String() string {
 		"%s/%s.%s",
 		declaringType.InternalPackageReference().FolderPath(),
 		declaringType.Name(),
-		ref.property)
+		ref.property,
+	)
 }

--- a/v2/tools/generator/internal/astmodel/property_remover_test.go
+++ b/v2/tools/generator/internal/astmodel/property_remover_test.go
@@ -57,7 +57,8 @@ func Test_PropertyRemover_GivenDefinition_RemovesExpectedProperty(t *testing.T) 
 			// Arrange
 			def := MakeTypeDefinition(
 				MakeInternalTypeName(ref, "TestDef"),
-				c.theType)
+				c.theType,
+			)
 
 			// Act
 			newDef, err := remover.Remove(def, c.propName)

--- a/v2/tools/generator/internal/astmodel/resource_type.go
+++ b/v2/tools/generator/internal/astmodel/resource_type.go
@@ -685,7 +685,8 @@ func (resource *ResourceType) AsDeclarations(
 	}
 
 	resourceListDeclaration, err := resource.resourceListTypeDecls(
-		codeGenerationContext, declContext.Name, declContext.Description)
+		codeGenerationContext, declContext.Name, declContext.Description,
+	)
 	if err != nil {
 		return nil, eris.Wrapf(err, "creating resource list type for %s", declContext.Name)
 	}
@@ -731,7 +732,8 @@ func (resource *ResourceType) generateMethodDecls(
 func (resource *ResourceType) makeResourceListTypeName(name InternalTypeName) TypeName {
 	return MakeInternalTypeName(
 		name.InternalPackageReference(),
-		name.Name()+"List")
+		name.Name()+"List",
+	)
 }
 
 func (resource *ResourceType) resourceListTypeDecls(
@@ -870,13 +872,15 @@ func generateMethodDeclForFunction(
 					e,
 					"generating method declaration for %s.%s",
 					typeName.Name(),
-					f.Name())
+					f.Name(),
+				)
 			} else {
 				err = eris.Errorf(
 					"generating method declaration for %s.%s: %s",
 					typeName.Name(),
 					f.Name(),
-					r)
+					r,
+				)
 			}
 		}
 	}()

--- a/v2/tools/generator/internal/astmodel/test_file_definition.go
+++ b/v2/tools/generator/internal/astmodel/test_file_definition.go
@@ -44,7 +44,8 @@ func NewTestFileDefinition(
 		defs,
 		func(left TypeDefinition, right TypeDefinition) int {
 			return cmp.Compare(left.Name().Name(), right.Name().Name())
-		})
+		},
+	)
 
 	// TODO: check that all definitions are from same package
 	return &TestFileDefinition{
@@ -82,7 +83,8 @@ func (file *TestFileDefinition) AsAst() (*dst.File, error) {
 	if len(errs) > 0 {
 		return nil, eris.Wrap(
 			kerrors.NewAggregate(errs),
-			"failed to generate test cases")
+			"failed to generate test cases",
+		)
 	}
 
 	var decls []dst.Decl

--- a/v2/tools/generator/internal/astmodel/type_definition_set.go
+++ b/v2/tools/generator/internal/astmodel/type_definition_set.go
@@ -215,7 +215,8 @@ func DiffTypes(x, y interface{}) string {
 	// prefer diff.Diff() over cmp.Diff() as the results are more readable
 	return diff.Diff(
 		pretty.Sprint(x),
-		pretty.Sprint(y))
+		pretty.Sprint(y),
+	)
 }
 
 // AddAllAllowDuplicates adds multiple definitions to the set.
@@ -590,7 +591,8 @@ func FindConnectedDefinitions(
 ) (TypeDefinitionSet, error) {
 	walker := NewTypeWalker(
 		definitions,
-		TypeVisitorBuilder[any]{}.Build())
+		TypeVisitorBuilder[any]{}.Build(),
+	)
 
 	result := make(TypeDefinitionSet)
 	for _, def := range roots {

--- a/v2/tools/generator/internal/astmodel/type_definition_set_test.go
+++ b/v2/tools/generator/internal/astmodel/type_definition_set_test.go
@@ -401,7 +401,8 @@ func createTestSpec(
 	specName := MakeInternalTypeName(pkg, name+SpecSuffix)
 	return MakeTypeDefinition(
 		specName,
-		NewObjectType().WithProperties(properties...))
+		NewObjectType().WithProperties(properties...),
+	)
 }
 
 // createTestStatus makes a status for testing
@@ -412,5 +413,6 @@ func createTestStatus(
 	statusName := MakeInternalTypeName(pkg, name+StatusSuffix)
 	return MakeTypeDefinition(
 		statusName,
-		NewObjectType().WithProperties(properties...))
+		NewObjectType().WithProperties(properties...),
+	)
 }

--- a/v2/tools/generator/internal/astmodel/type_visitor.go
+++ b/v2/tools/generator/internal/astmodel/type_visitor.go
@@ -115,7 +115,8 @@ func (tv *TypeVisitor[C]) VisitDefinition(td TypeDefinition, ctx C) (TypeDefinit
 			err,
 			"visit of %s/%s failed",
 			name.InternalPackageReference().FolderPath(),
-			name.Name())
+			name.Name(),
+		)
 	}
 
 	visitedType, err := tv.Visit(td.Type(), ctx)
@@ -124,7 +125,8 @@ func (tv *TypeVisitor[C]) VisitDefinition(td TypeDefinition, ctx C) (TypeDefinit
 			err,
 			"visit of type of %s/%s failed",
 			name.InternalPackageReference().FolderPath(),
-			name.Name())
+			name.Name(),
+		)
 	}
 
 	def := td.WithName(visitedName).WithType(visitedType)
@@ -175,7 +177,8 @@ func IdentityVisitOfObjectType[C any](this *TypeVisitor[C], it *ObjectType, ctx 
 		ctx,
 		func(_ *ObjectType, _ *PropertyDefinition, ctx C) (C, error) {
 			return ctx, nil
-		})
+		},
+	)
 }
 
 func OrderedIdentityVisitOfObjectType[C any](this *TypeVisitor[C], it *ObjectType, ctx C) (Type, error) {
@@ -185,7 +188,8 @@ func OrderedIdentityVisitOfObjectType[C any](this *TypeVisitor[C], it *ObjectTyp
 		ctx,
 		func(_ *ObjectType, _ *PropertyDefinition, ctx C) (C, error) {
 			return ctx, nil
-		})
+		},
+	)
 }
 
 type MakePerPropertyContext[C any] func(ot *ObjectType, prop *PropertyDefinition, ctx C) (C, error)

--- a/v2/tools/generator/internal/astmodel/type_walker_test.go
+++ b/v2/tools/generator/internal/astmodel/type_walker_test.go
@@ -26,22 +26,29 @@ func makeSimpleTestTypeGraph() TypeDefinitionSet {
 	result := make(TypeDefinitionSet)
 
 	leftChildType := NewObjectType().WithProperty(
-		NewPropertyDefinition("SimpleString", "simpleString", StringType))
+		NewPropertyDefinition("SimpleString", "simpleString", StringType),
+	)
 	leftChildDef := MakeTypeDefinition(
 		leftTypeName,
-		leftChildType)
+		leftChildType,
+	)
 	rightChildType := NewObjectType().WithProperty(
-		NewPropertyDefinition("SimpleInt", "simpleInt", IntType))
+		NewPropertyDefinition("SimpleInt", "simpleInt", IntType),
+	)
 	rightChildDef := MakeTypeDefinition(
 		rightTypeName,
-		rightChildType)
+		rightChildType,
+	)
 
 	rootType := NewObjectType().WithProperty(
-		NewPropertyDefinition("Left", "left", leftChildDef.Name())).WithProperty(
-		NewPropertyDefinition("Right", "right", rightChildDef.Name()))
+		NewPropertyDefinition("Left", "left", leftChildDef.Name()),
+	).WithProperty(
+		NewPropertyDefinition("Right", "right", rightChildDef.Name()),
+	)
 	rootDef := MakeTypeDefinition(
 		rootTypeName,
-		rootType)
+		rootType,
+	)
 
 	result.Add(leftChildDef)
 	result.Add(rightChildDef)
@@ -54,17 +61,22 @@ func makeDuplicateReferencesTypeGraph() TypeDefinitionSet {
 	result := make(TypeDefinitionSet)
 
 	childType := NewObjectType().WithProperty(
-		NewPropertyDefinition("SimpleString", "simpleString", StringType))
+		NewPropertyDefinition("SimpleString", "simpleString", StringType),
+	)
 	childDef := MakeTypeDefinition(
 		leftTypeName,
-		childType)
+		childType,
+	)
 
 	rootType := NewObjectType().WithProperty(
-		NewPropertyDefinition("Left", "left", childDef.Name())).WithProperty(
-		NewPropertyDefinition("Right", "right", childDef.Name()))
+		NewPropertyDefinition("Left", "left", childDef.Name()),
+	).WithProperty(
+		NewPropertyDefinition("Right", "right", childDef.Name()),
+	)
 	rootDef := MakeTypeDefinition(
 		rootTypeName,
-		rootType)
+		rootType,
+	)
 
 	result.Add(childDef)
 	result.Add(rootDef)
@@ -76,22 +88,29 @@ func makeCycleTypeGraph() TypeDefinitionSet {
 	result := make(TypeDefinitionSet)
 
 	leftChildType := NewObjectType().WithProperty(
-		NewPropertyDefinition("Root", "root", rootTypeName))
+		NewPropertyDefinition("Root", "root", rootTypeName),
+	)
 	leftChildDef := MakeTypeDefinition(
 		leftTypeName,
-		leftChildType)
+		leftChildType,
+	)
 	rightChildType := NewObjectType().WithProperty(
-		NewPropertyDefinition("SimpleInt", "simpleInt", IntType))
+		NewPropertyDefinition("SimpleInt", "simpleInt", IntType),
+	)
 	rightChildDef := MakeTypeDefinition(
 		rightTypeName,
-		rightChildType)
+		rightChildType,
+	)
 
 	rootType := NewObjectType().WithProperty(
-		NewPropertyDefinition("Left", "left", leftChildDef.Name())).WithProperty(
-		NewPropertyDefinition("Right", "right", rightChildDef.Name()))
+		NewPropertyDefinition("Left", "left", leftChildDef.Name()),
+	).WithProperty(
+		NewPropertyDefinition("Right", "right", rightChildDef.Name()),
+	)
 	rootDef := MakeTypeDefinition(
 		rootTypeName,
-		rootType)
+		rootType,
+	)
 
 	result.Add(leftChildDef)
 	result.Add(rightChildDef)

--- a/v2/tools/generator/internal/codegen/code_generator.go
+++ b/v2/tools/generator/internal/codegen/code_generator.go
@@ -277,7 +277,8 @@ func (generator *CodeGenerator) Generate(
 ) error {
 	log.V(1).Info(
 		"ASO Code Generator",
-		"version", version.BuildVersion)
+		"version", version.BuildVersion,
+	)
 
 	if generator.debugSettings != nil {
 		// Generate a diagram containing our stages
@@ -331,7 +332,8 @@ func (generator *CodeGenerator) logStateChanges(
 		"elapsed", duration,
 		"added", len(defsAdded),
 		"removed", len(defsRemoved),
-		"totalDefs", len(newState.Definitions()))
+		"totalDefs", len(newState.Definitions()),
+	)
 }
 
 // executeStage runs the given stage against the given state, returning the new state.

--- a/v2/tools/generator/internal/codegen/code_generator_test.go
+++ b/v2/tools/generator/internal/codegen/code_generator_test.go
@@ -58,9 +58,10 @@ func TestRemoveStages_PanicsForUnknownStage(t *testing.T) {
 		},
 	}
 
-	g.Expect(func() {
-		gen.RemoveStages("bang")
-	},
+	g.Expect(
+		func() {
+			gen.RemoveStages("bang")
+		},
 	).To(Panic())
 
 	gen.RemoveStages("foo", "baz")
@@ -72,7 +73,8 @@ func MakeFakePipelineStage(id string) *pipeline.Stage {
 		"Stage "+id,
 		func(ctx context.Context, state *pipeline.State) (*pipeline.State, error) {
 			return state, nil
-		})
+		},
+	)
 }
 
 /*
@@ -109,9 +111,10 @@ func TestReplaceStage_PanicsForUnknownStage(t *testing.T) {
 		},
 	}
 
-	g.Expect(func() {
-		gen.ReplaceStage("bang", zooStage)
-	},
+	g.Expect(
+		func() {
+			gen.ReplaceStage("bang", zooStage)
+		},
 	).To(Panic())
 }
 
@@ -149,8 +152,9 @@ func TestGolden_InjectStageAfter_PanicsForUnknownStage(t *testing.T) {
 		},
 	}
 
-	g.Expect(func() {
-		gen.InjectStageAfter("bang", zooStage)
-	},
+	g.Expect(
+		func() {
+			gen.InjectStageAfter("bang", zooStage)
+		},
 	).To(Panic())
 }

--- a/v2/tools/generator/internal/codegen/debug_reporter.go
+++ b/v2/tools/generator/internal/codegen/debug_reporter.go
@@ -33,7 +33,8 @@ func (dr *debugReporter) ReportStage(stage int, description string, state *pipel
 		func(def astmodel.TypeDefinition) bool {
 			// Allow matching just the group (e.g. network)
 			return dr.settings.MatchesGroup(def.Name().InternalPackageReference())
-		})
+		},
+	)
 
 	tcr := reporting.NewTypeCatalogReport(included, reporting.IncludeFunctions)
 	name := strconv.Itoa(stage) + "-" + description + ".txt"

--- a/v2/tools/generator/internal/codegen/embeddedresources/misbehaving_embedded_resources.go
+++ b/v2/tools/generator/internal/codegen/embeddedresources/misbehaving_embedded_resources.go
@@ -60,7 +60,8 @@ func findMisbehavingResources(
 							typeName:     ctx.typeName,
 							resourceName: ctx.resourceName,
 							propertyType: propertyType,
-						})
+						},
+					)
 				}
 			}
 

--- a/v2/tools/generator/internal/codegen/embeddedresources/remove_empty_objects.go
+++ b/v2/tools/generator/internal/codegen/embeddedresources/remove_empty_objects.go
@@ -66,7 +66,8 @@ func findEmptyObjectTypes(
 
 		log.V(1).Info(
 			"Removing empty type",
-			"name", def.Name())
+			"name", def.Name(),
+		)
 
 		result.Add(def.Name())
 	}
@@ -125,7 +126,8 @@ func makeRemovedTypeVisitor(
 				log.V(1).Info(
 					"Removing reference to empty type",
 					"property", prop.PropertyName(),
-					"referencing", ctx.typeName)
+					"referencing", ctx.typeName,
+				)
 			}
 		})
 

--- a/v2/tools/generator/internal/codegen/embeddedresources/renamer.go
+++ b/v2/tools/generator/internal/codegen/embeddedresources/renamer.go
@@ -43,7 +43,8 @@ func (r renamer) simplifyEmbeddedNameToOriginalName(
 	log.V(2).Info(
 		"Type not used, renaming for simplicity",
 		"originalName", associatedNames.Single(),
-		"newName", original)
+		"newName", original,
+	)
 
 	return renames, nil
 }
@@ -72,7 +73,8 @@ func (r renamer) simplifyEmbeddedNameRemoveContextAndCount(
 	log.V(2).Info(
 		"Type used in single context, renaming for simplicity",
 		"originalName", associated,
-		"newName", renames[associated])
+		"newName", renames[associated],
+	)
 
 	return renames, nil
 }
@@ -110,7 +112,8 @@ func (r renamer) simplifyEmbeddedNameRemoveContext(
 		log.V(2).Info(
 			"Type used in single context, removing context from name",
 			"originalName", associated,
-			"newName", renames[associated])
+			"newName", renames[associated],
+		)
 	}
 
 	return renames, nil

--- a/v2/tools/generator/internal/codegen/embeddedresources/renamer_test.go
+++ b/v2/tools/generator/internal/codegen/embeddedresources/renamer_test.go
@@ -45,7 +45,8 @@ func typesWithSubresourceTypeNoOriginalNameUsage() (astmodel.TypeDefinitionSet, 
 	prop := astmodel.NewPropertyDefinition(
 		"prop1",
 		"prop1",
-		modifiedTypeName)
+		modifiedTypeName,
+	)
 	resource := newTestObject(resourceTypeName, prop)
 	result.Add(resource)
 
@@ -70,11 +71,13 @@ func typesWithSubresourceTypeOriginalNameUsage() (astmodel.TypeDefinitionSet, ma
 	prop1 := astmodel.NewPropertyDefinition(
 		"prop1",
 		"prop1",
-		modifiedTypeName)
+		modifiedTypeName,
+	)
 	prop2 := astmodel.NewPropertyDefinition(
 		"prop2",
 		"prop2",
-		originalTypeName)
+		originalTypeName,
+	)
 
 	resource := newTestObject(resourceTypeName, prop1, prop2)
 	result.Add(resource)
@@ -106,11 +109,13 @@ func typesWithSubresourceTypeMultipleUsageContextsOneResource() (astmodel.TypeDe
 	prop1 := astmodel.NewPropertyDefinition(
 		"prop1",
 		"prop1",
-		modifiedTypeName1)
+		modifiedTypeName1,
+	)
 	prop2 := astmodel.NewPropertyDefinition(
 		"prop2",
 		"prop2",
-		modifiedTypeName2)
+		modifiedTypeName2,
+	)
 
 	resource := newTestObject(resourceTypeName, prop1, prop2)
 	result.Add(resource)
@@ -141,11 +146,13 @@ func typesWithSubresourceTypeMultipleResourcesOneUsageContextEach() (astmodel.Ty
 	prop1 := astmodel.NewPropertyDefinition(
 		"prop1",
 		"prop1",
-		modifiedTypeName1)
+		modifiedTypeName1,
+	)
 	prop2 := astmodel.NewPropertyDefinition(
 		"prop2",
 		"prop2",
-		modifiedTypeName2)
+		modifiedTypeName2,
+	)
 
 	resource := newTestObject(resourceTypeName, prop1, prop2)
 	result.Add(resource)

--- a/v2/tools/generator/internal/codegen/golden_files_test.go
+++ b/v2/tools/generator/internal/codegen/golden_files_test.go
@@ -85,7 +85,8 @@ func injectEmbeddedStructType() *pipeline.Stage {
 						prop := astmodel.NewPropertyDefinition(
 							"",
 							",inline",
-							embeddedTypeDef.Name())
+							embeddedTypeDef.Name(),
+						)
 						return objectType.WithEmbeddedProperty(prop)
 					})
 					if err != nil {
@@ -100,7 +101,8 @@ func injectEmbeddedStructType() *pipeline.Stage {
 			defs.Add(embeddedTypeDef)
 
 			return state.WithDefinitions(defs), nil
-		})
+		},
+	)
 }
 
 func runGoldenTest(t *testing.T, path string, testConfig GoldenTestConfig) {
@@ -161,12 +163,14 @@ func NewTestCodeGenerator(
 			pipeline.ReportOnTypesAndVersionsStageID,
 			pipeline.ReportResourceVersionsStageID,
 			pipeline.ReportResourceStructureStageID,
-			pipeline.ReportUpgradableResourcesStageID)
+			pipeline.ReportUpgradableResourcesStageID,
+		)
 		if !testConfig.HasARMResources {
 			codegen.RemoveStages(
 				pipeline.CreateARMTypesStageID,
 				pipeline.PruneResourcesWithLifecycleOwnedByParentStageID,
-				pipeline.ApplyARMConversionInterfaceStageID)
+				pipeline.ApplyARMConversionInterfaceStageID,
+			)
 
 			// These stages treat the collection of types as a graph of types rooted by a resource type.
 			// In the degenerate case where there are no resources it behaves the same as stripUnreferenced - removing
@@ -174,7 +178,8 @@ func NewTestCodeGenerator(
 			codegen.RemoveStages(
 				pipeline.RemoveEmbeddedResourcesStageID,
 				pipeline.CollapseCrossGroupReferencesStageID,
-				pipeline.TransformCrossResourceReferencesStageID)
+				pipeline.TransformCrossResourceReferencesStageID,
+			)
 
 			codegen.ReplaceStage(pipeline.StripUnreferencedTypeDefinitionsStageID, stripUnusedTypesPipelineStage())
 		} else {
@@ -187,7 +192,8 @@ func NewTestCodeGenerator(
 			pipeline.CheckForAnyTypeStageID,
 			pipeline.ReportResourceVersionsStageID,
 			pipeline.ReportResourceStructureStageID,
-			pipeline.ReportUpgradableResourcesStageID)
+			pipeline.ReportUpgradableResourcesStageID,
+		)
 		if !testConfig.HasARMResources {
 			codegen.ReplaceStage(pipeline.StripUnreferencedTypeDefinitionsStageID, stripUnusedTypesPipelineStage())
 		}
@@ -248,7 +254,8 @@ func loadTestSchemaIntoTypes(
 			}
 
 			return state.WithDefinitions(scanner.Definitions()), nil
-		})
+		},
+	)
 }
 
 func exportPackagesTestPipelineStage(t *testing.T, testName string) *pipeline.Stage {
@@ -306,7 +313,8 @@ func exportPackagesTestPipelineStage(t *testing.T, testName string) *pipeline.St
 			}
 
 			return state, nil
-		})
+		},
+	)
 }
 
 func stripUnusedTypesPipelineStage() *pipeline.Stage {
@@ -323,7 +331,8 @@ func stripUnusedTypesPipelineStage() *pipeline.Stage {
 			}
 
 			return state.WithDefinitions(defs), nil
-		})
+		},
+	)
 }
 
 // TODO: Ideally we wouldn't need a test specific function here, but currently
@@ -377,7 +386,8 @@ func addCrossResourceReferencesForTest(idFactory astmodel.IdentifierFactory) *pi
 			}
 
 			return state.WithDefinitions(defs), nil
-		})
+		},
+	)
 }
 
 func TestGolden(t *testing.T) {

--- a/v2/tools/generator/internal/codegen/pipeline/add_api_version_enums.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_api_version_enums.go
@@ -59,14 +59,17 @@ func (vs apiVersions) Get(pr astmodel.InternalPackageReference) apiVersion {
 	name := astmodel.MakeInternalTypeName(pr, "APIVersion") // TODO: constant?
 	value := astmodel.MakeEnumValue(
 		"Value",
-		fmt.Sprintf("%q", apiVersionFromPackageReference(pr)))
+		fmt.Sprintf("%q", apiVersionFromPackageReference(pr)),
+	)
 
 	result := apiVersion{name: name, value: value}
 	vs.generated[pr] = result
 	vs.output.Add(
 		astmodel.MakeTypeDefinition(
 			name,
-			astmodel.NewEnumType(astmodel.StringType, value)))
+			astmodel.NewEnumType(astmodel.StringType, value),
+		),
+	)
 	return result
 }
 

--- a/v2/tools/generator/internal/codegen/pipeline/add_arm_conversion_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_arm_conversion_interface.go
@@ -39,7 +39,8 @@ func ApplyARMConversionInterface(idFactory astmodel.IdentifierFactory, config *c
 			}
 
 			return state.WithDefinitions(definitions), nil
-		})
+		},
+	)
 }
 
 // LookupARMTypeDefinition gets the ARM type definition for a given Kubernetes type name.
@@ -242,7 +243,8 @@ func (c *armConversionApplier) addARMConversionInterface(
 			objectType,
 			kubeDef.Name(),
 			c.idFactory,
-			typeKind))
+			typeKind,
+		))
 		return result, nil
 	}
 
@@ -264,12 +266,14 @@ func (c *armConversionApplier) createOwnerProperty(ownerTypeName astmodel.Intern
 	prop := astmodel.NewPropertyDefinition(
 		c.idFactory.CreatePropertyName(astmodel.OwnerProperty, astmodel.Exported),
 		c.idFactory.CreateStringIdentifier(astmodel.OwnerProperty, astmodel.NotExported),
-		astmodel.OptionalKnownResourceReferenceType)
+		astmodel.OptionalKnownResourceReferenceType,
+	)
 	prop = prop.WithDescription(
 		fmt.Sprintf("The owner of the resource. The owner controls where the resource goes when it is deployed. "+
 			"The owner also controls the resources lifecycle. "+
 			"When the owner is deleted the resource will also be deleted. Owner is expected to "+
-			"be a reference to a %s/%s resource", group, kind))
+			"be a reference to a %s/%s resource", group, kind),
+	)
 	prop = prop.WithTag("group", group)
 	prop = prop.WithTag("kind", kind)
 	prop = prop.MakeRequired() // Owner is always required
@@ -281,11 +285,13 @@ func (c *armConversionApplier) createExtensionResourceOwnerProperty() *astmodel.
 	prop := astmodel.NewPropertyDefinition(
 		c.idFactory.CreatePropertyName(astmodel.OwnerProperty, astmodel.Exported),
 		c.idFactory.CreateStringIdentifier(astmodel.OwnerProperty, astmodel.NotExported),
-		astmodel.NewOptionalType(astmodel.ArbitraryOwnerReference)).MakeRequired()
+		astmodel.NewOptionalType(astmodel.ArbitraryOwnerReference),
+	).MakeRequired()
 	prop = prop.WithDescription(
 		"The owner of the resource. The owner controls where the resource goes when it is deployed. " +
 			"The owner also controls the resources lifecycle. " +
 			"When the owner is deleted the resource will also be deleted. " +
-			"This resource is an extension resource, which means that any other Azure resource can be its owner.")
+			"This resource is an extension resource, which means that any other Azure resource can be its owner.",
+	)
 	return prop
 }

--- a/v2/tools/generator/internal/codegen/pipeline/add_configmaps.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_configmaps.go
@@ -32,7 +32,8 @@ func AddConfigMaps(config *config.Configuration) *Stage {
 			}
 
 			return state.WithDefinitions(updatedDefs), nil
-		})
+		},
+	)
 
 	stage.RequiresPostrequisiteStages(CreateARMTypesStageID)
 
@@ -120,7 +121,8 @@ func transformConfigMaps(cfg *config.Configuration, definitions astmodel.TypeDef
 					return nil, eris.Errorf(
 						"failed to transform property to optional configmap on type %s. Property %s already exists",
 						ctx,
-						newProp.PropertyName())
+						newProp.PropertyName(),
+					)
 				}
 
 				it = it.WithProperties(updatedProp, newProp)

--- a/v2/tools/generator/internal/codegen/pipeline/add_configmaps_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_configmaps_test.go
@@ -27,7 +27,8 @@ func TestAddConfigMaps_AddsSpecWithRequiredConfigMaps(t *testing.T) {
 		test.FullNameProperty,
 		test.FamilyNameProperty,
 		test.KnownAsProperty,
-		test.RestrictedNameProperty)
+		test.RestrictedNameProperty,
+	)
 	status := test.CreateStatus(test.Pkg2020, "Person")
 	resource := test.CreateResource(test.Pkg2020, "Person", spec, status)
 
@@ -42,7 +43,9 @@ func TestAddConfigMaps_AddsSpecWithRequiredConfigMaps(t *testing.T) {
 			func(pc *config.PropertyConfiguration) error {
 				pc.ImportConfigMapMode.Set(config.ImportConfigMapModeRequired)
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 	g.Expect(
 		omc.ModifyProperty(
@@ -51,7 +54,9 @@ func TestAddConfigMaps_AddsSpecWithRequiredConfigMaps(t *testing.T) {
 			func(pc *config.PropertyConfiguration) error {
 				pc.ImportConfigMapMode.Set(config.ImportConfigMapModeOptional)
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 	g.Expect(
 		omc.ModifyProperty(
@@ -60,7 +65,9 @@ func TestAddConfigMaps_AddsSpecWithRequiredConfigMaps(t *testing.T) {
 			func(pc *config.PropertyConfiguration) error {
 				pc.ImportConfigMapMode.Set(config.ImportConfigMapModeOptional)
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 
 	configuration := config.NewConfiguration()

--- a/v2/tools/generator/internal/codegen/pipeline/add_cross_resource_references.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_cross_resource_references.go
@@ -58,7 +58,8 @@ func TransformCrossResourceReferences(configuration *config.Configuration, idFac
 			}
 
 			return state.WithDefinitions(resultDefs), nil
-		})
+		},
+	)
 }
 
 func makeReferencePropertyName(existing *astmodel.PropertyDefinition, isSlice bool, isMap bool) string {
@@ -295,7 +296,8 @@ func makeResourceReferenceProperty(
 	newProp := astmodel.NewPropertyDefinition(
 		idFactory.CreatePropertyName(referencePropertyName, astmodel.Exported),
 		idFactory.CreateStringIdentifier(referencePropertyName, astmodel.NotExported),
-		existing.PropertyType())
+		existing.PropertyType(),
+	)
 	// TODO: We could pass this information forward some other way?
 	// Add tag so that we remember what this field was before
 	newProp = newProp.WithTag(astmodel.ARMReferenceTag, originalName)

--- a/v2/tools/generator/internal/codegen/pipeline/add_cross_resource_references_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_cross_resource_references_test.go
@@ -38,7 +38,8 @@ func TestAddCrossResourceReferences_HandlesArray(t *testing.T) {
 
 	state, err := RunTestPipeline(
 		NewState(defs),
-		TransformCrossResourceReferences(configuration, idFactory))
+		TransformCrossResourceReferences(configuration, idFactory),
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	test.AssertPackagesGenerateExpectedCode(t, state.Definitions())
@@ -61,7 +62,8 @@ func TestAddCrossResourceReferences_HandlesMap(t *testing.T) {
 
 	state, err := RunTestPipeline(
 		NewState(defs),
-		TransformCrossResourceReferences(configuration, idFactory))
+		TransformCrossResourceReferences(configuration, idFactory),
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	test.AssertPackagesGenerateExpectedCode(t, state.Definitions())

--- a/v2/tools/generator/internal/codegen/pipeline/add_kubernetes_exporter.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_kubernetes_exporter.go
@@ -48,5 +48,6 @@ func AddKubernetesExporter(idFactory astmodel.IdentifierFactory) *Stage {
 			}
 
 			return state.WithOverlaidDefinitions(updatedDefs), nil
-		})
+		},
+	)
 }

--- a/v2/tools/generator/internal/codegen/pipeline/add_kubernetes_exporter_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_kubernetes_exporter_test.go
@@ -40,7 +40,8 @@ func TestAddKubernetesExporter_AutomaticallyGeneratesExportedConfigMaps(t *testi
 				})
 				return nil
 			},
-		)).
+		),
+	).
 		To(Succeed())
 
 	configuration := config.NewConfiguration()

--- a/v2/tools/generator/internal/codegen/pipeline/add_operator_spec.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_operator_spec.go
@@ -44,11 +44,13 @@ func AddOperatorSpec(configuration *config.Configuration, idFactory astmodel.Ide
 				dynamicConfigMapExporter := functions.NewConfigMapExporterInterface(
 					resource.Name(),
 					rt,
-					idFactory)
+					idFactory,
+				)
 				dynamicSecretExporter := functions.NewSecretsExporterInterface(
 					resource.Name(),
 					rt,
-					idFactory)
+					idFactory,
+				)
 
 				rt = rt.WithInterface(dynamicConfigMapExporter.ToInterfaceImplementation())
 				rt = rt.WithInterface(dynamicSecretExporter.ToInterfaceImplementation())
@@ -78,8 +80,10 @@ func AddOperatorSpec(configuration *config.Configuration, idFactory astmodel.Ide
 			return StateWithData(
 				state.WithOverlaidDefinitions(result),
 				ExportedConfigMaps,
-				exportedTypeNameConfigMaps), nil
-		})
+				exportedTypeNameConfigMaps,
+			), nil
+		},
+	)
 }
 
 func createOperatorSpecIfNeeded(
@@ -154,7 +158,8 @@ func (ctx configMapContext) withTypeName(typeName astmodel.TypeName) configMapCo
 var identityConfigMapObjectTypeVisit = astmodel.MakeIdentityVisitOfObjectType(
 	func(ot *astmodel.ObjectType, prop *astmodel.PropertyDefinition, ctx configMapContext) (configMapContext, error) {
 		return ctx.withPathElement(prop), nil
-	})
+	},
+)
 
 type configMapTypeWalker struct {
 	configuredProperties map[string]string
@@ -335,7 +340,8 @@ func (b *operatorSpecBuilder) newOperatorSpecProperty(operatorSpec astmodel.Type
 	prop := astmodel.NewPropertyDefinition(
 		astmodel.OperatorSpecProperty,
 		b.idFactory.CreateStringIdentifier(astmodel.OperatorSpecProperty, astmodel.NotExported),
-		operatorSpec.Name()).MakeTypeOptional()
+		operatorSpec.Name(),
+	).MakeTypeOptional()
 	desc := "The specification for configuring operator behavior. " +
 		"This field is interpreted by the operator and not passed directly to Azure"
 	prop = prop.WithDescription(desc)
@@ -347,7 +353,8 @@ func (b *operatorSpecBuilder) newProperty(typ astmodel.Type, propertyName string
 	prop := astmodel.NewPropertyDefinition(
 		b.idFactory.CreatePropertyName(propertyName, astmodel.Exported),
 		b.idFactory.CreateStringIdentifier(propertyName, astmodel.NotExported),
-		typ)
+		typ,
+	)
 	prop = prop.WithDescription(description)
 	prop = prop.MakeTypeOptional()
 
@@ -358,28 +365,32 @@ func (b *operatorSpecBuilder) newSecretsProperty(secretTypeName astmodel.TypeNam
 	return b.newProperty(
 		secretTypeName,
 		astmodel.OperatorSpecSecretsProperty,
-		"configures where to place Azure generated secrets.")
+		"configures where to place Azure generated secrets.",
+	)
 }
 
 func (b *operatorSpecBuilder) newConfigMapProperty(configMapTypeName astmodel.TypeName) *astmodel.PropertyDefinition {
 	return b.newProperty(
 		configMapTypeName,
 		astmodel.OperatorSpecConfigMapsProperty,
-		"configures where to place operator written ConfigMaps.")
+		"configures where to place operator written ConfigMaps.",
+	)
 }
 
 func (b *operatorSpecBuilder) newDynamicConfigMapProperty() *astmodel.PropertyDefinition {
 	return b.newProperty(
 		astmodel.DestinationExpressionCollectionType,
 		astmodel.OperatorSpecConfigMapExpressionsProperty,
-		"configures where to place operator written dynamic ConfigMaps (created with CEL expressions).")
+		"configures where to place operator written dynamic ConfigMaps (created with CEL expressions).",
+	)
 }
 
 func (b *operatorSpecBuilder) newDynamicSecretProperty() *astmodel.PropertyDefinition {
 	return b.newProperty(
 		astmodel.DestinationExpressionCollectionType,
 		astmodel.OperatorSpecSecretExpressionsProperty,
-		"configures where to place operator written dynamic secrets (created with CEL expressions).")
+		"configures where to place operator written dynamic secrets (created with CEL expressions).",
+	)
 }
 
 func (b *operatorSpecBuilder) addSecrets(
@@ -394,7 +405,9 @@ func (b *operatorSpecBuilder) addSecrets(
 	secretsTypeName := resourceName.WithName(
 		b.idFactory.CreateIdentifier(
 			resourceName.Name()+"OperatorSecrets",
-			astmodel.Exported))
+			astmodel.Exported,
+		),
+	)
 	secretsType := astmodel.NewObjectType()
 
 	// Add the "secrets" property to the operator spec
@@ -405,10 +418,12 @@ func (b *operatorSpecBuilder) addSecrets(
 		prop := astmodel.NewPropertyDefinition(
 			b.idFactory.CreatePropertyName(secret, astmodel.Exported),
 			b.idFactory.CreateStringIdentifier(secret, astmodel.NotExported),
-			astmodel.SecretDestinationType).MakeTypeOptional()
+			astmodel.SecretDestinationType,
+		).MakeTypeOptional()
 		desc := fmt.Sprintf(
 			"indicates where the %s secret should be placed. If omitted, the secret will not be retrieved from Azure.",
-			secret)
+			secret,
+		)
 		prop = prop.WithDescription(desc)
 		prop = prop.MakeOptional()
 		secretsType = secretsType.WithProperty(prop)
@@ -430,7 +445,9 @@ func (b *operatorSpecBuilder) addConfigs(
 	configMapTypeName := resourceName.WithName(
 		b.idFactory.CreateIdentifier(
 			resourceName.Name()+"OperatorConfigMaps",
-			astmodel.Exported))
+			astmodel.Exported,
+		),
+	)
 	configMapsType := astmodel.NewObjectType()
 
 	// Add the "configMaps" property to the operator spec
@@ -441,10 +458,12 @@ func (b *operatorSpecBuilder) addConfigs(
 		prop := astmodel.NewPropertyDefinition(
 			b.idFactory.CreatePropertyName(exportedConfig, astmodel.Exported),
 			b.idFactory.CreateStringIdentifier(exportedConfig, astmodel.NotExported),
-			astmodel.ConfigMapDestinationType).MakeTypeOptional()
+			astmodel.ConfigMapDestinationType,
+		).MakeTypeOptional()
 		desc := fmt.Sprintf(
 			"indicates where the %s config map should be placed. If omitted, no config map will be created.",
-			exportedConfig)
+			exportedConfig,
+		)
 		prop = prop.WithDescription(desc)
 		prop = prop.MakeOptional()
 		configMapsType = configMapsType.WithProperty(prop)
@@ -466,14 +485,16 @@ func (b *operatorSpecBuilder) addCustomProperties(
 		if !ok {
 			b.errs = append(
 				b.errs,
-				eris.Errorf("unknown type %q for custom OperatorSpec property %q", prop.Type, prop.Name))
+				eris.Errorf("unknown type %q for custom OperatorSpec property %q", prop.Type, prop.Name),
+			)
 			continue
 		}
 
 		property := astmodel.NewPropertyDefinition(
 			b.idFactory.CreatePropertyName(prop.Name, astmodel.Exported),
 			b.idFactory.CreateStringIdentifier(prop.Name, astmodel.NotExported),
-			propertyType).
+			propertyType,
+		).
 			MakeTypeOptional().
 			WithDescription(prop.Description)
 		b.operatorSpecType = b.operatorSpecType.WithProperty(property)
@@ -486,12 +507,14 @@ func (b *operatorSpecBuilder) build() (astmodel.TypeDefinition, error) {
 			eris.Wrapf(
 				kerrors.NewAggregate(b.errs),
 				"failed to build OperatorSpec for %q",
-				b.resource.Name())
+				b.resource.Name(),
+			)
 	}
 
 	def := astmodel.MakeTypeDefinition(
 		b.operatorSpecName,
-		b.operatorSpecType)
+		b.operatorSpecType,
+	)
 
 	description := "Details for configuring operator behavior. Fields in this struct are " +
 		"interpreted by the operator directly rather than being passed to Azure"

--- a/v2/tools/generator/internal/codegen/pipeline/add_operator_spec_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_operator_spec_test.go
@@ -36,7 +36,9 @@ func TestGolden_AddOperatorSpec_AddsSpecWithConfiguredSecrets(t *testing.T) {
 			func(tc *config.TypeConfiguration) error {
 				tc.AzureGeneratedSecrets.Set([]string{"key1"})
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 
 	configuration := config.NewConfiguration()
@@ -76,7 +78,8 @@ func TestAddOperatorSpec_AddsSpecWithConfiguredConfigMaps(t *testing.T) {
 				})
 				return nil
 			},
-		)).
+		),
+	).
 		To(Succeed())
 
 	configuration := config.NewConfiguration()
@@ -113,7 +116,9 @@ func TestAddOperatorSpec_AddsSpecWithManualConfigMaps(t *testing.T) {
 			func(tc *config.TypeConfiguration) error {
 				tc.ManualConfigs.Set([]string{"config1"})
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 
 	configuration := config.NewConfiguration()

--- a/v2/tools/generator/internal/codegen/pipeline/add_secrets.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_secrets.go
@@ -42,7 +42,8 @@ func AddSecrets(config *config.Configuration) *Stage {
 			}
 
 			return state.WithOverlaidDefinitions(astmodel.TypesDisjointUnion(updatedSpecs, updatedStatuses)), nil
-		})
+		},
+	)
 
 	stage.RequiresPostrequisiteStages(CreateARMTypesStageID)
 
@@ -77,7 +78,8 @@ func applyConfigSecretOverrides(
 				// and we don't have config to tell us for sure
 				return nil, eris.Errorf(
 					"property %s might be a secret and must be configured with $importSecretMode",
-					prop.PropertyName())
+					prop.PropertyName(),
+				)
 			}
 
 			if secrecyConfigured {
@@ -111,7 +113,8 @@ func applyConfigSecretOverrides(
 	if len(errs) > 0 {
 		return nil, eris.Wrap(
 			kerrors.NewAggregate(errs),
-			"encountered errors while applying config secrets")
+			"encountered errors while applying config secrets",
+		)
 	}
 
 	// Verify that all 'isSecret' modifiers are consumed before returning the result
@@ -119,7 +122,8 @@ func applyConfigSecretOverrides(
 	if err != nil {
 		return nil, eris.Wrap(
 			err,
-			"Found unused $importSecretMode configurations; these need to be fixed or removed.")
+			"Found unused $importSecretMode configurations; these need to be fixed or removed.",
+		)
 	}
 
 	return result, nil
@@ -286,7 +290,8 @@ func removeSecretProperties(_ *astmodel.TypeVisitor[any], it *astmodel.ObjectTyp
 				return nil, eris.Errorf(
 					"expected property %q to be a string, optional string, map[string]string, or []string, but was: %s",
 					prop.PropertyName(),
-					astmodel.DebugDescription(propType))
+					astmodel.DebugDescription(propType),
+				)
 			}
 
 			it = it.WithoutProperty(prop.PropertyName())
@@ -308,7 +313,8 @@ func transformSecretProperties(_ *astmodel.TypeVisitor[any], it *astmodel.Object
 				return nil, eris.Errorf(
 					"expected property %q to be a string, optional string, map[string]string, or []string, but was: %s",
 					prop.PropertyName(),
-					astmodel.DebugDescription(propType))
+					astmodel.DebugDescription(propType),
+				)
 			}
 
 			// Work out the secret reference type
@@ -336,7 +342,8 @@ func transformSecretProperties(_ *astmodel.TypeVisitor[any], it *astmodel.Object
 				if _, ok := it.Property(newProp.PropertyName()); ok {
 					return nil, eris.Errorf(
 						"property %q already exists on type, can't create optional secret pair",
-						newProp.PropertyName())
+						newProp.PropertyName(),
+					)
 				}
 
 				it = it.WithProperty(newProp)

--- a/v2/tools/generator/internal/codegen/pipeline/add_serialization_type_tag.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_serialization_type_tag.go
@@ -47,7 +47,8 @@ func AddSerializationTypeTag(configuration *config.Configuration) *Stage {
 			}
 
 			return state.WithDefinitions(updatedDefs), nil
-		})
+		},
+	)
 }
 
 type serializationVisitorContext struct {
@@ -72,7 +73,8 @@ func applySerializationTypeTag(it *astmodel.TypeVisitor[*serializationVisitorCon
 
 			prop = prop.WithTag(astmodel.SerializationType, astmodel.SerializationTypeExplicitEmptyCollection)
 			updatedProps = append(updatedProps, prop)
-		})
+		},
+	)
 
 	ot = ot.WithProperties(updatedProps...).WithProperties(updatedProps...)
 

--- a/v2/tools/generator/internal/codegen/pipeline/add_simple_cross_resource_references.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_simple_cross_resource_references.go
@@ -26,5 +26,6 @@ func TransformCrossResourceReferencesToString() *Stage {
 			}
 
 			return state.WithDefinitions(updatedDefs), nil
-		})
+		},
+	)
 }

--- a/v2/tools/generator/internal/codegen/pipeline/add_status_conditions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_status_conditions.go
@@ -30,7 +30,8 @@ func AddStatusConditions(idFactory astmodel.IdentifierFactory) *Stage {
 				conditionsProp := astmodel.NewPropertyDefinition(
 					astmodel.ConditionsProperty,
 					"conditions",
-					astmodel.NewArrayType(astmodel.ConditionType))
+					astmodel.NewArrayType(astmodel.ConditionType),
+				)
 				conditionsProp = conditionsProp.WithDescription("The observed state of the resource").MakeOptional()
 				updatedDef, err := propInjector.Inject(def, conditionsProp)
 				if err != nil {
@@ -59,7 +60,8 @@ func AddStatusConditions(idFactory astmodel.IdentifierFactory) *Stage {
 			}
 
 			return state.WithOverlaidDefinitions(result), nil
-		})
+		},
+	)
 }
 
 // NewConditionerInterfaceImpl creates an InterfaceImplementation with GetConditions() and
@@ -73,19 +75,22 @@ func NewConditionerInterfaceImpl(
 		resource,
 		idFactory,
 		functions.GetConditionsFunction,
-		astmodel.GenRuntimeConditionsReference)
+		astmodel.GenRuntimeConditionsReference,
+	)
 
 	setConditions := functions.NewResourceFunction(
 		"Set"+astmodel.ConditionsProperty,
 		resource,
 		idFactory,
 		functions.SetConditionsFunction,
-		astmodel.GenRuntimeConditionsReference)
+		astmodel.GenRuntimeConditionsReference,
+	)
 
 	result := astmodel.NewInterfaceImplementation(
 		astmodel.ConditionerType,
 		getConditions,
-		setConditions)
+		setConditions,
+	)
 
 	return result, nil
 }

--- a/v2/tools/generator/internal/codegen/pipeline/add_status_conditions_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_status_conditions_test.go
@@ -31,7 +31,8 @@ func TestGolden_AddStatusConditions(t *testing.T) {
 	initialState := NewState(defs)
 	finalState, err := RunTestPipeline(
 		initialState,
-		AddStatusConditions(idFactory))
+		AddStatusConditions(idFactory),
+	)
 	g.Expect(err).To(Succeed())
 
 	// When verifying the golden file, check to ensure that the Conditions property on the Status type looks correct,

--- a/v2/tools/generator/internal/codegen/pipeline/apply_cross_resource_references_from_config.go
+++ b/v2/tools/generator/internal/codegen/pipeline/apply_cross_resource_references_from_config.go
@@ -81,7 +81,8 @@ func ApplyCrossResourceReferencesFromConfig(
 						eris.Errorf(
 							"%s.%s looks like a resource reference but was not labelled as one; You may need to add it to the 'objectModelConfiguration' section of the config file",
 							typeName,
-							prop.PropertyName()),
+							prop.PropertyName(),
+						),
 					)
 				}
 
@@ -133,11 +134,13 @@ func ApplyCrossResourceReferencesFromConfig(
 			if err != nil {
 				return nil, eris.Wrap(
 					err,
-					"Found unused $armReference configurations; these need to be fixed or removed.")
+					"Found unused $armReference configurations; these need to be fixed or removed.",
+				)
 			}
 
 			return state.WithDefinitions(typesWithARMIDs), nil
-		})
+		},
+	)
 }
 
 type crossResourceReferenceChecker func(typeName astmodel.InternalTypeName, prop *astmodel.PropertyDefinition) ReferenceType
@@ -193,7 +196,8 @@ func MakeARMIDPropertyTypeVisitor(
 					"definition", ctx,
 					"property", prop.PropertyName(),
 					"was", wasType,
-					"now", nowType)
+					"now", nowType,
+				)
 			}
 
 			newProps = append(newProps, prop)

--- a/v2/tools/generator/internal/codegen/pipeline/apply_defaulter_and_validator_interfaces.go
+++ b/v2/tools/generator/internal/codegen/pipeline/apply_defaulter_and_validator_interfaces.go
@@ -69,7 +69,8 @@ func ApplyDefaulterAndValidatorInterfaces(configuration *config.Configuration, i
 			}
 
 			return state.WithOverlaidDefinitions(updatedDefs), nil
-		})
+		},
+	)
 
 	stage.RequiresPrerequisiteStages(ApplyKubernetesResourceInterfaceStageID, AddOperatorSpecStageID)
 	return stage
@@ -124,10 +125,12 @@ func getValidations(
 	if !resource.Owner().IsEmpty() {
 		validations[functions.ValidationKindCreate] = append(
 			validations[functions.ValidationKindCreate],
-			functions.NewValidateOwnerReferenceFunction(resourceDef, idFactory))
+			functions.NewValidateOwnerReferenceFunction(resourceDef, idFactory),
+		)
 		validations[functions.ValidationKindUpdate] = append(
 			validations[functions.ValidationKindUpdate],
-			functions.NewValidateOwnerReferenceFunction(resourceDef, idFactory))
+			functions.NewValidateOwnerReferenceFunction(resourceDef, idFactory),
+		)
 	}
 
 	// The expectation is that every resource has an Spec.OperatorSpec.SecretExpressions and
@@ -135,16 +138,20 @@ func getValidations(
 	// If this assumption has been violated, generating the validation function will raise an error.
 	validations[functions.ValidationKindCreate] = append(
 		validations[functions.ValidationKindCreate],
-		NewValidateSecretDestinationsFunction(resourceDef, idFactory))
+		NewValidateSecretDestinationsFunction(resourceDef, idFactory),
+	)
 	validations[functions.ValidationKindUpdate] = append(
 		validations[functions.ValidationKindUpdate],
-		NewValidateSecretDestinationsFunction(resourceDef, idFactory))
+		NewValidateSecretDestinationsFunction(resourceDef, idFactory),
+	)
 	validations[functions.ValidationKindCreate] = append(
 		validations[functions.ValidationKindCreate],
-		NewValidateConfigMapDestinationsFunction(resourceDef, idFactory))
+		NewValidateConfigMapDestinationsFunction(resourceDef, idFactory),
+	)
 	validations[functions.ValidationKindUpdate] = append(
 		validations[functions.ValidationKindUpdate],
-		NewValidateConfigMapDestinationsFunction(resourceDef, idFactory))
+		NewValidateConfigMapDestinationsFunction(resourceDef, idFactory),
+	)
 
 	hasConfigMapReferencePairs, err := hasOptionalConfigMapReferencePairs(resourceDef, defs)
 	if err != nil {
@@ -153,10 +160,12 @@ func getValidations(
 	if hasConfigMapReferencePairs {
 		validations[functions.ValidationKindCreate] = append(
 			validations[functions.ValidationKindCreate],
-			functions.NewValidateOptionalConfigMapReferenceFunction(resourceDef, idFactory))
+			functions.NewValidateOptionalConfigMapReferenceFunction(resourceDef, idFactory),
+		)
 		validations[functions.ValidationKindUpdate] = append(
 			validations[functions.ValidationKindUpdate],
-			functions.NewValidateOptionalConfigMapReferenceFunction(resourceDef, idFactory))
+			functions.NewValidateOptionalConfigMapReferenceFunction(resourceDef, idFactory),
+		)
 	}
 
 	hasSecretReferencePairs, err := hasOptionalSecretReferencePairs(resourceDef, defs)
@@ -166,10 +175,12 @@ func getValidations(
 	if hasSecretReferencePairs {
 		validations[functions.ValidationKindCreate] = append(
 			validations[functions.ValidationKindCreate],
-			functions.NewValidateOptionalSecretReferenceFunction(resourceDef, idFactory))
+			functions.NewValidateOptionalSecretReferenceFunction(resourceDef, idFactory),
+		)
 		validations[functions.ValidationKindUpdate] = append(
 			validations[functions.ValidationKindUpdate],
-			functions.NewValidateOptionalSecretReferenceFunction(resourceDef, idFactory))
+			functions.NewValidateOptionalSecretReferenceFunction(resourceDef, idFactory),
+		)
 	}
 
 	return validations, nil
@@ -193,7 +204,8 @@ func NewValidateSecretDestinationsFunction(resourceDef astmodel.TypeDefinition, 
 		resourceDef.Name(),
 		idFactory,
 		validateSecretDestinations(resourceDef),
-		astmodel.GenRuntimeSecretsReference)
+		astmodel.GenRuntimeSecretsReference,
+	)
 }
 
 func validateSecretDestinations(resourceDef astmodel.TypeDefinition) functions.DataFunctionHandler[astmodel.InternalTypeName] {
@@ -221,7 +233,8 @@ func validateSecretDestinations(resourceDef astmodel.TypeDefinition) functions.D
 			astmodel.OperatorSpecSecretExpressionsProperty,
 			astmodel.NewOptionalType(astmodel.SecretDestinationType),
 			astmodel.GenRuntimeSecretsReference,
-			"ValidateDestinations")
+			"ValidateDestinations",
+		)
 		if err != nil {
 			return nil, eris.Wrapf(err, "creating body of method %s", methodName)
 		}
@@ -267,7 +280,8 @@ func NewValidateConfigMapDestinationsFunction(resourceDef astmodel.TypeDefinitio
 		resourceDef.Name(),
 		idFactory,
 		validateConfigMapDestinations(resourceDef),
-		astmodel.GenRuntimeConfigMapsReference)
+		astmodel.GenRuntimeConfigMapsReference,
+	)
 }
 
 func validateConfigMapDestinations(resourceDef astmodel.TypeDefinition) functions.DataFunctionHandler[astmodel.InternalTypeName] {
@@ -295,7 +309,8 @@ func validateConfigMapDestinations(resourceDef astmodel.TypeDefinition) function
 			astmodel.OperatorSpecConfigMapExpressionsProperty,
 			astmodel.NewOptionalType(astmodel.ConfigMapDestinationType),
 			astmodel.GenRuntimeConfigMapsReference,
-			"ValidateDestinations")
+			"ValidateDestinations",
+		)
 		if err != nil {
 			return nil, eris.Wrapf(err, "creating body of method %s", methodName)
 		}
@@ -371,7 +386,8 @@ func validateOperatorSpecSliceBody(
 		return nil, eris.Errorf(
 			"can't generate method for validating OperatorSpec %s and %s if both fields don't exist",
 			property,
-			expressionsProperty)
+			expressionsProperty,
+		)
 	}
 
 	var body []dst.Stmt
@@ -416,7 +432,9 @@ func validateOperatorSpecSliceBody(
 			body,
 			astbuilder.IfNotNil(
 				propertySelector,
-				astbuilder.AssignmentStatement(dst.NewIdent(toValidateVar), token.ASSIGN, sliceBuilder.Build())))
+				astbuilder.AssignmentStatement(dst.NewIdent(toValidateVar), token.ASSIGN, sliceBuilder.Build()),
+			),
+		)
 	}
 
 	selfParameter := dst.NewIdent(objIdent)
@@ -441,7 +459,10 @@ func validateOperatorSpecSliceBody(
 				validateFunctionName,
 				selfParameter,
 				toValidateParameter,
-				expressionsToValidateParameter)))
+				expressionsToValidateParameter,
+			),
+		),
+	)
 
 	return body, nil
 }
@@ -467,7 +488,8 @@ func getOperatorSpecType(defs astmodel.ReadonlyTypeDefinitions, resource *astmod
 		return nil, eris.Errorf(
 			"expected %s to be an astmodel.TypeName, but it was %T",
 			astmodel.OperatorSpecProperty,
-			operatorSpecProp.PropertyType())
+			operatorSpecProp.PropertyType(),
+		)
 	}
 
 	operatorSpecDef, err := defs.GetDefinition(operatorSpecTypeName)
@@ -479,7 +501,8 @@ func getOperatorSpecType(defs astmodel.ReadonlyTypeDefinitions, resource *astmod
 		return nil, eris.Errorf(
 			"expected %s to be an astmodel.ObjectType but it was %T",
 			operatorSpecTypeName,
-			operatorSpecDef.Type())
+			operatorSpecDef.Type(),
+		)
 	}
 
 	return operatorSpecType, nil
@@ -526,7 +549,8 @@ func getOperatorSpecSubType(defs astmodel.ReadonlyTypeDefinitions, resource *ast
 		return nil, eris.Errorf(
 			"expected %s to be an astmodel.InternalTypeName, but it was %T",
 			name,
-			prop.PropertyType())
+			prop.PropertyType(),
+		)
 	}
 	def, err := defs.GetDefinition(typeName)
 	if err != nil {
@@ -551,7 +575,8 @@ func hasOptionalConfigMapReferencePairs(resourceDef astmodel.TypeDefinition, def
 				}
 
 				return ctx, nil
-			}),
+			},
+		),
 	}.Build()
 
 	walker := astmodel.NewTypeWalker(defs, visitor)
@@ -574,7 +599,8 @@ func hasOptionalSecretReferencePairs(resourceDef astmodel.TypeDefinition, defs a
 				}
 
 				return ctx, nil
-			}),
+			},
+		),
 	}.Build()
 
 	walker := astmodel.NewTypeWalker(defs, visitor)

--- a/v2/tools/generator/internal/codegen/pipeline/apply_export_filters.go
+++ b/v2/tools/generator/internal/codegen/pipeline/apply_export_filters.go
@@ -27,7 +27,8 @@ func ApplyExportFilters(
 		"Apply export filters to reduce the number of generated types",
 		func(ctx context.Context, state *State) (*State, error) {
 			return filterTypes(configuration, state, log)
-		})
+		},
+	)
 
 	stage.RequiresPostrequisiteStages(VerifyNoErroredTypesStageID)
 	return stage
@@ -74,7 +75,8 @@ func filterTypes(
 				"can't rename %s to %s, name is already used by %s",
 				name,
 				newName,
-				existing.Name())
+				existing.Name(),
+			)
 		}
 
 		renames[name] = n

--- a/v2/tools/generator/internal/codegen/pipeline/apply_is_resource_overrides.go
+++ b/v2/tools/generator/internal/codegen/pipeline/apply_is_resource_overrides.go
@@ -52,7 +52,8 @@ func ApplyIsResourceOverrides(configuration *config.Configuration) *Stage {
 
 			state = state.WithOverlaidDefinitions(updatedDefs)
 			return state, nil
-		})
+		},
+	)
 
 	return stage
 }

--- a/v2/tools/generator/internal/codegen/pipeline/apply_kubernetes_resource_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/apply_kubernetes_resource_interface.go
@@ -33,7 +33,8 @@ func ApplyKubernetesResourceInterface(
 					typeDef,
 					idFactory,
 					state.Definitions(),
-					log)
+					log,
+				)
 				if err != nil {
 					return nil, eris.Wrapf(err, "couldn't implement Kubernetes resource interface for %q", typeName)
 				}
@@ -42,5 +43,6 @@ func ApplyKubernetesResourceInterface(
 			}
 
 			return state.WithOverlaidDefinitions(updatedDefs), nil
-		})
+		},
+	)
 }

--- a/v2/tools/generator/internal/codegen/pipeline/apply_type_rewrites.go
+++ b/v2/tools/generator/internal/codegen/pipeline/apply_type_rewrites.go
@@ -38,7 +38,8 @@ func ApplyTypeRewrites(
 				// When we remove type aliases later in the pipeline, these will result in any references being updated
 				if newDef.Name() != def.Name() {
 					alias := astmodel.MakeTypeDefinition(
-						def.Name(), newDef.Name())
+						def.Name(), newDef.Name(),
+					)
 					definitions.Add(alias)
 				}
 			}
@@ -49,7 +50,8 @@ func ApplyTypeRewrites(
 			}
 
 			return state.WithDefinitions(definitions), nil
-		})
+		},
+	)
 
 	stage.RequiresPrerequisiteStages("nameTypes", "allof-anyof-objects")
 
@@ -77,7 +79,8 @@ func transformDefinition(
 				"Transforming type",
 				"type", name,
 				"because", transformer.Because,
-				"transformation", result.Type())
+				"transformation", result.Type(),
+			)
 
 			def = result
 		}

--- a/v2/tools/generator/internal/codegen/pipeline/assemble_oneof.go
+++ b/v2/tools/generator/internal/codegen/pipeline/assemble_oneof.go
@@ -28,7 +28,8 @@ func AssembleOneOfTypes(idFactory astmodel.IdentifierFactory) *Stage {
 				return nil, eris.Wrapf(err, "assembling OneOf types")
 			}
 			return state.WithOverlaidDefinitions(newDefs), nil
-		})
+		},
+	)
 
 	return stage
 }
@@ -214,7 +215,8 @@ func (oa *oneOfAssembler) removeCommonPropertiesFromRoot(root astmodel.InternalT
 		func(oneOf *astmodel.OneOfType) (*astmodel.OneOfType, error) {
 			result := oneOf.WithoutAnyPropertyObjects()
 			return result, nil
-		})
+		},
+	)
 
 	return eris.Wrapf(err, "removing common properties from root %s", root)
 }
@@ -227,7 +229,8 @@ func (oa *oneOfAssembler) removeParentReferenceFromLeaf(parent astmodel.TypeName
 		leaf,
 		func(oneOf *astmodel.OneOfType) (*astmodel.OneOfType, error) {
 			return oneOf.WithoutType(parent), nil
-		})
+		},
+	)
 	return eris.Wrapf(err, "removing parent reference from leaf %s", leaf)
 }
 
@@ -249,7 +252,8 @@ func (oa *oneOfAssembler) embedCommonPropertiesInLeaf(parent astmodel.InternalTy
 			}
 
 			return result, nil
-		})
+		},
+	)
 
 	return eris.Wrapf(err, "embedding common properties from OneOf in leaf %s", leaf)
 }
@@ -289,7 +293,8 @@ func (oa *oneOfAssembler) addLeafReferenceToRoot(root astmodel.InternalTypeName,
 		root,
 		func(oneOf *astmodel.OneOfType) (*astmodel.OneOfType, error) {
 			return oneOf.WithType(leaf), nil
-		})
+		},
+	)
 
 	return eris.Wrapf(err, "adding leaf reference %s to root %s", leaf, root)
 }
@@ -315,16 +320,19 @@ func (oa *oneOfAssembler) addDiscriminatorProperty(name astmodel.InternalTypeNam
 			// Create the discriminator property as a single valued enum
 			enumType := astmodel.NewEnumType(
 				astmodel.StringType,
-				astmodel.MakeEnumValue(valueName, fmt.Sprintf("%q", discriminatorValue)))
+				astmodel.MakeEnumValue(valueName, fmt.Sprintf("%q", discriminatorValue)),
+			)
 
 			property := astmodel.NewPropertyDefinition(
 				propertyName,
 				propertyJSON,
-				astmodel.NewOptionalType(enumType))
+				astmodel.NewOptionalType(enumType),
+			)
 
 			obj := astmodel.NewObjectType().WithProperty(property)
 			return oneOf.WithAdditionalPropertyObject(obj), nil
-		})
+		},
+	)
 
 	return err
 }

--- a/v2/tools/generator/internal/codegen/pipeline/assert_types_collection_valid.go
+++ b/v2/tools/generator/internal/codegen/pipeline/assert_types_collection_valid.go
@@ -33,5 +33,6 @@ func AssertTypesCollectionValid() *Stage {
 			}
 
 			return state, nil
-		})
+		},
+	)
 }

--- a/v2/tools/generator/internal/codegen/pipeline/catalog_known_resources.go
+++ b/v2/tools/generator/internal/codegen/pipeline/catalog_known_resources.go
@@ -33,7 +33,8 @@ func CatalogKnownResources() *Stage {
 			}
 
 			return StateWithData(state, AllKnownResources, catalog), nil
-		})
+		},
+	)
 
 	// We're cataloging all known resources, so we have to do this before we reduce the set of
 	// resources we're processing by applying the export filters.

--- a/v2/tools/generator/internal/codegen/pipeline/check_for_anytype.go
+++ b/v2/tools/generator/internal/codegen/pipeline/check_for_anytype.go
@@ -75,7 +75,8 @@ func checkForAnyType(description string, packages []string) *Stage {
 			}
 
 			return state.WithDefinitions(output), nil
-		})
+		},
+	)
 }
 
 func containsAnyType(theType astmodel.Type) bool {
@@ -127,7 +128,8 @@ func collectBadPackages(
 		}
 		sort.Strings(leftovers)
 		return nil, eris.Errorf(
-			"no AnyTypes found in: %s", strings.Join(leftovers, ", "))
+			"no AnyTypes found in: %s", strings.Join(leftovers, ", "),
+		)
 
 	}
 

--- a/v2/tools/generator/internal/codegen/pipeline/collapse_cross_group_refs.go
+++ b/v2/tools/generator/internal/codegen/pipeline/collapse_cross_group_refs.go
@@ -40,7 +40,8 @@ func CollapseCrossGroupReferences(idFactory astmodel.IdentifierFactory) *Stage {
 			}
 
 			return state.WithDefinitions(result), nil
-		})
+		},
+	)
 }
 
 func newTypeWalker(

--- a/v2/tools/generator/internal/codegen/pipeline/convert_allof_and_oneof_to_objects.go
+++ b/v2/tools/generator/internal/codegen/pipeline/convert_allof_and_oneof_to_objects.go
@@ -56,7 +56,8 @@ func ConvertAllOfAndOneOfToObjects(idFactory astmodel.IdentifierFactory) *Stage 
 
 			finalDefs := newDefs.OverlayWith(baseSynthesizer.updatedDefs)
 			return state.WithDefinitions(finalDefs), nil
-		})
+		},
+	)
 }
 
 func createVisitorForSynthesizer(baseSynthesizer synthesizer) astmodel.TypeVisitor[resourceFieldSelector] {
@@ -767,7 +768,8 @@ func (s synthesizer) handleTypeName(leftName astmodel.InternalTypeName, right as
 	if err != nil {
 		return nil, eris.Wrapf(
 			err,
-			"intersecting %s with %s", leftName, astmodel.DebugDescription(right))
+			"intersecting %s with %s", leftName, astmodel.DebugDescription(right),
+		)
 	}
 
 	// TODO: can we somehow process these pointed-to types first,
@@ -914,7 +916,8 @@ func (synthesizer) handleMapObject(leftMap *astmodel.MapType, rightObj *astmodel
 		additionalProps := astmodel.NewPropertyDefinition(
 			astmodel.AdditionalPropertiesPropertyName,
 			astmodel.AdditionalPropertiesJSONName,
-			leftMap)
+			leftMap,
+		)
 
 		return rightObj.WithProperties(additionalProps), nil
 	}
@@ -953,7 +956,8 @@ func (s synthesizer) allOfSlice(types []astmodel.Type) (astmodel.Type, error) {
 			}
 
 			return 0
-		})
+		},
+	)
 
 	var result astmodel.Type = astmodel.AnyType
 	for _, t := range toMerge {

--- a/v2/tools/generator/internal/codegen/pipeline/convert_allof_and_oneof_to_objects_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/convert_allof_and_oneof_to_objects_test.go
@@ -41,7 +41,8 @@ func defineEnum(strings ...string) astmodel.Type {
 
 	return astmodel.NewEnumType(
 		astmodel.StringType,
-		values...)
+		values...,
+	)
 }
 
 // any type merged with AnyType is just the type
@@ -90,7 +91,8 @@ func TestMergeMapObject(t *testing.T) {
 		astmodel.NewPropertyDefinition(
 			astmodel.AdditionalPropertiesPropertyName,
 			astmodel.AdditionalPropertiesJSONName,
-			newMap),
+			newMap,
+		),
 	)
 
 	synth := makeSynth()
@@ -234,13 +236,16 @@ func TestMergeObjectObjectCommonProperties(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	obj1 := astmodel.NewObjectType().WithProperties(
-		astmodel.NewPropertyDefinition("x", "x", defineEnum("a", "b")))
+		astmodel.NewPropertyDefinition("x", "x", defineEnum("a", "b")),
+	)
 
 	obj2 := astmodel.NewObjectType().WithProperties(
-		astmodel.NewPropertyDefinition("x", "x", defineEnum("b", "c")))
+		astmodel.NewPropertyDefinition("x", "x", defineEnum("b", "c")),
+	)
 
 	expected := astmodel.NewObjectType().WithProperties(
-		astmodel.NewPropertyDefinition("x", "x", defineEnum("b")))
+		astmodel.NewPropertyDefinition("x", "x", defineEnum("b")),
+	)
 
 	synth := makeSynth()
 	g.Expect(synth.intersectTypes(obj1, obj2)).To(Equal(expected))
@@ -285,7 +290,8 @@ func TestMergeValidated(t *testing.T) {
 		astmodel.StringType,
 		astmodel.StringValidations{
 			MaxLength: &maxLen,
-		})
+		},
+	)
 
 	synth := makeSynth()
 	g.Expect(synth.intersectTypes(validatedString, astmodel.StringType)).To(Equal(validatedString))
@@ -301,13 +307,15 @@ func TestMergeValidatedOfOptional(t *testing.T) {
 		astmodel.OptionalStringType,
 		astmodel.StringValidations{
 			MaxLength: &maxLen,
-		})
+		},
+	)
 
 	validatedString := astmodel.NewValidatedType(
 		astmodel.StringType,
 		astmodel.StringValidations{
 			MaxLength: &maxLen,
-		})
+		},
+	)
 
 	synth := makeSynth()
 	g.Expect(synth.intersectTypes(validatedOptionalString, astmodel.StringType)).To(Equal(validatedString))
@@ -457,7 +465,8 @@ func TestSynthesizerOneOfObject_GivenOneOfUsingTypeNames_ReturnsExpectedObject(t
 
 	commonProperties := test.CreateObjectType(
 		test.FamilyNameProperty,
-		test.FullNameProperty)
+		test.FullNameProperty,
+	)
 
 	parent := createTestLeafOneOfDefinition(
 		"Parent",
@@ -465,21 +474,24 @@ func TestSynthesizerOneOfObject_GivenOneOfUsingTypeNames_ReturnsExpectedObject(t
 		"", // No discriminator, to force use of type names
 		commonProperties,
 		test.PostalAddress2021,
-		test.ResidentialAddress2021)
+		test.ResidentialAddress2021,
+	)
 
 	child := createTestLeafOneOfDefinition(
 		"Child",
 		"", // No swagger name, to force use of type names
 		"", // No discriminator, to force use of type names
 		commonProperties,
-		test.KnownAsProperty)
+		test.KnownAsProperty,
+	)
 
 	person := createTestRootOneOfDefinition(
 		"Person",
 		"Kind",
 		// Use names to reference leaves
 		parent.Name(),
-		child.Name())
+		child.Name(),
+	)
 
 	synth := makeSynth(parent, child, person)
 
@@ -500,7 +512,8 @@ func TestSynthesizerOneOfObject_GivenOneOfUsingSwaggerNames_ReturnsExpectedObjec
 
 	commonProperties := test.CreateObjectType(
 		test.FamilyNameProperty,
-		test.FullNameProperty)
+		test.FullNameProperty,
+	)
 
 	parent := createTestLeafOneOfDefinition(
 		"Parent",
@@ -508,21 +521,24 @@ func TestSynthesizerOneOfObject_GivenOneOfUsingSwaggerNames_ReturnsExpectedObjec
 		"", // No discriminator, to force use of the Swagger names
 		commonProperties,
 		test.PostalAddress2021,
-		test.ResidentialAddress2021)
+		test.ResidentialAddress2021,
+	)
 
 	child := createTestLeafOneOfDefinition(
 		"Child",
 		"Junior",
 		"", // No discriminator, to force use of the Swagger names
 		commonProperties,
-		test.KnownAsProperty)
+		test.KnownAsProperty,
+	)
 
 	person := createTestRootOneOfDefinition(
 		"Person",
 		"Kind",
 		// Use bodies to ensure we're not using the type names
 		parent.Type(),
-		child.Type())
+		child.Type(),
+	)
 
 	synth := makeSynth(parent, child, person)
 
@@ -543,7 +559,8 @@ func TestSynthesizerOneOfObject_GivenOneOfUsingDiscriminatorValues_ReturnsExpect
 
 	commonProperties := test.CreateObjectType(
 		test.FamilyNameProperty,
-		test.FullNameProperty)
+		test.FullNameProperty,
+	)
 
 	parent := createTestLeafOneOfDefinition(
 		"Parent",
@@ -551,21 +568,24 @@ func TestSynthesizerOneOfObject_GivenOneOfUsingDiscriminatorValues_ReturnsExpect
 		"Maxima",
 		commonProperties,
 		test.PostalAddress2021,
-		test.ResidentialAddress2021)
+		test.ResidentialAddress2021,
+	)
 
 	child := createTestLeafOneOfDefinition(
 		"Child",
 		"", // no swagger name
 		"Minima",
 		commonProperties,
-		test.KnownAsProperty)
+		test.KnownAsProperty,
+	)
 
 	person := createTestRootOneOfDefinition(
 		"Person",
 		"Kind",
 		// Use bodies to ensure we're not using the type names
 		parent.Type(),
-		child.Type())
+		child.Type(),
+	)
 
 	synth := makeSynth(parent, child, person)
 
@@ -616,16 +636,23 @@ func Test_ConversionWithNestedAllOfs_ReturnsExpectedResult(t *testing.T) {
 		astmodel.NewObjectType().
 			WithProperties(
 				astmodel.NewPropertyDefinition(
-					"Location", "location", astmodel.OptionalStringType),
+					"Location", "location", astmodel.OptionalStringType,
+				),
 				astmodel.NewPropertyDefinition(
-					"Tags", "tags", astmodel.NewOptionalType(astmodel.AnyType))))
+					"Tags", "tags", astmodel.NewOptionalType(astmodel.AnyType),
+				),
+			),
+	)
 
 	webTestProperties := astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(test.Pkg2020, "WebTestProperties"),
 		astmodel.NewObjectType().
 			WithProperties(
 				astmodel.NewPropertyDefinition(
-					"Alias", "alias", astmodel.OptionalStringType)))
+					"Alias", "alias", astmodel.OptionalStringType,
+				),
+			),
+	)
 
 	webTest := astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(test.Pkg2020, "WebTest"),
@@ -636,23 +663,33 @@ func Test_ConversionWithNestedAllOfs_ReturnsExpectedResult(t *testing.T) {
 					"Kind", "kind", astmodel.NewOptionalType(astmodel.NewEnumType(
 						astmodel.StringType,
 						astmodel.MakeEnumValue("MultiStep", "multistep"),
-						astmodel.MakeEnumValue("Ping", "ping")))),
-				astmodel.NewPropertyDefinition("Properties", "properties", webTestProperties.Name()))))
+						astmodel.MakeEnumValue("Ping", "ping"),
+					)),
+				),
+				astmodel.NewPropertyDefinition("Properties", "properties", webTestProperties.Name()),
+			),
+		),
+	)
 
 	webTestSpec := astmodel.NewAllOfType(
 		webTest.Name(),
 		astmodel.NewObjectType().WithProperties(
 			astmodel.NewPropertyDefinition("AzureName", "azurename", astmodel.StringType),
-			astmodel.NewPropertyDefinition("Name", "name", astmodel.StringType)))
+			astmodel.NewPropertyDefinition("Name", "name", astmodel.StringType),
+		),
+	)
 
 	webTest_Status := astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(test.Pkg2020, "WebTest_Status"),
 		astmodel.NewObjectType().WithProperties(
-			astmodel.NewPropertyDefinition("Status", "status", astmodel.OptionalStringType)))
+			astmodel.NewPropertyDefinition("Status", "status", astmodel.OptionalStringType),
+		),
+	)
 
 	webTestResource := astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(test.Pkg2020, "WebTestResource"),
-		astmodel.NewResourceType(webTestSpec, webTest_Status.Name()))
+		astmodel.NewResourceType(webTestSpec, webTest_Status.Name()),
+	)
 
 	defs := make(astmodel.TypeDefinitionSet)
 	defs.AddAll(webtestsResource, webTestProperties, webTest, webTest_Status, webTestResource)
@@ -679,25 +716,30 @@ func TestConversionOfSequentialOneOf_ReturnsExpectedResults(t *testing.T) {
 	first := astmodel.NewObjectType().
 		WithProperties(
 			astmodel.NewPropertyDefinition("alpha", "alpha", astmodel.StringType),
-			astmodel.NewPropertyDefinition("beta", "beta", astmodel.StringType))
+			astmodel.NewPropertyDefinition("beta", "beta", astmodel.StringType),
+		)
 
 	second := astmodel.NewObjectType().
 		WithProperties(
 			astmodel.NewPropertyDefinition("gamma", "gamma", astmodel.StringType),
-			astmodel.NewPropertyDefinition("delta", "delta", astmodel.StringType))
+			astmodel.NewPropertyDefinition("delta", "delta", astmodel.StringType),
+		)
 
 	third := astmodel.NewObjectType().
 		WithProperties(
 			astmodel.NewPropertyDefinition("epsilon", "epsilon", astmodel.StringType),
-			astmodel.NewPropertyDefinition("zeta", "zeta", astmodel.StringType))
+			astmodel.NewPropertyDefinition("zeta", "zeta", astmodel.StringType),
+		)
 
 	firstDef := astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(test.Pkg2020, "First"),
-		first)
+		first,
+	)
 
 	allOfDef := astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(test.Pkg2020, "AllOf"),
-		astmodel.NewAllOfType(firstDef.Name(), second, third))
+		astmodel.NewAllOfType(firstDef.Name(), second, third),
+	)
 
 	defs := make(astmodel.TypeDefinitionSet)
 	defs.AddAll(allOfDef, firstDef)
@@ -731,19 +773,24 @@ func TestConversionOfAllOf_WhenContainingOneOf_ReturnsExpectedResult(t *testing.
 				astmodel.NewPropertyDefinition(
 					"KeyVaultURL",
 					"keyVaultUrl",
-					astmodel.StringType),
+					astmodel.StringType,
+				),
 				astmodel.NewPropertyDefinition(
 					"HotCachePeriod",
 					"hotCachePeriod",
-					astmodel.StringType),
+					astmodel.StringType,
+				),
 				astmodel.NewPropertyDefinition(
 					"Kind",
 					"kind",
-					astmodel.NewEnumType(astmodel.StringType, astmodel.MakeEnumValue("ReadWriteDatabase", "ReadWriteDatabase"))),
+					astmodel.NewEnumType(astmodel.StringType, astmodel.MakeEnumValue("ReadWriteDatabase", "ReadWriteDatabase")),
+				),
 				astmodel.NewPropertyDefinition(
 					"Location",
 					"location",
-					astmodel.StringType)),
+					astmodel.StringType,
+				),
+			),
 	)
 
 	readonlyFollowingDatabase := astmodel.MakeTypeDefinition(
@@ -753,19 +800,24 @@ func TestConversionOfAllOf_WhenContainingOneOf_ReturnsExpectedResult(t *testing.
 				astmodel.NewPropertyDefinition(
 					"DatabaseShareOrigin",
 					"databaseShareOrigin",
-					astmodel.StringType),
+					astmodel.StringType,
+				),
 				astmodel.NewPropertyDefinition(
 					"HotCachePeriod",
 					"hotCachePeriod",
-					astmodel.StringType),
+					astmodel.StringType,
+				),
 				astmodel.NewPropertyDefinition(
 					"Kind",
 					"kind",
-					astmodel.NewEnumType(astmodel.StringType, astmodel.MakeEnumValue("ReadOnlyFollowingDatabase", "ReadOnlyFollowingDatabase"))),
+					astmodel.NewEnumType(astmodel.StringType, astmodel.MakeEnumValue("ReadOnlyFollowingDatabase", "ReadOnlyFollowingDatabase")),
+				),
 				astmodel.NewPropertyDefinition(
 					"Location",
 					"location",
-					astmodel.StringType)),
+					astmodel.StringType,
+				),
+			),
 	)
 
 	database := astmodel.MakeTypeDefinition(
@@ -773,7 +825,8 @@ func TestConversionOfAllOf_WhenContainingOneOf_ReturnsExpectedResult(t *testing.
 		astmodel.NewOneOfType(
 			"database",
 			readwriteDatabase.Name(),
-			readonlyFollowingDatabase.Name()).
+			readonlyFollowingDatabase.Name(),
+		).
 			WithDiscriminatorProperty("Kind"),
 	)
 
@@ -791,21 +844,29 @@ func TestConversionOfAllOf_WhenContainingOneOf_ReturnsExpectedResult(t *testing.
 								astmodel.StringType,
 								astmodel.StringValidations{
 									MaxLength: to.Ptr(int64(96)),
-								}))),
+								},
+							),
+						),
+					),
 				astmodel.NewObjectType().
 					WithProperty(
 						astmodel.NewPropertyDefinition(
 							"Name",
 							"name",
-							astmodel.StringType))),
+							astmodel.StringType,
+						),
+					),
+			),
 			astmodel.NewObjectType(),
-		))
+		),
+	)
 
 	defs := astmodel.MakeTypeDefinitionSetFromDefinitions(
 		readwriteDatabase,
 		readonlyFollowingDatabase,
 		database,
-		clusters_database)
+		clusters_database,
+	)
 
 	state := NewState(defs)
 	stage := ConvertAllOfAndOneOfToObjects(idFactory)

--- a/v2/tools/generator/internal/codegen/pipeline/create_arm_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_arm_types.go
@@ -45,7 +45,8 @@ func CreateARMTypes(
 			}
 
 			return state.WithDefinitions(newDefs), nil
-		})
+		},
+	)
 }
 
 type skipError struct{}
@@ -128,7 +129,8 @@ func (c *armTypeCreator) createARMTypes() (astmodel.TypeDefinitionSet, error) {
 				_, isObject := astmodel.AsObjectType(def.Type())
 				_, isEnum := astmodel.AsEnumType(def.Type())
 				return isObject || isEnum
-			})
+			},
+		)
 
 	for name, def := range otherDefs {
 		if !requiresARMType(def) {
@@ -156,7 +158,8 @@ func (c *armTypeCreator) createARMTypesForResource(
 		return eris.Wrapf(
 			err,
 			"resolving resource spec and status for %s",
-			rsrc.Name())
+			rsrc.Name(),
+		)
 	}
 
 	// Create ARM type for the Spec
@@ -165,7 +168,8 @@ func (c *armTypeCreator) createARMTypesForResource(
 		return eris.Wrapf(
 			err,
 			"unable to create arm resource spec definition for resource %s",
-			rsrc.Name())
+			rsrc.Name(),
+		)
 	}
 
 	c.addARMType(resolved.SpecDef, spec)
@@ -178,7 +182,8 @@ func (c *armTypeCreator) createARMTypesForResource(
 			return eris.Wrapf(
 				err,
 				"unable to create arm resource status definition for resource %s",
-				rsrc.Name())
+				rsrc.Name(),
+			)
 		}
 
 		c.addARMType(resolved.StatusDef, status)
@@ -197,7 +202,8 @@ func (c *armTypeCreator) createARMResourceSpecDefinition(
 			eris.Errorf(
 				"expected resource %s to be a resource type, but got %s",
 				rsrcDef.Name(),
-				astmodel.DebugDescription(rsrcDef.Type(), rsrcDef.Name().InternalPackageReference()))
+				astmodel.DebugDescription(rsrcDef.Type(), rsrcDef.Name().InternalPackageReference()),
+			)
 	}
 
 	emptyDef := astmodel.TypeDefinition{}
@@ -284,7 +290,8 @@ func (c *armTypeCreator) createARMObjectTypeDefinition(
 		c.findOneOfLeafPropertiesStillOnRoot(def),
 		c.addOneOfConversionFunctionIfNeeded(def),
 		c.addLeafOneOfPropertiesIfNeeded(def),
-		removeFlattening)
+		removeFlattening,
+	)
 	if err != nil {
 		return astmodel.TypeDefinition{},
 			eris.Wrapf(err, "creating ARM prototype %s from Kubernetes definition %s", armName, def.Name())
@@ -387,7 +394,8 @@ func (c *armTypeCreator) addOneOfConversionFunctionIfNeeded(
 		if isOneOf {
 			c.log.V(1).Info(
 				"Adding MarshalJSON and UnmarshalJSON to OneOf",
-				"type", def.Name())
+				"type", def.Name(),
+			)
 			marshal := functions.NewOneOfJSONMarshalFunction(t, c.idFactory)
 			unmarshal := functions.NewOneOfJSONUnmarshalFunction(t, c.idFactory)
 			return t.WithFunction(marshal).WithFunction(unmarshal), nil
@@ -445,7 +453,8 @@ func (c *armTypeCreator) createUserAssignedIdentitiesProperty(
 	newProp := astmodel.NewPropertyDefinition(
 		c.idFactory.CreatePropertyName(astmodel.UserAssignedIdentitiesProperty, astmodel.Exported),
 		c.idFactory.CreateStringIdentifier(astmodel.UserAssignedIdentitiesProperty, astmodel.NotExported),
-		newPropType).MakeTypeOptional()
+		newPropType,
+	).MakeTypeOptional()
 
 	err := c.armDefs.AddAllowDuplicates(newDef)
 	if err != nil {
@@ -486,7 +495,8 @@ func (c *armTypeCreator) createResourceReferenceProperty(
 	newProp := astmodel.NewPropertyDefinition(
 		c.idFactory.CreatePropertyName(armPropName, astmodel.Exported),
 		c.idFactory.CreateStringIdentifier(armPropName, astmodel.NotExported),
-		newPropType).
+		newPropType,
+	).
 		MakeTypeOptional().
 		WithDescription(prop.Description())
 

--- a/v2/tools/generator/internal/codegen/pipeline/create_arm_types_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_arm_types_test.go
@@ -31,11 +31,13 @@ func TestCreateFlattenedARMType_CreatesExpectedConversions(t *testing.T) {
 		"PersonProperties",
 		test.FullNameProperty,
 		test.FamilyNameProperty,
-		test.KnownAsProperty)
+		test.KnownAsProperty,
+	)
 	specPropertiesProp := astmodel.NewPropertyDefinition(
 		"Properties",
 		"properties",
-		specProperties.Name()).SetFlatten(true).MakeTypeOptional()
+		specProperties.Name(),
+	).SetFlatten(true).MakeTypeOptional()
 	spec := test.CreateSpec(test.Pkg2020, "Person", specPropertiesProp, test.NameProperty)
 	status := test.CreateStatus(test.Pkg2020, "Person")
 	resource := test.CreateARMResource(test.Pkg2020, "Person", spec, status, test.Pkg2020APIVersion)
@@ -58,7 +60,8 @@ func TestCreateFlattenedARMType_CreatesExpectedConversions(t *testing.T) {
 		applyARMConversionInterface,
 		flatten,
 		simplify,
-		strip)
+		strip,
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	test.AssertPackagesGenerateExpectedCode(t, state.Definitions())
@@ -74,11 +77,13 @@ func TestCreateFlattenedARMTypeWithResourceRef_CreatesExpectedConversions(t *tes
 		"PersonProperties",
 		test.FullNameProperty,
 		test.FamilyNameProperty,
-		test.KnownAsProperty)
+		test.KnownAsProperty,
+	)
 	specPropertiesProp := astmodel.NewPropertyDefinition(
 		"Properties",
 		"properties",
-		specProperties.Name()).SetFlatten(true).MakeTypeOptional()
+		specProperties.Name(),
+	).SetFlatten(true).MakeTypeOptional()
 	spec := test.CreateSpec(test.Pkg2020, "Person", specPropertiesProp, test.NameProperty)
 	status := test.CreateStatus(test.Pkg2020, "Person")
 	resource := test.CreateARMResource(test.Pkg2020, "Person", spec, status, test.Pkg2020APIVersion)
@@ -95,7 +100,9 @@ func TestCreateFlattenedARMTypeWithResourceRef_CreatesExpectedConversions(t *tes
 			func(propertyConfiguration *config.PropertyConfiguration) error {
 				propertyConfiguration.ReferenceType.Set(config.ReferenceTypeARM)
 				return nil
-			})).To(Succeed())
+			},
+		),
+	).To(Succeed())
 
 	configuration := config.NewConfiguration()
 	configuration.ObjectModelConfiguration = omc
@@ -116,7 +123,8 @@ func TestCreateFlattenedARMTypeWithResourceRef_CreatesExpectedConversions(t *tes
 		applyARMConversionInterface,
 		flatten,
 		simplify,
-		strip)
+		strip,
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	test.AssertPackagesGenerateExpectedCode(t, state.Definitions())
@@ -132,11 +140,13 @@ func TestCreateFlattenedARMTypeWithConfigMap_CreatesExpectedConversions(t *testi
 		"PersonProperties",
 		test.FullNameProperty,
 		test.FamilyNameProperty,
-		test.KnownAsProperty)
+		test.KnownAsProperty,
+	)
 	specPropertiesProp := astmodel.NewPropertyDefinition(
 		"Properties",
 		"properties",
-		specProperties.Name()).SetFlatten(true).MakeTypeOptional()
+		specProperties.Name(),
+	).SetFlatten(true).MakeTypeOptional()
 	spec := test.CreateSpec(test.Pkg2020, "Person", specPropertiesProp, test.NameProperty)
 	status := test.CreateStatus(test.Pkg2020, "Person")
 	resource := test.CreateARMResource(test.Pkg2020, "Person", spec, status, test.Pkg2020APIVersion)
@@ -153,7 +163,9 @@ func TestCreateFlattenedARMTypeWithConfigMap_CreatesExpectedConversions(t *testi
 			func(pc *config.PropertyConfiguration) error {
 				pc.ImportConfigMapMode.Set(config.ImportConfigMapModeRequired)
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 	g.Expect(
 		omc.ModifyProperty(
@@ -162,7 +174,9 @@ func TestCreateFlattenedARMTypeWithConfigMap_CreatesExpectedConversions(t *testi
 			func(pc *config.PropertyConfiguration) error {
 				pc.ImportConfigMapMode.Set(config.ImportConfigMapModeOptional)
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 
 	configuration := config.NewConfiguration()
@@ -182,7 +196,8 @@ func TestCreateFlattenedARMTypeWithConfigMap_CreatesExpectedConversions(t *testi
 		applyARMConversionInterface,
 		flatten,
 		simplify,
-		strip)
+		strip,
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	test.AssertPackagesGenerateExpectedCode(t, state.Definitions())
@@ -199,11 +214,13 @@ func TestCreateARMTypeWithConfigMap_CreatesExpectedConversions(t *testing.T) {
 		test.FullNameProperty,
 		test.FamilyNameProperty,
 		test.KnownAsProperty,
-		test.RestrictedNameProperty)
+		test.RestrictedNameProperty,
+	)
 	specPropertiesProp := astmodel.NewPropertyDefinition(
 		"Properties",
 		"properties",
-		specProperties.Name()).MakeTypeOptional()
+		specProperties.Name(),
+	).MakeTypeOptional()
 	spec := test.CreateSpec(test.Pkg2020, "Person", specPropertiesProp, test.NameProperty)
 	status := test.CreateStatus(test.Pkg2020, "Person")
 	resource := test.CreateARMResource(test.Pkg2020, "Person", spec, status, test.Pkg2020APIVersion)
@@ -220,7 +237,9 @@ func TestCreateARMTypeWithConfigMap_CreatesExpectedConversions(t *testing.T) {
 			func(pc *config.PropertyConfiguration) error {
 				pc.ImportConfigMapMode.Set(config.ImportConfigMapModeRequired)
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 	g.Expect(
 		omc.ModifyProperty(
@@ -229,7 +248,9 @@ func TestCreateARMTypeWithConfigMap_CreatesExpectedConversions(t *testing.T) {
 			func(pc *config.PropertyConfiguration) error {
 				pc.ImportConfigMapMode.Set(config.ImportConfigMapModeOptional)
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 	g.Expect(
 		omc.ModifyProperty(
@@ -238,7 +259,9 @@ func TestCreateARMTypeWithConfigMap_CreatesExpectedConversions(t *testing.T) {
 			func(pc *config.PropertyConfiguration) error {
 				pc.ImportConfigMapMode.Set(config.ImportConfigMapModeOptional)
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 
 	configuration := config.NewConfiguration()
@@ -256,7 +279,8 @@ func TestCreateARMTypeWithConfigMap_CreatesExpectedConversions(t *testing.T) {
 		createARMTypes,
 		applyARMConversionInterface,
 		simplify,
-		strip)
+		strip,
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	test.AssertPackagesGenerateExpectedCode(t, state.Definitions())
@@ -279,11 +303,13 @@ func TestCreateARMTypeWithSecret_CreatesExpectedConversions(t *testing.T) {
 		test.FamilyNameProperty,
 		test.KnownAsProperty,
 		secretDataProperty,
-		secretSliceProperty)
+		secretSliceProperty,
+	)
 	specPropertiesProp := astmodel.NewPropertyDefinition(
 		"Properties",
 		"properties",
-		specProperties.Name()).MakeTypeOptional()
+		specProperties.Name(),
+	).MakeTypeOptional()
 	spec := test.CreateSpec(test.Pkg2020, "Person", specPropertiesProp, test.NameProperty)
 	status := test.CreateStatus(test.Pkg2020, "Person")
 	resource := test.CreateARMResource(test.Pkg2020, "Person", spec, status, test.Pkg2020APIVersion)
@@ -300,7 +326,9 @@ func TestCreateARMTypeWithSecret_CreatesExpectedConversions(t *testing.T) {
 			func(pc *config.PropertyConfiguration) error {
 				pc.Secrecy.Set(astmodel.ImportSecretModeRequired)
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 	g.Expect(
 		omc.ModifyProperty(
@@ -309,7 +337,9 @@ func TestCreateARMTypeWithSecret_CreatesExpectedConversions(t *testing.T) {
 			func(pc *config.PropertyConfiguration) error {
 				pc.Secrecy.Set(astmodel.ImportSecretModeRequired)
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 	g.Expect(
 		omc.ModifyProperty(
@@ -318,7 +348,9 @@ func TestCreateARMTypeWithSecret_CreatesExpectedConversions(t *testing.T) {
 			func(pc *config.PropertyConfiguration) error {
 				pc.Secrecy.Set(astmodel.ImportSecretModeRequired)
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 
 	configuration := config.NewConfiguration()
@@ -336,7 +368,8 @@ func TestCreateARMTypeWithSecret_CreatesExpectedConversions(t *testing.T) {
 		createARMTypes,
 		applyARMConversionInterface,
 		simplify,
-		strip)
+		strip,
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	test.AssertPackagesGenerateExpectedCode(t, state.Definitions())
@@ -347,32 +380,38 @@ func TestCreateARMTypeConversionsWhenSimplifying_CreatesExpectedConversions(t *t
 
 	aliasDef := astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(test.Pkg2020, "Alias"),
-		astmodel.StringType)
+		astmodel.StringType,
+	)
 
 	aliasProperty := astmodel.NewPropertyDefinition(
 		"Alias",
 		"alias",
-		aliasDef.Name()).
+		aliasDef.Name(),
+	).
 		WithDescription("Expect alias on CRD type to become string on ARM type")
 
 	qualificationsDef := astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(test.Pkg2020, "Qualifications"),
-		astmodel.NewArrayType(astmodel.StringType))
+		astmodel.NewArrayType(astmodel.StringType),
+	)
 
 	qualificationsProperty := astmodel.NewPropertyDefinition(
 		"Qualifications",
 		"qualifications",
-		qualificationsDef.Name()).
+		qualificationsDef.Name(),
+	).
 		WithDescription("Expect alias of array on CRD type to become array on ARM type")
 
 	codesDef := astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(test.Pkg2020, "Codes"),
-		astmodel.NewMapType(astmodel.StringType, astmodel.StringType))
+		astmodel.NewMapType(astmodel.StringType, astmodel.StringType),
+	)
 
 	codesProperty := astmodel.NewPropertyDefinition(
 		"Codes",
 		"codes",
-		codesDef.Name()).
+		codesDef.Name(),
+	).
 		WithDescription("Expect alias of map on CRD type to become map on ARM type")
 
 	cases := map[string]struct {
@@ -403,12 +442,14 @@ func TestCreateARMTypeConversionsWhenSimplifying_CreatesExpectedConversions(t *t
 				test.Pkg2020,
 				"Person",
 				test.FullNameProperty,
-				c.property)
+				c.property,
+			)
 
 			// Arrange: Create a set of all our definitions
 			defs := astmodel.MakeTypeDefinitionSetFromDefinitions(
 				c.propertyDef,
-				person)
+				person,
+			)
 
 			idFactory := astmodel.NewIdentifierFactory()
 			omc := config.NewObjectModelConfiguration()
@@ -417,7 +458,8 @@ func TestCreateARMTypeConversionsWhenSimplifying_CreatesExpectedConversions(t *t
 			state, err := RunTestPipeline(
 				NewState(defs),
 				CreateARMTypes(omc, idFactory, logr.Discard()),
-				ApplyARMConversionInterface(idFactory, omc))
+				ApplyARMConversionInterface(idFactory, omc),
+			)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			test.AssertPackagesGenerateExpectedCode(t, state.Definitions(), test.CreateFolderForTest())
@@ -445,53 +487,63 @@ func TestCreateARMTypes_WithTopLevelOneOf_GeneratesExpectedCode(t *testing.T) {
 		astmodel.MakeInternalTypeName(test.Pkg2022, "ReadWriteDatabaseKind"),
 		astmodel.NewEnumType(
 			astmodel.StringType,
-			readWriteKind))
+			readWriteKind,
+		),
+	)
 
 	readwriteDatabase := test.CreateObjectDefinition(
 		test.Pkg2022,
 		"ReadWriteDatabase",
 		astmodel.NewPropertyDefinition("Kind", "kind", readWriteDatabaseKind.Name()),
 		astmodel.NewPropertyDefinition("Location", "location", astmodel.OptionalStringType),
-		astmodel.NewPropertyDefinition("Properties", "properties", astmodel.OptionalStringType))
+		astmodel.NewPropertyDefinition("Properties", "properties", astmodel.OptionalStringType),
+	)
 
 	readOnlyFollowingKind := astmodel.MakeEnumValue("ReadOnlyFollowing", "ReadOnlyFollowing")
 	readOnlyFollowingDatabaseKind := astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(test.Pkg2022, "ReadOnlyFollowingDatabaseKind"),
 		astmodel.NewEnumType(
 			astmodel.StringType,
-			readOnlyFollowingKind))
+			readOnlyFollowingKind,
+		),
+	)
 
 	readOnlyFollowingDatabase := test.CreateObjectDefinition(
 		test.Pkg2022,
 		"ReadOnlyFollowingDatabase",
 		astmodel.NewPropertyDefinition("Kind", "kind", readOnlyFollowingDatabaseKind.Name()),
 		astmodel.NewPropertyDefinition("Location", "location", astmodel.OptionalStringType),
-		astmodel.NewPropertyDefinition("Properties", "properties", astmodel.OptionalStringType))
+		astmodel.NewPropertyDefinition("Properties", "properties", astmodel.OptionalStringType),
+	)
 
 	clusterDatabaseSpec := test.CreateObjectDefinition(
 		test.Pkg2022,
 		"ClusterDatabase_Spec",
 		astmodel.NewPropertyDefinition("Name", "name", astmodel.OptionalStringType),
 		astmodel.NewPropertyDefinition("ReadOnlyFollowing", "readOnlyFollowing", astmodel.NewOptionalType(readOnlyFollowingDatabase.Name())),
-		astmodel.NewPropertyDefinition("ReadWrite", "readWrite", astmodel.NewOptionalType(readwriteDatabase.Name())))
+		astmodel.NewPropertyDefinition("ReadWrite", "readWrite", astmodel.NewOptionalType(readwriteDatabase.Name())),
+	)
 
 	var err error
 	clusterDatabaseSpec, err = clusterDatabaseSpec.ApplyObjectTransformation(
 		func(o *astmodel.ObjectType) (astmodel.Type, error) {
 			return astmodel.OneOfFlag.ApplyTo(o), nil
-		})
+		},
+	)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	clusterDatabaseStatus := test.CreateObjectDefinition(
 		test.Pkg2022,
 		"ClusterDatabase_Status",
-		astmodel.NewPropertyDefinition("Name", "name", astmodel.OptionalStringType))
+		astmodel.NewPropertyDefinition("Name", "name", astmodel.OptionalStringType),
+	)
 
 	clusterResource := test.CreateResource(
 		test.Pkg2022,
 		"ClusterDatabase",
 		clusterDatabaseSpec,
-		clusterDatabaseStatus)
+		clusterDatabaseStatus,
+	)
 
 	defs := make(astmodel.TypeDefinitionSet)
 	defs.AddAll(
@@ -502,7 +554,8 @@ func TestCreateARMTypes_WithTopLevelOneOf_GeneratesExpectedCode(t *testing.T) {
 		clusterResource,
 		readWriteDatabaseKind,
 		readOnlyFollowingDatabaseKind,
-		test.Pkg2020APIVersion)
+		test.Pkg2020APIVersion,
+	)
 
 	idFactory := astmodel.NewIdentifierFactory()
 
@@ -519,7 +572,8 @@ func TestCreateARMTypes_WithTopLevelOneOf_GeneratesExpectedCode(t *testing.T) {
 		applyARMConversionInterface,
 		flatten,
 		simplify,
-		strip)
+		strip,
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	test.AssertPackagesGenerateExpectedCode(t, state.Definitions())

--- a/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph.go
@@ -56,7 +56,8 @@ func CreateConversionGraph(
 			}
 
 			return StateWithData(state, ConversionGraphInfo, graph), nil
-		})
+		},
+	)
 
 	stage.AddDiagnostic(exportConversionGraph)
 

--- a/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph_test.go
@@ -31,12 +31,14 @@ func TestCreateConversionGraph(t *testing.T) {
 
 	initialState, err := RunTestPipeline(
 		NewState(defs),
-		CreateStorageTypes())
+		CreateStorageTypes(),
+	)
 	g.Expect(err).To(Succeed())
 
 	finalState, err := RunTestPipeline(
 		initialState,
-		CreateConversionGraph(cfg))
+		CreateConversionGraph(cfg),
+	)
 	g.Expect(err).To(Succeed())
 
 	g.Expect(finalState.Definitions()).To(HaveLen(6))

--- a/v2/tools/generator/internal/codegen/pipeline/create_resource_extension_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_resource_extension_types.go
@@ -32,7 +32,8 @@ func CreateResourceExtensions(localPath string, idFactory astmodel.IdentifierFac
 				packageRef := astmodel.MakeNamedLocalPackageReference(
 					localPath,
 					group,
-					"customizations")
+					"customizations",
+				)
 				extensionTypeName := astmodel.MakeInternalTypeName(packageRef, typeDef.Name().Name()+"Extension")
 				extendedResourceTypesMapping[extensionTypeName] = append(extendedResourceTypesMapping[extensionTypeName], typeDef.Name())
 			}
@@ -43,7 +44,8 @@ func CreateResourceExtensions(localPath string, idFactory astmodel.IdentifierFac
 
 				newExtensionType := astmodel.MakeTypeDefinition(
 					extensionName,
-					astmodel.NewObjectType().WithFunction(fn))
+					astmodel.NewObjectType().WithFunction(fn),
+				)
 
 				if err := extendedResourceDefs.AddAllowDuplicates(newExtensionType); err != nil {
 					return nil, err
@@ -52,7 +54,8 @@ func CreateResourceExtensions(localPath string, idFactory astmodel.IdentifierFac
 			}
 			state.definitions.AddTypes(extendedResourceDefs)
 			return state, nil
-		})
+		},
+	)
 
 	return stage
 }

--- a/v2/tools/generator/internal/codegen/pipeline/create_resource_extension_types_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_resource_extension_types_test.go
@@ -24,7 +24,8 @@ func TestGolden_ResoureExtension_OneVersion(t *testing.T) {
 	defs.AddAll(resourceV1, specV1, statusV1)
 
 	initialState, err := RunTestPipeline(
-		NewState(defs))
+		NewState(defs),
+	)
 	g.Expect(err).To(Succeed())
 
 	finalState, err := RunTestPipeline(initialState, CreateResourceExtensions("testPath", astmodel.NewIdentifierFactory()))
@@ -47,7 +48,8 @@ func TestGolden_ResoureExtension_MoreThanOneVersion(t *testing.T) {
 	defs.AddAll(resourceV1, specV1, statusV1, resourceV2, specV2, statusV2)
 
 	initialState, err := RunTestPipeline(
-		NewState(defs))
+		NewState(defs),
+	)
 	g.Expect(err).To(Succeed())
 
 	finalState, err := RunTestPipeline(initialState, CreateResourceExtensions("testPath", astmodel.NewIdentifierFactory()))

--- a/v2/tools/generator/internal/codegen/pipeline/create_storage_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_storage_types.go
@@ -72,7 +72,8 @@ func CreateStorageTypes() *Stage {
 			}
 
 			return state.WithOverlaidDefinitions(storageDefs), nil
-		})
+		},
+	)
 
 	return stage
 }

--- a/v2/tools/generator/internal/codegen/pipeline/create_storage_types_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_storage_types_test.go
@@ -33,7 +33,8 @@ func TestGolden_CreateStorageTypes(t *testing.T) {
 		test.FamilyNameProperty,
 		test.KnownAsProperty,
 		test.ResidentialAddress2021,
-		test.PostalAddress2021)
+		test.PostalAddress2021,
+	)
 	statusV2 := test.CreateStatus(test.Pkg2021, "Person")
 	resourceV2 := test.CreateResource(test.Pkg2021, "Person", specV2, statusV2)
 

--- a/v2/tools/generator/internal/codegen/pipeline/crossplane_add_at_provider.go
+++ b/v2/tools/generator/internal/codegen/pipeline/crossplane_add_at_provider.go
@@ -25,7 +25,8 @@ func AddCrossplaneAtProvider(idFactory astmodel.IdentifierFactory) *Stage {
 			for _, typeDef := range definitions {
 				if _, ok := astmodel.AsResourceType(typeDef.Type()); ok {
 					atProviderTypes, err := nestStatusIntoAtProvider(
-						idFactory, definitions, typeDef)
+						idFactory, definitions, typeDef,
+					)
 					if err != nil {
 						return nil, eris.Wrapf(err, "creating AtProvider definitions")
 					}
@@ -44,7 +45,8 @@ func AddCrossplaneAtProvider(idFactory astmodel.IdentifierFactory) *Stage {
 			result.AddTypes(unmodified)
 
 			return state.WithDefinitions(result), nil
-		})
+		},
+	)
 }
 
 // nestStatusIntoAtProvider returns the type definitions required to nest the contents of the "Status" type

--- a/v2/tools/generator/internal/codegen/pipeline/crossplane_add_embedded_resource_spec.go
+++ b/v2/tools/generator/internal/codegen/pipeline/crossplane_add_embedded_resource_spec.go
@@ -24,7 +24,8 @@ func AddCrossplaneEmbeddedResourceSpec(idFactory astmodel.IdentifierFactory) *St
 			definitions := state.Definitions()
 			specTypeName := astmodel.MakeExternalTypeName(
 				CrossplaneRuntimeV1Package,
-				idFactory.CreateIdentifier("ResourceSpec", astmodel.Exported))
+				idFactory.CreateIdentifier("ResourceSpec", astmodel.Exported),
+			)
 			embeddedSpec := astmodel.NewPropertyDefinition("", ",inline", specTypeName)
 
 			result := make(astmodel.TypeDefinitionSet)
@@ -56,5 +57,6 @@ func AddCrossplaneEmbeddedResourceSpec(idFactory astmodel.IdentifierFactory) *St
 			}
 
 			return state.WithDefinitions(result), nil
-		})
+		},
+	)
 }

--- a/v2/tools/generator/internal/codegen/pipeline/crossplane_add_embedded_resource_status.go
+++ b/v2/tools/generator/internal/codegen/pipeline/crossplane_add_embedded_resource_status.go
@@ -22,7 +22,8 @@ func AddCrossplaneEmbeddedResourceStatus(idFactory astmodel.IdentifierFactory) *
 			definitions := state.Definitions()
 			statusTypeName := astmodel.MakeExternalTypeName(
 				CrossplaneRuntimeV1Package,
-				idFactory.CreateIdentifier("ResourceStatus", astmodel.Exported))
+				idFactory.CreateIdentifier("ResourceStatus", astmodel.Exported),
+			)
 			embeddedStatus := astmodel.NewPropertyDefinition("", ",inline", statusTypeName)
 
 			result := make(astmodel.TypeDefinitionSet)
@@ -64,5 +65,6 @@ func AddCrossplaneEmbeddedResourceStatus(idFactory astmodel.IdentifierFactory) *
 			}
 
 			return state.WithDefinitions(result), nil
-		})
+		},
+	)
 }

--- a/v2/tools/generator/internal/codegen/pipeline/crossplane_add_for_provider.go
+++ b/v2/tools/generator/internal/codegen/pipeline/crossplane_add_for_provider.go
@@ -26,7 +26,8 @@ func AddCrossplaneForProvider(idFactory astmodel.IdentifierFactory) *Stage {
 			for _, typeDef := range definitions {
 				if _, ok := astmodel.AsResourceType(typeDef.Type()); ok {
 					forProviderTypes, err := nestSpecIntoForProvider(
-						idFactory, definitions, typeDef)
+						idFactory, definitions, typeDef,
+					)
 					if err != nil {
 						return nil, eris.Wrapf(err, "creating 'ForProvider' definitions")
 					}
@@ -39,7 +40,8 @@ func AddCrossplaneForProvider(idFactory astmodel.IdentifierFactory) *Stage {
 			result.AddTypes(unmodified)
 
 			return state.WithDefinitions(result), nil
-		})
+		},
+	)
 }
 
 // nestSpecIntoForProvider returns the type definitions required to nest the contents of the "Spec" type
@@ -96,13 +98,15 @@ func nestType(
 	// Copy outer type properties onto new "nesting type" with name nestedTypeName
 	nestedDef := astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(outerTypeName.InternalPackageReference(), nestedTypeName),
-		outerObject)
+		outerObject,
+	)
 	result = append(result, nestedDef)
 
 	nestedProperty := astmodel.NewPropertyDefinition(
 		idFactory.CreatePropertyName(nestedPropertyName, astmodel.Exported),
 		idFactory.CreateStringIdentifier(nestedPropertyName, astmodel.NotExported),
-		nestedDef.Name())
+		nestedDef.Name(),
+	)
 
 	// Change existing object type to have a single property pointing to the above nested type
 	updatedObject := outerObject.WithoutProperties().WithProperty(nestedProperty)

--- a/v2/tools/generator/internal/codegen/pipeline/crossplane_add_owner_properties.go
+++ b/v2/tools/generator/internal/codegen/pipeline/crossplane_add_owner_properties.go
@@ -23,10 +23,12 @@ func AddCrossplaneOwnerProperties(idFactory astmodel.IdentifierFactory) *Stage {
 			definitions := state.Definitions()
 			referenceTypeName := astmodel.MakeExternalTypeName(
 				CrossplaneRuntimeV1Package,
-				idFactory.CreateIdentifier("Reference", astmodel.Exported))
+				idFactory.CreateIdentifier("Reference", astmodel.Exported),
+			)
 			selectorTypeName := astmodel.MakeExternalTypeName(
 				CrossplaneRuntimeV1Package,
-				idFactory.CreateIdentifier("Selector", astmodel.Exported))
+				idFactory.CreateIdentifier("Selector", astmodel.Exported),
+			)
 
 			result := make(astmodel.TypeDefinitionSet)
 			for _, typeDef := range definitions {
@@ -62,15 +64,18 @@ func AddCrossplaneOwnerProperties(idFactory astmodel.IdentifierFactory) *Stage {
 							nameProperty := astmodel.NewPropertyDefinition(
 								name,
 								idFactory.CreateStringIdentifier(string(name), astmodel.NotExported),
-								astmodel.StringType)
+								astmodel.StringType,
+							)
 							nameRefProperty := astmodel.NewPropertyDefinition(
 								nameRef,
 								idFactory.CreateStringIdentifier(string(nameRef), astmodel.NotExported),
-								referenceTypeName).MakeTypeOptional()
+								referenceTypeName,
+							).MakeTypeOptional()
 							nameSelectorProperty := astmodel.NewPropertyDefinition(
 								nameSelector,
 								idFactory.CreateStringIdentifier(string(nameSelector), astmodel.NotExported),
-								selectorTypeName).MakeTypeOptional()
+								selectorTypeName,
+							).MakeTypeOptional()
 
 							result := o.WithProperty(nameProperty).WithProperty(nameRefProperty).WithProperty(nameSelectorProperty)
 							return result, nil
@@ -93,7 +98,8 @@ func AddCrossplaneOwnerProperties(idFactory astmodel.IdentifierFactory) *Stage {
 			}
 
 			return state.WithDefinitions(result), nil
-		})
+		},
+	)
 }
 
 func lookupOwners(defs astmodel.TypeDefinitionSet, resourceDef astmodel.TypeDefinition) ([]astmodel.TypeName, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/delete_generated_code.go
+++ b/v2/tools/generator/internal/codegen/pipeline/delete_generated_code.go
@@ -36,7 +36,8 @@ func DeleteGeneratedCode(outputFolder string) *Stage {
 			}
 
 			return state, nil
-		})
+		},
+	)
 }
 
 func deleteGeneratedCodeFromFolder(ctx context.Context, outputFolder string) error {

--- a/v2/tools/generator/internal/codegen/pipeline/determine_resource_ownership.go
+++ b/v2/tools/generator/internal/codegen/pipeline/determine_resource_ownership.go
@@ -35,7 +35,8 @@ func DetermineResourceOwnership(
 			}
 
 			return state.WithOverlaidDefinitions(defs), nil
-		})
+		},
+	)
 }
 
 type ownershipStage struct {
@@ -87,7 +88,8 @@ func (o *ownershipStage) assignOwners() (astmodel.TypeDefinitionSet, error) {
 		if err != nil {
 			errs = append(
 				errs,
-				eris.Wrapf(err, "failed to update ownership for resource %s", def.Name()))
+				eris.Wrapf(err, "failed to update ownership for resource %s", def.Name()),
+			)
 			continue
 		}
 
@@ -100,7 +102,8 @@ func (o *ownershipStage) assignOwners() (astmodel.TypeDefinitionSet, error) {
 			if err != nil {
 				errs = append(
 					errs,
-					eris.Wrapf(err, "failed to remove resources property from resource %s", def.Name()))
+					eris.Wrapf(err, "failed to remove resources property from resource %s", def.Name()),
+				)
 				continue
 			}
 
@@ -111,7 +114,8 @@ func (o *ownershipStage) assignOwners() (astmodel.TypeDefinitionSet, error) {
 	if len(errs) > 0 {
 		return nil, eris.Wrapf(
 			kerrors.NewAggregate(errs),
-			"failed to update ownership for some resources")
+			"failed to update ownership for some resources",
+		)
 	}
 
 	o.setDefaultOwner(updatedDefs)
@@ -227,7 +231,8 @@ func (o *ownershipStage) updateChildResourceDefinitionsWithOwner(
 		// we need to choose the one with the most recent package reference.
 		if astmodel.ComparePathAndVersion(
 			existingOwner.InternalPackageReference().ImportPath(),
-			owningResourceName.InternalPackageReference().ImportPath()) < 0 {
+			owningResourceName.InternalPackageReference().ImportPath(),
+		) < 0 {
 			// New owner is more recent, so use it
 			applyOwnerToChild(owningResourceName, childResourceDef, childResource)
 			continue
@@ -259,7 +264,8 @@ func (o *ownershipStage) setDefaultOwner(
 				// Note that the version doesn't really matter here -- it's removed later. We just need to refer to the logical
 				// resource group really
 				o.configuration.MakeLocalPackageReference("resources", "v20191001"),
-				"ResourceGroup")
+				"ResourceGroup",
+			)
 			updatedType := resourceType.WithOwner(ownerTypeName) // TODO: Note that right now... this type doesn't actually exist...
 			// This can overwrite because a resource with no owner may have had child resources,
 			// and earlier on in this process we removed the resources property from the parent resource,

--- a/v2/tools/generator/internal/codegen/pipeline/ensure_type_has_arm_type.go
+++ b/v2/tools/generator/internal/codegen/pipeline/ensure_type_has_arm_type.go
@@ -23,7 +23,8 @@ func EnsureARMTypeExistsForEveryResource() *Stage {
 		func(ctx context.Context, state *State) (*State, error) {
 			definitions := state.Definitions()
 			return state, validateExpectedTypesHaveARMType(definitions)
-		})
+		},
+	)
 }
 
 // validateExpectedTypesHaveARMType returns an error containing details about all

--- a/v2/tools/generator/internal/codegen/pipeline/export_controller_type_registrations.go
+++ b/v2/tools/generator/internal/codegen/pipeline/export_controller_type_registrations.go
@@ -95,7 +95,8 @@ func ExportControllerResourceRegistrations(idFactory astmodel.IdentifierFactory,
 			}
 
 			return state, nil
-		})
+		},
+	)
 }
 
 func transformChainsToIndexFunctionsAndKeys(
@@ -115,7 +116,8 @@ func transformChainsToIndexFunctionsAndKeys(
 			chain.indexMethodName(idFactory, def.Name()),
 			def.Name(),
 			propertyKey,
-			chain.properties())
+			chain.properties(),
+		)
 		indexFunctions = append(indexFunctions, indexFunction)
 		propertyKeys = append(propertyKeys, propertyKey)
 	}

--- a/v2/tools/generator/internal/codegen/pipeline/export_generated_code.go
+++ b/v2/tools/generator/internal/codegen/pipeline/export_generated_code.go
@@ -48,7 +48,8 @@ func ExportPackages(
 			}
 
 			return state, nil
-		})
+		},
+	)
 
 	stage.RequiresPrerequisiteStages(DeleteGeneratedCodeStageID)
 
@@ -97,13 +98,15 @@ func writeFiles(
 			} else {
 				return 0
 			}
-		})
+		},
+	)
 
 	// emit each package
 	log.Info(
 		"Writing packages",
 		"count", len(pkgs),
-		"outputPath", outputPath)
+		"outputPath", outputPath,
+	)
 
 	globalProgress := newProgressMeter()
 	groupProgress := newProgressMeter()
@@ -179,13 +182,15 @@ func (export *progressMeter) Log(log logr.Logger) {
 			"label", export.label,
 			"files", export.files,
 			"types", export.definitions,
-			"elapsed", elapsed)
+			"elapsed", elapsed,
+		)
 	} else {
 		log.V(1).Info(
 			"Wrote files",
 			"files", export.files,
 			"types", export.definitions,
-			"elapsed", elapsed)
+			"elapsed", elapsed,
+		)
 	}
 
 	export.resetAt = time.Now()

--- a/v2/tools/generator/internal/codegen/pipeline/flatten_properties.go
+++ b/v2/tools/generator/internal/codegen/pipeline/flatten_properties.go
@@ -36,7 +36,8 @@ func FlattenProperties(log logr.Logger) *Stage {
 			}
 
 			return state.WithDefinitions(result), nil
-		})
+		},
+	)
 }
 
 func makeFlatteningVisitor(defs astmodel.TypeDefinitionSet, log logr.Logger) astmodel.TypeVisitor[astmodel.TypeName] {
@@ -160,7 +161,8 @@ func collectAndFlattenProperties(
 				"Skipping flatten",
 				"property", prop.PropertyName(),
 				"container", container,
-				"reason", err)
+				"reason", err,
+			)
 
 			innerProps = []*astmodel.PropertyDefinition{
 				prop.SetFlatten(false),

--- a/v2/tools/generator/internal/codegen/pipeline/flatten_properties_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/flatten_properties_test.go
@@ -47,7 +47,8 @@ func TestDuplicateNamesAreCaughtAndRenamed(t *testing.T) {
 	newObjType := astmodel.NewObjectType().
 		WithProperties(
 			prop,
-			prop.WithName(newName).WithJSONName(newJSONName).AddFlattenedFrom("Inner"))
+			prop.WithName(newName).WithJSONName(newJSONName).AddFlattenedFrom("Inner"),
+		)
 	expectedDefs := make(astmodel.TypeDefinitionSet)
 	expectedDefs.Add(astmodel.MakeTypeDefinition(astmodel.MakeInternalTypeName(placeholderPackage, "ObjType"), newObjType))
 
@@ -59,15 +60,18 @@ func TestFlatteningWorks(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	inner2Obj := astmodel.NewObjectType().WithProperties(
-		astmodel.NewPropertyDefinition("x", "x", astmodel.StringType))
+		astmodel.NewPropertyDefinition("x", "x", astmodel.StringType),
+	)
 
 	innerObj := astmodel.NewObjectType().WithProperties(
 		astmodel.NewPropertyDefinition("inner2", "inner2", inner2Obj).SetFlatten(true),
-		astmodel.NewPropertyDefinition("y", "y", astmodel.IntType))
+		astmodel.NewPropertyDefinition("y", "y", astmodel.IntType),
+	)
 
 	objType := astmodel.NewObjectType().WithProperties(
 		astmodel.NewPropertyDefinition("inner", "inner", innerObj).SetFlatten(true),
-		astmodel.NewPropertyDefinition("z", "z", astmodel.IntType))
+		astmodel.NewPropertyDefinition("z", "z", astmodel.IntType),
+	)
 
 	defs := make(astmodel.TypeDefinitionSet)
 	defs.Add(astmodel.MakeTypeDefinition(astmodel.MakeInternalTypeName(placeholderPackage, "objType"), objType))

--- a/v2/tools/generator/internal/codegen/pipeline/flatten_resources.go
+++ b/v2/tools/generator/internal/codegen/pipeline/flatten_resources.go
@@ -56,7 +56,8 @@ func FlattenResources() *Stage {
 			}
 
 			return state.WithDefinitions(results), nil
-		})
+		},
+	)
 }
 
 func flattenResource(defs astmodel.TypeDefinitionSet, t astmodel.Type, depth int) (astmodel.Type, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/handle_user_assigned_identities.go
+++ b/v2/tools/generator/internal/codegen/pipeline/handle_user_assigned_identities.go
@@ -36,7 +36,8 @@ func HandleUserAssignedIdentities() *Stage {
 			updatedDefs.AddTypes(transformer.typesToAdd)
 
 			return state.WithDefinitions(updatedDefs), nil
-		})
+		},
+	)
 
 	return stage
 }

--- a/v2/tools/generator/internal/codegen/pipeline/implement_convertible_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/implement_convertible_interface.go
@@ -39,7 +39,8 @@ func ImplementConvertibleInterface(idFactory astmodel.IdentifierFactory) *Stage 
 						return nil, eris.Wrapf(
 							err,
 							"finding hub for %s",
-							def.Name())
+							def.Name(),
+						)
 					}
 
 					if astmodel.TypeEquals(def.Name(), hub) {
@@ -67,13 +68,15 @@ func ImplementConvertibleInterface(idFactory astmodel.IdentifierFactory) *Stage 
 					}
 
 					return &modified, nil
-				})
+				},
+			)
 			if err != nil {
 				return nil, eris.Wrap(err, "injecting conversions.Convertible implementations")
 			}
 
 			return state.WithOverlaidDefinitions(modifiedTypes), nil
-		})
+		},
+	)
 
 	stage.RequiresPrerequisiteStages(InjectPropertyAssignmentFunctionsStageID)
 	return stage

--- a/v2/tools/generator/internal/codegen/pipeline/implement_convertible_spec_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/implement_convertible_spec_interface.go
@@ -38,7 +38,8 @@ func ImplementConvertibleSpecInterface(idFactory astmodel.IdentifierFactory) *St
 			}
 
 			return state.WithOverlaidDefinitions(modifiedDefinitions), nil
-		})
+		},
+	)
 
 	stage.RequiresPrerequisiteStages(InjectPropertyAssignmentFunctionsStageID)
 	return stage

--- a/v2/tools/generator/internal/codegen/pipeline/implement_convertible_status_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/implement_convertible_status_interface.go
@@ -38,7 +38,8 @@ func ImplementConvertibleStatusInterface(idFactory astmodel.IdentifierFactory) *
 			}
 
 			return state.WithOverlaidDefinitions(modifiedDefs), nil
-		})
+		},
+	)
 
 	stage.RequiresPrerequisiteStages(InjectPropertyAssignmentFunctionsStageID)
 	return stage

--- a/v2/tools/generator/internal/codegen/pipeline/implement_importable_resource_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/implement_importable_resource_interface.go
@@ -69,13 +69,15 @@ func ImplementImportableResourceInterface(
 			if len(errs) > 0 {
 				return nil, eris.Wrap(
 					kerrors.NewAggregate(errs),
-					"unable to implement ImportableResource interface")
+					"unable to implement ImportableResource interface",
+				)
 			}
 
 			// Add the new definitions to the state
 			state = state.WithOverlaidDefinitions(newDefs)
 			return state, nil
-		})
+		},
+	)
 
 	stage.RequiresPrerequisiteStages(InjectSpecInitializationFunctionsStageID)
 
@@ -123,5 +125,6 @@ func createImportableResourceImplementation(
 
 	return astmodel.NewInterfaceImplementation(
 		astmodel.ImportableResourceType,
-		fn), nil
+		fn,
+	), nil
 }

--- a/v2/tools/generator/internal/codegen/pipeline/improve_property_descriptions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/improve_property_descriptions.go
@@ -34,7 +34,8 @@ func ImprovePropertyDescriptions() *Stage {
 			}
 
 			return state.WithDefinitions(result), nil
-		})
+		},
+	)
 
 	return stage
 }
@@ -73,7 +74,8 @@ func createPropertyImprovingVisitor(defs astmodel.TypeDefinitionSet) astmodel.Ty
 				}
 
 				prop = prop.WithDescription(
-					strings.Join(desc, " "))
+					strings.Join(desc, " "),
+				)
 
 				result = result.WithProperty(prop)
 			}

--- a/v2/tools/generator/internal/codegen/pipeline/inject_hub_function.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_hub_function.go
@@ -46,7 +46,8 @@ func InjectHubFunction(idFactory astmodel.IdentifierFactory) *Stage {
 			}
 
 			return state.WithDefinitions(result), nil
-		})
+		},
+	)
 
 	stage.RequiresPrerequisiteStages(MarkLatestStorageVariantAsHubVersionID)
 	return stage

--- a/v2/tools/generator/internal/codegen/pipeline/inject_hub_function_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_hub_function_test.go
@@ -28,7 +28,8 @@ func TestGolden_InjectHubFunction_WhenResourceIsStorageVersion_GeneratesExpected
 	resource := test.CreateResource(test.Pkg2020, "Person", spec, status)
 
 	resource = resource.WithType(
-		resource.Type().(*astmodel.ResourceType).MarkAsStorageVersion())
+		resource.Type().(*astmodel.ResourceType).MarkAsStorageVersion(),
+	)
 
 	defs := make(astmodel.TypeDefinitionSet)
 	defs.AddAll(resource, status, spec)
@@ -44,7 +45,8 @@ func TestGolden_InjectHubFunction_WhenResourceIsStorageVersion_GeneratesExpected
 
 	finalState, err := RunTestPipeline(
 		initialState,
-		InjectHubFunction(idFactory))
+		InjectHubFunction(idFactory),
+	)
 
 	g.Expect(err).To(Succeed())
 
@@ -77,7 +79,8 @@ func TestGolden_InjectHubFunction_WhenResourceIsNotStorageVersion_GeneratesExpec
 
 	finalState, err := RunTestPipeline(
 		initialState,
-		InjectHubFunction(idFactory))
+		InjectHubFunction(idFactory),
+	)
 	g.Expect(err).To(Succeed())
 
 	test.AssertPackagesGenerateExpectedCode(t, finalState.Definitions(), test.DiffWithTypes(initialState.Definitions()))

--- a/v2/tools/generator/internal/codegen/pipeline/inject_original_gvk_function.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_original_gvk_function.go
@@ -46,7 +46,8 @@ func InjectOriginalGVKFunction(idFactory astmodel.IdentifierFactory) *Stage {
 			}
 
 			return state.WithDefinitions(result), nil
-		})
+		},
+	)
 
 	stage.RequiresPrerequisiteStages(InjectOriginalVersionFunctionStageID)
 	return stage

--- a/v2/tools/generator/internal/codegen/pipeline/inject_original_gvk_function_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_original_gvk_function_test.go
@@ -30,12 +30,14 @@ func TestGolden_InjectOriginalGVKFunction(t *testing.T) {
 
 	initialState, err := RunTestPipeline(
 		NewState(defs),
-		InjectOriginalVersionFunction(idFactory))
+		InjectOriginalVersionFunction(idFactory),
+	)
 	g.Expect(err).To(Succeed())
 
 	finalState, err := RunTestPipeline(
 		initialState,
-		InjectOriginalGVKFunction(idFactory))
+		InjectOriginalGVKFunction(idFactory),
+	)
 	g.Expect(err).To(Succeed())
 
 	test.AssertPackagesGenerateExpectedCode(t, finalState.Definitions(), test.DiffWithTypes(initialState.Definitions()))

--- a/v2/tools/generator/internal/codegen/pipeline/inject_original_version_function.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_original_version_function.go
@@ -42,11 +42,13 @@ func InjectOriginalVersionFunction(idFactory astmodel.IdentifierFactory) *Stage 
 			}
 
 			return state.WithDefinitions(result), nil
-		})
+		},
+	)
 
 	stage.RequiresPostrequisiteStages(
 		CreateStorageTypesStageID,
-		InjectOriginalVersionPropertyStageID)
+		InjectOriginalVersionPropertyStageID,
+	)
 
 	return stage
 }

--- a/v2/tools/generator/internal/codegen/pipeline/inject_original_version_property.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_original_version_property.go
@@ -54,5 +54,6 @@ func InjectOriginalVersionProperty() *Stage {
 			}
 
 			return state.WithDefinitions(result), nil
-		})
+		},
+	)
 }

--- a/v2/tools/generator/internal/codegen/pipeline/inject_original_version_property_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_original_version_property_test.go
@@ -31,7 +31,8 @@ func TestGolden_InjectOriginalVersionProperty_InjectsIntoSpec(t *testing.T) {
 
 	finalState, err := RunTestPipeline(
 		initialState,
-		InjectOriginalVersionProperty())
+		InjectOriginalVersionProperty(),
+	)
 	g.Expect(err).To(Succeed())
 
 	test.AssertPackagesGenerateExpectedCode(t, finalState.Definitions(), test.DiffWithTypes(initialState.Definitions()))
@@ -57,12 +58,14 @@ func TestGolden_InjectOriginalVersionProperty_WhenOriginalVersionFunctionFound_D
 
 	initialState, err := RunTestPipeline(
 		NewState(defs),
-		InjectOriginalVersionFunction(idFactory))
+		InjectOriginalVersionFunction(idFactory),
+	)
 	g.Expect(err).To(Succeed())
 
 	finalState, err := RunTestPipeline(
 		initialState,
-		InjectOriginalVersionProperty())
+		InjectOriginalVersionProperty(),
+	)
 	g.Expect(err).To(Succeed())
 
 	test.AssertPackagesGenerateExpectedCode(t, finalState.Definitions(), test.DiffWithTypes(initialState.Definitions()))

--- a/v2/tools/generator/internal/codegen/pipeline/inject_property_assignment_functions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_property_assignment_functions.go
@@ -50,7 +50,8 @@ func InjectPropertyAssignmentFunctions(
 					// just skip it - not a resource nor an object
 					log.V(2).Info(
 						"Skipping as no conversion functions needed",
-						"type", name)
+						"type", name,
+					)
 					continue
 				}
 
@@ -80,13 +81,15 @@ func InjectPropertyAssignmentFunctions(
 						"AssignPropertiesTo",
 						idFactory,
 						createAssignPropertiesOverrideStub("dst", astmodel.NewOptionalType(nextDef.Name())),
-						nextDef.Name().PackageReference())
+						nextDef.Name().PackageReference(),
+					)
 
 					assignPropertiesFromFunc := functions.NewObjectFunction(
 						"AssignPropertiesFrom",
 						idFactory,
 						createAssignPropertiesOverrideStub("src", astmodel.NewOptionalType(nextDef.Name())),
-						nextDef.Name().PackageReference())
+						nextDef.Name().PackageReference(),
+					)
 
 					ifaceType = ifaceType.WithFunction(assignPropertiesToFunc).WithFunction(assignPropertiesFromFunc)
 
@@ -95,7 +98,8 @@ func InjectPropertyAssignmentFunctions(
 					augmentationInterface = augmentationInterfaceTypeName
 					ifaceDef := astmodel.MakeTypeDefinition(
 						augmentationInterfaceTypeName,
-						ifaceType)
+						ifaceType,
+					)
 					result.Add(ifaceDef)
 				}
 
@@ -108,7 +112,8 @@ func InjectPropertyAssignmentFunctions(
 			}
 
 			return state.WithDefinitions(result), nil
-		})
+		},
+	)
 
 	// Needed to populate the conversion graph
 	stage.RequiresPrerequisiteStages(CreateStorageTypesStageID)

--- a/v2/tools/generator/internal/codegen/pipeline/inject_property_assignment_functions_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_property_assignment_functions_test.go
@@ -29,7 +29,8 @@ func TestGolden_InjectPropertyAssignmentFunctions(t *testing.T) {
 		"Person",
 		test.FullNameProperty,
 		test.FamilyNameProperty,
-		test.KnownAsProperty)
+		test.KnownAsProperty,
+	)
 	statusV1 := test.CreateStatus(test.Pkg2020, "Person")
 	resourceV1 := test.CreateResource(test.Pkg2020, "Person", specV1, statusV1)
 
@@ -42,7 +43,8 @@ func TestGolden_InjectPropertyAssignmentFunctions(t *testing.T) {
 		test.FamilyNameProperty,
 		test.KnownAsProperty,
 		test.ResidentialAddress2021,
-		test.PostalAddress2021)
+		test.PostalAddress2021,
+	)
 	statusV2 := test.CreateStatus(test.Pkg2021, "Person")
 	resourceV2 := test.CreateResource(test.Pkg2021, "Person", specV2, statusV2)
 
@@ -56,7 +58,8 @@ func TestGolden_InjectPropertyAssignmentFunctions(t *testing.T) {
 		state,
 		CreateStorageTypes(),       // First create the storage types
 		CreateConversionGraph(cfg), // Then, create the conversion graph showing relationships
-		InjectPropertyAssignmentFunctions(cfg, idFactory, logr.Discard()))
+		InjectPropertyAssignmentFunctions(cfg, idFactory, logr.Discard()),
+	)
 	g.Expect(err).To(Succeed())
 
 	test.AssertPackagesGenerateExpectedCode(t, finalState.Definitions())

--- a/v2/tools/generator/internal/codegen/pipeline/inject_spec_initialization_functions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_spec_initialization_functions.go
@@ -82,7 +82,8 @@ func InjectSpecInitializationFunctions(
 			}
 
 			return state.WithOverlaidDefinitions(newDefs), nil
-		})
+		},
+	)
 
 	// Needed to populate the conversion graph
 	stage.RequiresPrerequisiteStages(CreateStorageTypesStageID, CreateConversionGraphStageID)
@@ -230,7 +231,8 @@ func (s *specInitializationScanner) visitInternalTypeName(
 			"visiting definitions of spec type %s and status type %s in package %s",
 			specName.Name(),
 			statusName.Name(),
-			specName.InternalPackageReference().FolderPath())
+			specName.InternalPackageReference().FolderPath(),
+		)
 	}
 
 	return specName, nil
@@ -264,7 +266,8 @@ func (s *specInitializationScanner) visitObjectType(
 			// I know that both the property names will be the same, so only log once
 			// (including the name twice was tried, but was confusing)
 			errs = append(errs, eris.Wrapf(
-				err, "visiting spec and status properties %s", specProperty.PropertyName()))
+				err, "visiting spec and status properties %s", specProperty.PropertyName(),
+			))
 		}
 	}
 

--- a/v2/tools/generator/internal/codegen/pipeline/inject_spec_initialization_functions_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_spec_initialization_functions_test.go
@@ -30,14 +30,16 @@ func TestGolden_InjectSpecInitializationFunctions(t *testing.T) {
 		test.Pkg2020,
 		"Address"+astmodel.SpecSuffix,
 		test.FullAddressProperty,
-		test.CityProperty)
+		test.CityProperty,
+	)
 
 	// Define a status type for addresses
 	addressStatus := test.CreateObjectDefinition(
 		test.Pkg2020,
 		"Address"+astmodel.StatusSuffix,
 		test.FullAddressProperty,
-		test.CityProperty)
+		test.CityProperty,
+	)
 
 	// Define a second status type for addresses, with a wholly different name
 	locationStatus := test.CreateObjectDefinition(
@@ -45,45 +47,52 @@ func TestGolden_InjectSpecInitializationFunctions(t *testing.T) {
 		"Location"+astmodel.StatusSuffix,
 		test.FullAddressProperty,
 		test.CityProperty,
-		test.StatusProperty)
+		test.StatusProperty,
+	)
 
 	// Define a spec property for addresses
 	addressesSpecProperty := astmodel.NewPropertyDefinition(
 		"Addresses",
 		"addresses",
-		astmodel.NewArrayType(addressSpec.Name())).
+		astmodel.NewArrayType(addressSpec.Name()),
+	).
 		WithDescription("All the places this person has lived.")
 
 	// Define a status property for locations, using the same type as the spec property for addresses
 	locationsSpecProperty := astmodel.NewPropertyDefinition(
 		"Locations",
 		"locations",
-		astmodel.NewArrayType(addressSpec.Name())).
+		astmodel.NewArrayType(addressSpec.Name()),
+	).
 		WithDescription("Other places this person frequents.")
 
 	// Define a status property for addresses
 	addressesStatusProperty := astmodel.NewPropertyDefinition(
 		"Addresses",
 		"addresses",
-		astmodel.NewArrayType(addressStatus.Name())).
+		astmodel.NewArrayType(addressStatus.Name()),
+	).
 		WithDescription("All the places this person has lived.")
 
 	// Define a status proeprty for locations
 	locationsStatusProperty := astmodel.NewPropertyDefinition(
 		"Locations",
 		"locations",
-		astmodel.NewArrayType(locationStatus.Name())).
+		astmodel.NewArrayType(locationStatus.Name()),
+	).
 		WithDescription("Other places this person frequents.")
 
 	personReferenceProperty := astmodel.NewPropertyDefinition(
 		"PersonReference",
 		"personReference",
-		astmodel.ResourceReferenceType)
+		astmodel.ResourceReferenceType,
+	)
 
 	personIDProperty := astmodel.NewPropertyDefinition(
 		"PersonId",
 		"personId",
-		astmodel.StringType)
+		astmodel.StringType,
+	)
 
 	spec := test.CreateSpec(
 		test.Pkg2020,
@@ -119,7 +128,8 @@ func TestGolden_InjectSpecInitializationFunctions(t *testing.T) {
 		state,
 		CreateStorageTypes(),       // First create the storage types
 		CreateConversionGraph(cfg), // Then create the conversion graph
-		InjectSpecInitializationFunctions(cfg, idFactory)) // Then create the spec initialization functions
+		InjectSpecInitializationFunctions(cfg, idFactory),
+	) // Then create the spec initialization functions
 	g.Expect(err).To(Succeed())
 
 	test.AssertPackagesGenerateExpectedCode(t, finalState.Definitions())

--- a/v2/tools/generator/internal/codegen/pipeline/json_serialization_test_cases.go
+++ b/v2/tools/generator/internal/codegen/pipeline/json_serialization_test_cases.go
@@ -42,7 +42,8 @@ func InjectJSONSerializationTests(idFactory astmodel.IdentifierFactory) *Stage {
 			}
 
 			return state.WithOverlaidDefinitions(modifiedDefinitions), nil
-		})
+		},
+	)
 
 	stage.RequiresPostrequisiteStages("simplifyDefinitions" /* needs flags */)
 

--- a/v2/tools/generator/internal/codegen/pipeline/json_serialization_test_cases_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/json_serialization_test_cases_test.go
@@ -29,7 +29,8 @@ func TestGolden_InjectJsonSerializationTests(t *testing.T) {
 		"Person",
 		test.FullNameProperty,
 		test.FamilyNameProperty,
-		test.KnownAsProperty)
+		test.KnownAsProperty,
+	)
 	statusV1 := test.CreateStatus(test.Pkg2020, "Person")
 	resourceV1 := test.CreateResource(test.Pkg2020, "Person", specV1, statusV1)
 
@@ -44,7 +45,8 @@ func TestGolden_InjectJsonSerializationTests(t *testing.T) {
 		test.FamilyNameProperty,
 		test.KnownAsProperty,
 		test.ResidentialAddress2021,
-		test.PostalAddress2021)
+		test.PostalAddress2021,
+	)
 	statusV2 := test.CreateStatus(test.Pkg2021, "Person")
 	resourceV2 := test.CreateResource(test.Pkg2021, "Person", specV2, statusV2)
 
@@ -59,7 +61,8 @@ func TestGolden_InjectJsonSerializationTests(t *testing.T) {
 		CreateStorageTypes(),       // First create the storage types
 		CreateConversionGraph(cfg), // Then, create the conversion graph showing relationships
 		InjectPropertyAssignmentFunctions(cfg, idFactory, logr.Discard()),
-		InjectJSONSerializationTests(idFactory))
+		InjectJSONSerializationTests(idFactory),
+	)
 	g.Expect(err).To(Succeed())
 
 	/*

--- a/v2/tools/generator/internal/codegen/pipeline/load_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/load_types.go
@@ -48,7 +48,8 @@ func LoadTypes(
 		func(ctx context.Context, state *State) (*State, error) {
 			log.V(1).Info(
 				"Loading Swagger data",
-				"source", config.SchemaRoot)
+				"source", config.SchemaRoot,
+			)
 
 			swaggerTypes, err := loadSwaggerData(ctx, idFactory, config, log)
 			if err != nil {
@@ -58,7 +59,8 @@ func LoadTypes(
 			log.V(1).Info(
 				"Loaded Swagger data",
 				"resources", len(swaggerTypes.ResourceDefinitions),
-				"otherDefinitions", len(swaggerTypes.OtherDefinitions))
+				"otherDefinitions", len(swaggerTypes.OtherDefinitions),
+			)
 
 			if len(swaggerTypes.ResourceDefinitions) == 0 || len(swaggerTypes.OtherDefinitions) == 0 {
 				return nil, eris.Errorf("Failed to load swagger information")
@@ -121,11 +123,13 @@ func LoadTypes(
 			}
 
 			return state.WithDefinitions(defs), nil
-		})
+		},
+	)
 }
 
 var requiredSpecFields = astmodel.NewObjectType().WithProperties(
-	astmodel.NewPropertyDefinition(astmodel.NameProperty, "name", astmodel.StringType))
+	astmodel.NewPropertyDefinition(astmodel.NameProperty, "name", astmodel.StringType),
+)
 
 func addRequiredSpecFields(t astmodel.Type) astmodel.Type {
 	return astmodel.BuildAllOfType(t, requiredSpecFields)
@@ -188,7 +192,8 @@ func renamed(
 	renamer := astmodel.NewRenamingVisitorFromLambda(
 		func(typeName astmodel.InternalTypeName) astmodel.InternalTypeName {
 			return typeName.WithName(typeName.Name() + suffix)
-		})
+		},
+	)
 
 	var errs []error
 	otherTypes := make(astmodel.TypeDefinitionSet)
@@ -302,7 +307,8 @@ func loadSwaggerData(
 		ctx,
 		idFactory,
 		config,
-		log)
+		log,
+	)
 	if err != nil {
 		return jsonast.SwaggerTypes{}, err
 	}
@@ -316,7 +322,8 @@ func loadSwaggerData(
 			log,
 			"Loading Swagger files",
 			"loaded", countLoaded,
-			"total", len(schemas))
+			"total", len(schemas),
+		)
 		countLoaded++
 
 		extractor := jsonast.NewSwaggerTypeExtractor(
@@ -326,7 +333,8 @@ func loadSwaggerData(
 			schemaPath,
 			*schema.Package, // always set during generation
 			loader,
-			log)
+			log,
+		)
 
 		types, err := extractor.ExtractTypes(ctx)
 		if err != nil {
@@ -339,7 +347,8 @@ func loadSwaggerData(
 	log.Info(
 		"Loaded Swagger files",
 		"loaded", countLoaded,
-		"total", len(schemas))
+		"total", len(schemas),
+	)
 
 	return mergeSwaggerTypesByGroup(idFactory, typesByGroup, config)
 }
@@ -412,7 +421,8 @@ func mergeTypesForPackage(
 		typesFromFiles,
 		func(left typesFromFile, right typesFromFile) int {
 			return strings.Compare(left.filePath, right.filePath)
-		})
+		},
+	)
 
 	typeNameCounts := make(map[astmodel.InternalTypeName]int)
 	for _, typesFromFile := range typesFromFiles {
@@ -499,7 +509,8 @@ func mergeTypesForPackage(
 						"merging file %s: renaming %s to %s resulted in a collision with an existing type",
 						typesFromFile.filePath,
 						rn.Name(),
-						newNameA.Name())
+						newNameA.Name(),
+					)
 
 					return nil, err
 				}
@@ -509,7 +520,8 @@ func mergeTypesForPackage(
 						"merging file %s: renaming %s to %s resulted in a collision with an existing type",
 						typesFromFile.filePath,
 						rn.Name(),
-						newNameB.Name())
+						newNameB.Name(),
+					)
 
 					return nil, err
 				}
@@ -525,7 +537,8 @@ func mergeTypesForPackage(
 				err := eris.Errorf(
 					"merging file %s: duplicate resource types generated with name %s",
 					typesFromFile.filePath,
-					rn.Name())
+					rn.Name(),
+				)
 
 				return nil, err
 			}
@@ -639,7 +652,8 @@ func generateRenaming(
 	// Prefix the typename with the filename
 	result := astmodel.MakeInternalTypeName(
 		original.InternalPackageReference(),
-		idFactory.CreateIdentifier(name+original.Name(), astmodel.Exported))
+		idFactory.CreateIdentifier(name+original.Name(), astmodel.Exported),
+	)
 
 	// see if there are any collisions: add Xs until there are no collisions
 	// TODO: this might result in non-determinism depending on iteration order
@@ -741,7 +755,8 @@ func structurallyIdentical(
 		if !astmodel.TypeEquals(
 			leftDefinitions[next.left].Type(),
 			rightDefinitions[next.right].Type(),
-			override) {
+			override,
+		) {
 			return false
 		}
 	}
@@ -816,7 +831,8 @@ func loadAllSchemas(
 			pkg := astmodel.MakeVersionedLocalPackageReference(
 				localPathPrefix,
 				idFactory.CreateGroupName(group),
-				version)
+				version,
+			)
 
 			// We need the file if the version is short (e.g. "v1") because those are often shared between
 			// resource providers.
@@ -831,7 +847,8 @@ func loadAllSchemas(
 			logInfoSparse(
 				log,
 				"Scanning for schemas",
-				"found", countFound)
+				"found", countFound,
+			)
 			countFound++
 
 			eg.Go(func() error {
@@ -839,7 +856,8 @@ func loadAllSchemas(
 
 				log.V(1).Info(
 					"Loading OpenAPI spec",
-					"file", filePath)
+					"file", filePath,
+				)
 
 				fileContent, err := os.ReadFile(filePath)
 				if err != nil {
@@ -865,7 +883,8 @@ func loadAllSchemas(
 	egErr := eg.Wait() // for files to finish loading
 	log.Info(
 		"Scanning for schemas",
-		"found", countFound)
+		"found", countFound,
+	)
 
 	if err != nil {
 		return nil, err

--- a/v2/tools/generator/internal/codegen/pipeline/make_one_of_discriminant_required.go
+++ b/v2/tools/generator/internal/codegen/pipeline/make_one_of_discriminant_required.go
@@ -39,7 +39,8 @@ func MakeOneOfDiscriminantRequired() *Stage {
 			}
 
 			return state.WithOverlaidDefinitions(updatedDefs), nil
-		})
+		},
+	)
 }
 
 type propertyModifier struct {
@@ -82,7 +83,8 @@ func makeOneOfDiscriminantTypeRequired(
 		return nil, eris.Errorf(
 			"OneOf %s was not of type Object, instead was: %s",
 			oneOf.Name(),
-			astmodel.DebugDescription(oneOf.Type()))
+			astmodel.DebugDescription(oneOf.Type()),
+		)
 	}
 
 	result := make(astmodel.TypeDefinitionSet)

--- a/v2/tools/generator/internal/codegen/pipeline/make_status_properties_optional.go
+++ b/v2/tools/generator/internal/codegen/pipeline/make_status_properties_optional.go
@@ -45,7 +45,8 @@ func MakeStatusPropertiesOptional() *Stage {
 			}
 
 			return state.WithOverlaidDefinitions(result), nil
-		})
+		},
+	)
 }
 
 // makeStatusPropertiesOptional makes all properties optional on top level Status types

--- a/v2/tools/generator/internal/codegen/pipeline/mark_latest_api_version_as_storage_version.go
+++ b/v2/tools/generator/internal/codegen/pipeline/mark_latest_api_version_as_storage_version.go
@@ -30,7 +30,8 @@ func MarkLatestAPIVersionAsStorageVersion() *Stage {
 			}
 
 			return state.WithDefinitions(updatedDefs), nil
-		})
+		},
+	)
 }
 
 // MarkLatestResourceVersionsForStorage marks the latest version of each resource as the storage version
@@ -85,8 +86,10 @@ func groupResourcesByVersion(definitions astmodel.TypeDefinitionSet) map[unversi
 			func(left astmodel.TypeDefinition, right astmodel.TypeDefinition) int {
 				return astmodel.ComparePathAndVersion(
 					left.Name().PackageReference().ImportPath(),
-					right.Name().PackageReference().ImportPath())
-			})
+					right.Name().PackageReference().ImportPath(),
+				)
+			},
+		)
 	}
 
 	return result

--- a/v2/tools/generator/internal/codegen/pipeline/mark_latest_api_version_as_storage_version_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/mark_latest_api_version_as_storage_version_test.go
@@ -38,7 +38,8 @@ func TestGolden_MarkLatestAPIVersionAsStorageVersion(t *testing.T) {
 
 	finalState, err := RunTestPipeline(
 		initialState,
-		MarkLatestAPIVersionAsStorageVersion())
+		MarkLatestAPIVersionAsStorageVersion(),
+	)
 	g.Expect(err).To(Succeed())
 
 	// Check that the expected types are flagged as storage types

--- a/v2/tools/generator/internal/codegen/pipeline/mark_latest_storage_variant_as_hub_version.go
+++ b/v2/tools/generator/internal/codegen/pipeline/mark_latest_storage_variant_as_hub_version.go
@@ -47,13 +47,15 @@ func MarkLatestStorageVariantAsHubVersion() *Stage {
 
 					// Nothing to modify, nothing to return
 					return nil, nil
-				})
+				},
+			)
 			if err != nil {
 				return nil, eris.Wrap(err, "marking storage versions")
 			}
 
 			return state.WithOverlaidDefinitions(updatedDefs), nil
-		})
+		},
+	)
 
 	stage.RequiresPrerequisiteStages(CreateConversionGraphStageID)
 	return stage

--- a/v2/tools/generator/internal/codegen/pipeline/move_types_for_version_migration.go
+++ b/v2/tools/generator/internal/codegen/pipeline/move_types_for_version_migration.go
@@ -36,7 +36,8 @@ func MoveTypesForVersionMigration(
 			}
 
 			return state.WithDefinitions(newDefinitions), nil
-		})
+		},
+	)
 
 	stage.RequiresPostrequisiteStages(CreateStorageTypesStageID)
 
@@ -138,7 +139,8 @@ func (p *versionMigrationFactory) findLegacyModeResourcesToMove() (astmodel.Type
 	if len(legacyGroups) > 0 {
 		return nil, eris.Errorf(
 			"expected to find resources introduced prior to ASO version 2.17 in group(s) %s but none were found",
-			strings.Join(set.AsSortedSlice(legacyGroups), ", "))
+			strings.Join(set.AsSortedSlice(legacyGroups), ", "),
+		)
 	}
 
 	return result, nil
@@ -206,7 +208,8 @@ func (p *versionMigrationFactory) collectRelatedDefinitions(
 	if err != nil {
 		return nil, eris.Wrap(
 			err,
-			"finding types connected to resources requiring version migration")
+			"finding types connected to resources requiring version migration",
+		)
 	}
 
 	return connected, nil

--- a/v2/tools/generator/internal/codegen/pipeline/name_types_for_crd.go
+++ b/v2/tools/generator/internal/codegen/pipeline/name_types_for_crd.go
@@ -52,7 +52,8 @@ func NameTypesForCRD(idFactory astmodel.IdentifierFactory) *Stage {
 			}
 
 			return state.WithDefinitions(result), nil
-		})
+		},
+	)
 }
 
 func nameInnerTypes(
@@ -206,7 +207,8 @@ func newNameHint(name astmodel.TypeName) nameHint {
 				baseName = strings.TrimSuffix(baseName, s)
 				suffixes = append(
 					[]string{strings.TrimPrefix(s, "_")},
-					suffixes...)
+					suffixes...,
+				)
 				done = false
 				break
 			}

--- a/v2/tools/generator/internal/codegen/pipeline/override_descriptions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/override_descriptions.go
@@ -39,7 +39,8 @@ func OverrideDescriptions(configuration *config.Configuration) *Stage {
 			}
 
 			return state.WithDefinitions(result), nil
-		})
+		},
+	)
 
 	stage.RequiresPrerequisiteStages(FlattenPropertiesStageID, RenamePropertiesStageID)
 	return stage

--- a/v2/tools/generator/internal/codegen/pipeline/pipeline_diagram.go
+++ b/v2/tools/generator/internal/codegen/pipeline/pipeline_diagram.go
@@ -59,7 +59,8 @@ func (diagram *PipelineDiagram) createDiagram(stages []*Stage) []byte {
 		b.WriteString(
 			fmt.Sprintf("    %s [label=\"%s\"];\n",
 				diagram.idFor(stage),
-				diagram.safeDescription(stage.Description())))
+				diagram.safeDescription(stage.Description())),
+		)
 
 		// If we've reached the end of the block, add a newline
 		if index < len(stages)-1 && index%(blockSize+1) == blockSize {
@@ -79,12 +80,14 @@ func (diagram *PipelineDiagram) createDiagram(stages []*Stage) []byte {
 				b.WriteString(
 					fmt.Sprintf("    %s -> %s [dir=forward];\n",
 						diagram.idFor(stage),
-						diagram.idFor(nextStage)))
+						diagram.idFor(nextStage)),
+				)
 			} else {
 				b.WriteString(
 					fmt.Sprintf("    %s -> %s [dir=back];\n",
 						diagram.idFor(nextStage),
-						diagram.idFor(stage)))
+						diagram.idFor(stage)),
+				)
 			}
 		}
 

--- a/v2/tools/generator/internal/codegen/pipeline/promote_root_oneof-properties.go
+++ b/v2/tools/generator/internal/codegen/pipeline/promote_root_oneof-properties.go
@@ -29,7 +29,8 @@ func PromoteRootOneOfProperties() *Stage {
 			}
 
 			return state.WithOverlaidDefinitions(newDefs), nil
-		})
+		},
+	)
 
 	return stage
 }

--- a/v2/tools/generator/internal/codegen/pipeline/property_assignment_test_cases.go
+++ b/v2/tools/generator/internal/codegen/pipeline/property_assignment_test_cases.go
@@ -43,11 +43,13 @@ func InjectPropertyAssignmentTests(idFactory astmodel.IdentifierFactory) *Stage 
 			}
 
 			return state.WithOverlaidDefinitions(modifiedDefs), nil
-		})
+		},
+	)
 
 	stage.RequiresPrerequisiteStages(
 		InjectPropertyAssignmentFunctionsStageID, // Need PropertyAssignmentFunctions to test
-		InjectJSONSerializationTestsID)           // We reuse the generators from the JSON tests
+		InjectJSONSerializationTestsID,
+	) // We reuse the generators from the JSON tests
 
 	return stage
 }

--- a/v2/tools/generator/internal/codegen/pipeline/property_assignment_test_cases_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/property_assignment_test_cases_test.go
@@ -29,7 +29,8 @@ func TestGolden_InjectPropertyAssignmentTests(t *testing.T) {
 		"Person",
 		test.FullNameProperty,
 		test.FamilyNameProperty,
-		test.KnownAsProperty)
+		test.KnownAsProperty,
+	)
 	statusV1 := test.CreateStatus(test.Pkg2020, "Person")
 	resourceV1 := test.CreateResource(test.Pkg2020, "Person", specV1, statusV1)
 
@@ -42,7 +43,8 @@ func TestGolden_InjectPropertyAssignmentTests(t *testing.T) {
 		test.FamilyNameProperty,
 		test.KnownAsProperty,
 		test.ResidentialAddress2021,
-		test.PostalAddress2021)
+		test.PostalAddress2021,
+	)
 	statusV2 := test.CreateStatus(test.Pkg2021, "Person")
 	resourceV2 := test.CreateResource(test.Pkg2021, "Person", specV2, statusV2)
 
@@ -57,7 +59,8 @@ func TestGolden_InjectPropertyAssignmentTests(t *testing.T) {
 		CreateConversionGraph(cfg), // Then, create the conversion graph showing relationships
 		InjectPropertyAssignmentFunctions(cfg, idFactory, logr.Discard()),
 		InjectJSONSerializationTests(idFactory),
-		InjectPropertyAssignmentTests(idFactory))
+		InjectPropertyAssignmentTests(idFactory),
+	)
 	g.Expect(err).To(Succeed())
 
 	test.AssertPackagesGenerateExpectedCode(t, finalState.Definitions())

--- a/v2/tools/generator/internal/codegen/pipeline/prune_resources_with_lifecycle_owned_by_parent.go
+++ b/v2/tools/generator/internal/codegen/pipeline/prune_resources_with_lifecycle_owned_by_parent.go
@@ -80,7 +80,8 @@ func PruneResourcesWithLifecycleOwnedByParent(configuration *config.Configuratio
 			}
 
 			return state.WithDefinitions(prunedDefs), nil
-		})
+		},
+	)
 
 	stage.RequiresPrerequisiteStages(CreateARMTypesStageID)
 	return stage

--- a/v2/tools/generator/internal/codegen/pipeline/recursivetypefixer/simple_recursive_type_fixer.go
+++ b/v2/tools/generator/internal/codegen/pipeline/recursivetypefixer/simple_recursive_type_fixer.go
@@ -112,7 +112,8 @@ func (s *SimpleRecursiveTypeFixer) unrollRecursiveReference(
 	s.log.V(2).Info(
 		"unrolling recursive reference",
 		"from", ctx.name,
-		"to", ctx.unrolledName)
+		"to", ctx.unrolledName,
+	)
 
 	return astmodel.IdentityVisitOfTypeName(this, ctx.unrolledName, ctx)
 }

--- a/v2/tools/generator/internal/codegen/pipeline/remove_armid_from_status.go
+++ b/v2/tools/generator/internal/codegen/pipeline/remove_armid_from_status.go
@@ -32,7 +32,8 @@ func FixIDFields() *Stage {
 
 			state = state.WithOverlaidDefinitions(updatedDefs)
 			return state, nil
-		})
+		},
+	)
 
 	return stage
 }

--- a/v2/tools/generator/internal/codegen/pipeline/remove_embedded_resources.go
+++ b/v2/tools/generator/internal/codegen/pipeline/remove_embedded_resources.go
@@ -38,5 +38,6 @@ func RemoveEmbeddedResources(
 			}
 
 			return state.WithDefinitions(result), nil
-		})
+		},
+	)
 }

--- a/v2/tools/generator/internal/codegen/pipeline/remove_embedded_resources_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/remove_embedded_resources_test.go
@@ -24,56 +24,68 @@ var (
 	// Lion
 	LionSpecDef = astmodel.MakeTypeDefinition(
 		LionSpecName,
-		LionSpecType)
+		LionSpecType,
+	)
 	LionSpecType = astmodel.NewObjectType().WithProperties(
 		NameProperty,
 		LionTypeProperty,
 		APIVersionProperty,
-		LionPropertiesProperty).WithIsResource(true).WithResource(LionName)
+		LionPropertiesProperty,
+	).WithIsResource(true).WithResource(LionName)
 	LionStatusDef = astmodel.MakeTypeDefinition(
 		LionStatusName,
-		LionStatusType)
+		LionStatusType,
+	)
 	LionStatusType = astmodel.NewObjectType().WithProperties(
 		NameProperty,
 		LionTypeProperty,
 		APIVersionProperty,
-		LionPropertiesProperty)
+		LionPropertiesProperty,
+	)
 
 	// LionPride
 	LionPrideSpecDef = astmodel.MakeTypeDefinition(
 		LionPrideSpecName,
-		LionPrideSpecType)
+		LionPrideSpecType,
+	)
 	LionPrideSpecType = astmodel.NewObjectType().WithProperties(
 		NameProperty,
 		LionPrideTypeProperty,
 		APIVersionProperty,
-		LionPridePropertiesProperty).WithIsResource(true).WithResource(LionPrideName)
+		LionPridePropertiesProperty,
+	).WithIsResource(true).WithResource(LionPrideName)
 	LionPrideStatusDef = astmodel.MakeTypeDefinition(
 		LionPrideStatusName,
-		LionPrideStatusType)
+		LionPrideStatusType,
+	)
 	LionPrideStatusType = astmodel.NewObjectType().WithProperties(
 		NameProperty,
 		LionPrideTypeProperty,
 		APIVersionProperty,
-		LionPridePropertiesProperty)
+		LionPridePropertiesProperty,
+	)
 
 	// LionCub
 	LionCubSpecDef = astmodel.MakeTypeDefinition(
 		LionCubSpecName,
-		LionCubSpecType)
+		LionCubSpecType,
+	)
 	LionCubSpecType = astmodel.NewObjectType().WithProperties(
 		NameProperty,
 		LionCubTypeProperty,
 		APIVersionProperty,
-		LionCubPropertiesProperty).WithIsResource(true).WithResource(LionCubName)
+		LionCubPropertiesProperty,
+	).WithIsResource(true).WithResource(LionCubName)
 	LionCubStatusDef = astmodel.MakeTypeDefinition(
 		LionCubStatusName,
-		LionCubStatusType)
+		LionCubStatusType,
+	)
 	LionCubStatusType = astmodel.NewObjectType().WithProperties(
 		NameProperty,
 		LionCubTypeProperty,
 		APIVersionProperty,
-		LionCubPropertiesProperty)
+		LionCubPropertiesProperty,
+	)
 
 	LionResourceType      = astmodel.NewResourceType(LionSpecName, LionStatusName)
 	LionPrideResourceType = astmodel.NewResourceType(LionPrideSpecName, LionPrideStatusName)
@@ -84,33 +96,42 @@ var (
 
 	LionRef = astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(LionsPkg, "LionRef"),
-		LionSpecType.WithProperty(IDProperty))
+		LionSpecType.WithProperty(IDProperty),
+	)
 	LionCubRef = astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(LionsPkg, "LionCubRef"),
-		LionCubSpecType.WithProperty(IDProperty))
+		LionCubSpecType.WithProperty(IDProperty),
+	)
 
 	LionPrideTypeEnumDef = astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(LionsPkg, "LionPrideType"),
-		astmodel.NewEnumType(astmodel.StringType, astmodel.MakeEnumValue("type", "Microsoft.Lions/lionPride")))
+		astmodel.NewEnumType(astmodel.StringType, astmodel.MakeEnumValue("type", "Microsoft.Lions/lionPride")),
+	)
 	LionTypeEnumDef = astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(LionsPkg, "LionType"),
-		astmodel.NewEnumType(astmodel.StringType, astmodel.MakeEnumValue("type", "Microsoft.Lions/lion")))
+		astmodel.NewEnumType(astmodel.StringType, astmodel.MakeEnumValue("type", "Microsoft.Lions/lion")),
+	)
 	LionCubTypeEnumDef = astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(LionsPkg, "LionCubType"),
-		astmodel.NewEnumType(astmodel.StringType, astmodel.MakeEnumValue("type", "Microsoft.Lions/cub")))
+		astmodel.NewEnumType(astmodel.StringType, astmodel.MakeEnumValue("type", "Microsoft.Lions/cub")),
+	)
 	APIVersionTypeEnumDef = astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(LionsPkg, "APIVersion"),
-		astmodel.NewEnumType(astmodel.StringType, astmodel.MakeEnumValue("apiVersion", `"2020-06-01"`)))
+		astmodel.NewEnumType(astmodel.StringType, astmodel.MakeEnumValue("apiVersion", `"2020-06-01"`)),
+	)
 
 	LionPropertiesDef = astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(LionsPkg, "LionProperties"),
-		astmodel.NewObjectType().WithProperty(RoarVolumeProperty))
+		astmodel.NewObjectType().WithProperty(RoarVolumeProperty),
+	)
 	LionPridePropertiesDef = astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(LionsPkg, "LionPrideProperties"),
-		astmodel.NewObjectType().WithProperties(LionPrideLionsProperty, HuntsProperty))
+		astmodel.NewObjectType().WithProperties(LionPrideLionsProperty, HuntsProperty),
+	)
 	LionCubPropertiesDef = astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(LionsPkg, "LionCubProperties"),
-		astmodel.NewObjectType().WithProperties(LionCubCutenessProperty))
+		astmodel.NewObjectType().WithProperties(LionCubCutenessProperty),
+	)
 
 	// Properties
 	NameProperty          = astmodel.NewPropertyDefinition("Name", "name", astmodel.StringType).MakeTypeOptional().MakeRequired()
@@ -156,7 +177,8 @@ func LionDefs() astmodel.TypeDefinitionSet {
 		LionPridePropertiesDef,
 		LionPrideTypeEnumDef,
 		APIVersionTypeEnumDef,
-		LionRef)
+		LionRef,
+	)
 
 	return defs
 }
@@ -169,7 +191,8 @@ func LionCubDefs() astmodel.TypeDefinitionSet {
 		LionCubStatusDef,
 		LionCubPropertiesDef,
 		LionCubTypeEnumDef,
-		LionCubRef)
+		LionCubRef,
+	)
 
 	return defs
 }
@@ -191,7 +214,8 @@ func TestGolden_EmbeddedSubresource_IsRemoved(t *testing.T) {
 
 	state, err := RunTestPipeline(
 		NewState(defs),
-		removeEmbedded)
+		removeEmbedded,
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	test.AssertPackagesGenerateExpectedCode(t, state.Definitions())
@@ -210,7 +234,8 @@ func TestGolden_EmbeddedResource_IsRemovedRetainsId(t *testing.T) {
 
 	state, err := RunTestPipeline(
 		NewState(defs),
-		removeEmbedded)
+		removeEmbedded,
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	test.AssertPackagesGenerateExpectedCode(t, state.Definitions())
@@ -234,7 +259,8 @@ func TestGolden_EmbeddedResourcesWithMultipleEmbeddings_AllEmbeddingsAreRemovedA
 
 	state, err := RunTestPipeline(
 		NewState(defs),
-		removeEmbedded)
+		removeEmbedded,
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	test.AssertPackagesGenerateExpectedCode(t, state.Definitions())
@@ -260,13 +286,17 @@ func TestGolden_EmbeddedResourceWithCyclesAndResourceLookalikes_RemovesCycles(t 
 		astmodel.NewObjectType().WithProperties(
 			NameProperty,
 			dummyPropertiesProperty,
-			refProperty))
+			refProperty,
+		),
+	)
 	right := astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(LionsPkg, "Right"),
 		astmodel.NewObjectType().WithProperties(
 			NameProperty,
 			dummyPropertiesProperty,
-			refProperty))
+			refProperty,
+		),
+	)
 
 	// Lion needs to point to left and right
 	leftProperty := astmodel.NewPropertyDefinition("Left", "left", left.Name())
@@ -275,7 +305,9 @@ func TestGolden_EmbeddedResourceWithCyclesAndResourceLookalikes_RemovesCycles(t 
 		LionPropertiesDef.Name(),
 		astmodel.NewObjectType().WithProperties(
 			leftProperty,
-			rightProperty))
+			rightProperty,
+		),
+	)
 
 	// Remove the lions property because it adds some confusion/mess to the generated files and doesn't actually
 	// target our scenario anyway
@@ -290,7 +322,8 @@ func TestGolden_EmbeddedResourceWithCyclesAndResourceLookalikes_RemovesCycles(t 
 
 	state, err := RunTestPipeline(
 		NewState(defs),
-		removeEmbedded)
+		removeEmbedded,
+	)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	test.AssertPackagesGenerateExpectedCode(t, state.Definitions())

--- a/v2/tools/generator/internal/codegen/pipeline/remove_empty_objects.go
+++ b/v2/tools/generator/internal/codegen/pipeline/remove_empty_objects.go
@@ -27,5 +27,6 @@ func RemoveEmptyObjects(log logr.Logger) *Stage {
 			}
 
 			return state.WithDefinitions(updatedDefs), nil
-		})
+		},
+	)
 }

--- a/v2/tools/generator/internal/codegen/pipeline/remove_status_property_validations.go
+++ b/v2/tools/generator/internal/codegen/pipeline/remove_status_property_validations.go
@@ -49,7 +49,8 @@ func RemoveStatusValidations() *Stage {
 			}
 
 			return state.WithOverlaidDefinitions(result), nil
-		})
+		},
+	)
 }
 
 func removeStatusTypeValidations(definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {
@@ -61,7 +62,8 @@ func removeStatusTypeValidations(definitions astmodel.TypeDefinitionSet) (astmod
 			VisitEnumType:      removeEnumValidations,
 			VisitValidatedType: removeValidatedType,
 			VisitObjectType:    removeKubebuilderRequired,
-		}.Build())
+		}.Build(),
+	)
 
 	var errs []error
 

--- a/v2/tools/generator/internal/codegen/pipeline/remove_type_aliases.go
+++ b/v2/tools/generator/internal/codegen/pipeline/remove_type_aliases.go
@@ -50,7 +50,8 @@ func RemoveTypeAliases() *Stage {
 			}
 
 			return state.WithDefinitions(result), nil
-		})
+		},
+	)
 }
 
 func resolveTypeName(

--- a/v2/tools/generator/internal/codegen/pipeline/rename_properties.go
+++ b/v2/tools/generator/internal/codegen/pipeline/rename_properties.go
@@ -57,7 +57,8 @@ func RenameProperties(cfg *config.ObjectModelConfiguration) *Stage {
 			}
 
 			return state.WithOverlaidDefinitions(modified), nil
-		})
+		},
+	)
 
 	stage.RequiresPostrequisiteStages(
 		AddStatusConditionsStageID, // Must rename other properties before we try to introduce the `Conditions` property
@@ -103,7 +104,8 @@ func renamePropertiesInObjectType(
 			properties = append(properties, updated)
 
 			return nil
-		})
+		},
+	)
 	if err != nil {
 		return nil, eris.Wrapf(err, "renaming properties for %s", typeName)
 	}

--- a/v2/tools/generator/internal/codegen/pipeline/rename_properties_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/rename_properties_test.go
@@ -35,15 +35,18 @@ func Test_RenameProperties_RenamesExpectedProperty(t *testing.T) {
 		func(p *config.PropertyConfiguration) error {
 			p.RenameTo.Set("Alias")
 			return nil
-		})).To(Succeed())
+		},
+	)).To(Succeed())
 
 	initialState, err := RunTestPipeline(
-		NewState(defs))
+		NewState(defs),
+	)
 	g.Expect(err).To(Succeed())
 
 	finalState, err := RunTestPipeline(
 		initialState,
-		RenameProperties(omc))
+		RenameProperties(omc),
+	)
 	g.Expect(err).To(Succeed())
 
 	// When verifying the golden file, ensure the property has been renamed as expected
@@ -61,7 +64,8 @@ func Test_RenameProperties_PopulatesExpectedARMProperty(t *testing.T) {
 	apiVersionValue := astmodel.MakeEnumValue("apiVersion", `"2020-06-01"`)
 	apiVersion := astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(test.Pkg2020, "APIVersion"),
-		astmodel.NewEnumType(astmodel.StringType, apiVersionValue))
+		astmodel.NewEnumType(astmodel.StringType, apiVersionValue),
+	)
 
 	apiVersionProperty := astmodel.NewPropertyDefinition("APIVersion", "apiVersion", apiVersion.Name()).
 		MakeTypeOptional().
@@ -76,7 +80,8 @@ func Test_RenameProperties_PopulatesExpectedARMProperty(t *testing.T) {
 		apiVersionProperty,
 		test.FullNameProperty,
 		test.KnownAsProperty,
-		test.FamilyNameProperty)
+		test.FamilyNameProperty,
+	)
 
 	personStatus := test.CreateStatus(
 		test.Pkg2020,
@@ -84,7 +89,8 @@ func Test_RenameProperties_PopulatesExpectedARMProperty(t *testing.T) {
 		test.NameProperty,
 		test.FullNameProperty,
 		test.KnownAsProperty,
-		test.FamilyNameProperty)
+		test.FamilyNameProperty,
+	)
 
 	personResourceType := astmodel.NewResourceType(personSpec.Name(), personStatus.Name()).
 		WithAPIVersion(apiVersion.Name(), apiVersionValue)
@@ -97,7 +103,8 @@ func Test_RenameProperties_PopulatesExpectedARMProperty(t *testing.T) {
 		person,
 		personSpec,
 		personStatus,
-		apiVersion)
+		apiVersion,
+	)
 
 	cfg := config.NewConfiguration()
 	omc := cfg.ObjectModelConfiguration
@@ -107,7 +114,8 @@ func Test_RenameProperties_PopulatesExpectedARMProperty(t *testing.T) {
 		func(p *config.PropertyConfiguration) error {
 			p.RenameTo.Set("Alias")
 			return nil
-		})).To(Succeed())
+		},
+	)).To(Succeed())
 
 	initialState, err := RunTestPipeline(
 		NewState(defs),
@@ -140,7 +148,8 @@ func Test_RenameProperties_WhenFlattening_PopulatesExpectedARMProperty(t *testin
 	apiVersionValue := astmodel.MakeEnumValue("apiVersion", `"2020-06-01"`)
 	apiVersion := astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(test.Pkg2020, "APIVersion"),
-		astmodel.NewEnumType(astmodel.StringType, apiVersionValue))
+		astmodel.NewEnumType(astmodel.StringType, apiVersionValue),
+	)
 
 	apiVersionProperty := astmodel.NewPropertyDefinition("APIVersion", "apiVersion", apiVersion.Name()).
 		MakeTypeOptional().
@@ -186,7 +195,8 @@ func Test_RenameProperties_WhenFlattening_PopulatesExpectedARMProperty(t *testin
 		personSpec,
 		personStatus,
 		apiVersion,
-		address)
+		address,
+	)
 
 	cfg := config.NewConfiguration()
 	omc := cfg.ObjectModelConfiguration
@@ -196,7 +206,8 @@ func Test_RenameProperties_WhenFlattening_PopulatesExpectedARMProperty(t *testin
 		func(p *config.PropertyConfiguration) error {
 			p.RenameTo.Set("PostalAddress")
 			return nil
-		})).To(Succeed())
+		},
+	)).To(Succeed())
 
 	initialState, err := RunTestPipeline(
 		NewState(defs),

--- a/v2/tools/generator/internal/codegen/pipeline/repair_skipping_properties.go
+++ b/v2/tools/generator/internal/codegen/pipeline/repair_skipping_properties.go
@@ -78,7 +78,8 @@ func RepairSkippingProperties(
 			}
 
 			return state.WithOverlaidDefinitions(defs), err
-		})
+		},
+	)
 
 	// We have to have a conversion graph to detect skipping properties
 	stage.RequiresPrerequisiteStages(CreateConversionGraphStageID)
@@ -190,7 +191,8 @@ func (repairer *skippingPropertyRepairer) RepairSkippedProperties() (astmodel.Ty
 			return nil, eris.Wrapf(
 				err,
 				"failed to find connected definitions from %s",
-				originalDef.Name())
+				originalDef.Name(),
+			)
 		}
 
 		// Rename all the types, and their references, to copy them into the compat package
@@ -203,14 +205,16 @@ func (repairer *skippingPropertyRepairer) RepairSkippedProperties() (astmodel.Ty
 				}
 
 				return result
-			})
+			},
+		)
 		newDefs, err := renamer.RenameAll(defs)
 		if err != nil {
 			return nil, eris.Wrapf(
 				err,
 				"failed to rename connected definitions from %s into package %s",
 				originalDef.Name(),
-				compatPackage)
+				compatPackage,
+			)
 		}
 
 		// If the repair added any new types (mostly it won't), include them in the result.
@@ -226,7 +230,8 @@ func (repairer *skippingPropertyRepairer) RepairSkippedProperties() (astmodel.Ty
 	if len(errs) > 0 {
 		return nil, eris.Wrapf(
 			kerrors.NewAggregate(errs),
-			"failed to repair skipping properties")
+			"failed to repair skipping properties",
+		)
 	}
 
 	return result, nil
@@ -313,7 +318,8 @@ func (repairer *skippingPropertyRepairer) createRepairs(
 	repairer.log.V(2).Info(
 		"Found skipping property with different shape, constructing compat types to repair",
 		"lastObserved", lastObserved.String(),
-		"reintroduced", reintroduced.String())
+		"reintroduced", reintroduced.String(),
+	)
 
 	// We've found a skipping property with a different shape. If it's a TypeName we need to repair it.
 	// We do this by creating a new type that has the same shape as the missing property, injected just prior to
@@ -344,7 +350,8 @@ func (repairer *skippingPropertyRepairer) createRepairs(
 		return nil, eris.Wrapf(
 			err,
 			"failed to repair the rest of the chain after reintroduction at %s",
-			reintroduced)
+			reintroduced,
+		)
 	}
 
 	if result == nil {
@@ -451,12 +458,14 @@ func (repairer *skippingPropertyRepairer) mergeRepairs(
 		// as a part of the conversion process bewteeen an API version and the storage version.
 		if astmodel.ComparePathAndVersion(
 			proposedRepair.InternalPackageReference().ImportPath(),
-			existingRepair.InternalPackageReference().ImportPath()) > 0 {
+			existingRepair.InternalPackageReference().ImportPath(),
+		) > 0 {
 			repairer.log.V(1).Info(
 				"Conflicting repairs for compatibility type, using newer",
 				"type", source,
 				"using", proposedRepair,
-				"discarding", existingRepair)
+				"discarding", existingRepair,
+			)
 			into[source] = proposedRepair
 		}
 	}

--- a/v2/tools/generator/internal/codegen/pipeline/repair_skipping_properties_golden_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/repair_skipping_properties_golden_test.go
@@ -69,5 +69,6 @@ func TestGolden_RepairSkippingProperties_WhenPropertyTypesDiffer_GeneratesExpect
 	test.AssertPackagesGenerateExpectedCode(
 		t,
 		finalState.Definitions(),
-		test.DiffWith(comparisonState.Definitions().AsSlice()...))
+		test.DiffWith(comparisonState.Definitions().AsSlice()...),
+	)
 }

--- a/v2/tools/generator/internal/codegen/pipeline/repair_skipping_properties_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/repair_skipping_properties_test.go
@@ -237,7 +237,8 @@ func Test_RepairSkippingProperties_WhenPropertyTypesDiffer_InjectsExpectedAdditi
 
 	expected := astmodel.MakeInternalTypeName(
 		astmodel.MakeCompatPackageReference(test.Pkg2021s),
-		"Residence")
+		"Residence",
+	)
 	g.Expect(finalState.definitions).To(HaveKey(expected))
 }
 

--- a/v2/tools/generator/internal/codegen/pipeline/replace_anytype_with_json_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/replace_anytype_with_json_test.go
@@ -78,7 +78,8 @@ func TestReplacingMapMapInterface(t *testing.T) {
 	// should be a map[string]JSON.
 	expectedType := astmodel.NewMapType(
 		astmodel.StringType,
-		astmodel.JSONType)
+		astmodel.JSONType,
+	)
 
 	finalDefinitions := finalState.Definitions()
 	aDef := finalDefinitions[aName]

--- a/v2/tools/generator/internal/codegen/pipeline/report_resource_structure.go
+++ b/v2/tools/generator/internal/codegen/pipeline/report_resource_structure.go
@@ -28,7 +28,8 @@ func ReportResourceStructure(configuration *config.Configuration) *Stage {
 			report := NewResourceStructureReport(state.Definitions())
 			err := report.SaveReports(configuration.FullTypesOutputPath())
 			return state, err
-		})
+		},
+	)
 }
 
 type ResourceStructureReport struct {

--- a/v2/tools/generator/internal/codegen/pipeline/report_resource_versions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/report_resource_versions.go
@@ -66,7 +66,8 @@ func ReportResourceVersions(configuration *config.Configuration) *Stage {
 
 			err = configuration.ObjectModelConfiguration.SupportedFrom.VerifyConsumed()
 			return state, err
-		})
+		},
+	)
 }
 
 type ResourceVersionsReport struct {
@@ -163,7 +164,8 @@ func (report *ResourceVersionsReport) loadFragments() error {
 
 			report.availableFragments[name] = string(content)
 			return nil
-		})
+		},
+	)
 	if err != nil {
 		return eris.Wrapf(err, "Unable to load fragments from %q", fragmentsPath)
 	}
@@ -391,32 +393,37 @@ func (report *ResourceVersionsReport) writeGroupSections(
 	deprecatedSection := createSection(
 		"deprecated",
 		"Deprecated",
-		releasedResources.Where(report.isDeprecatedResource))
+		releasedResources.Where(report.isDeprecatedResource),
+	)
 
 	// Create a section for all prerelease resources (those not yet released)
 	prereleaseSection := createSection(
 		"prerelease",
 		"Next Release",
-		releasedResources.Where(report.isUnreleasedResource))
+		releasedResources.Where(report.isUnreleasedResource),
+	)
 
 	// Create a section for the latest versions of all supported resources
 	latestSection := createSection(
 		"latest",
 		"Latest Released Versions",
-		findRecommendedReleases(releasedResources))
+		findRecommendedReleases(releasedResources),
+	)
 
 	// Create a section for all other supported versions
 	otherSection := createSection(
 		"other",
 		"Other Supported Versions",
-		releasedResources)
+		releasedResources,
+	)
 
 	// Create an empty section for all released resources
 	// (This will initially be empty, but )
 	releasedSection := createSection(
 		"released",
 		"Released",
-		set.Make[ResourceVersionsReportResourceItem]())
+		set.Make[ResourceVersionsReportResourceItem](),
+	)
 
 	// If every resource is the latest version, move them to the released section
 	if len(otherSection.kinds) == 0 {
@@ -438,7 +445,8 @@ func (report *ResourceVersionsReport) writeGroupSections(
 			section.id,
 			"### "+section.title,
 			section.kinds,
-			buffer)
+			buffer,
+		)
 		if err != nil {
 			return eris.Wrapf(err, "writing section %s for group %s", section.id, group)
 		}
@@ -582,7 +590,8 @@ func (report *ResourceVersionsReport) createTable(
 		armVersion,
 		crdVersion,
 		supportedFrom,
-		sample)
+		sample,
+	)
 
 	toIterate := items.Values()
 	slices.SortFunc(
@@ -598,7 +607,8 @@ func (report *ResourceVersionsReport) createTable(
 
 			// Reversed parameters because we want more recent versions listed first
 			return astmodel.ComparePathAndVersion(right.PackageReference().ImportPath(), left.PackageReference().ImportPath())
-		})
+		},
+	)
 
 	sampleLinks, err := report.FindSampleLinks(info.Group)
 	if err != nil {
@@ -623,7 +633,8 @@ func (report *ResourceVersionsReport) createTable(
 			armVersion,
 			crdVersion,
 			supportedFrom,
-			sample)
+			sample,
+		)
 	}
 
 	return result, nil
@@ -888,14 +899,16 @@ func (report *ResourceVersionsReport) groupInfo(
 			saveCandidate(
 				strings.TrimPrefix(provider, prefix),
 				provider,
-				best)
+				best,
+			)
 		} else if strings.HasPrefix(strings.ToLower(provider), strings.ToLower(prefix)) {
 			// If the provider starts with "Microsoft." (but doesn't match the case exactly),
 			// that's not so good, but better than the defaults
 			saveCandidate(
 				caser.String(provider[len(prefix):]),
 				caser.String(provider),
-				better)
+				better,
+			)
 		} else {
 			// Just use what we have
 			saveCandidate(provider, provider, good)

--- a/v2/tools/generator/internal/codegen/pipeline/report_resource_versions_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/report_resource_versions_test.go
@@ -32,14 +32,16 @@ func TestGolden_ReportAllResourceVersions(t *testing.T) {
 		test.Pkg2020,
 		"Person",
 		test.CreateSpec(test.Pkg2020, "Person"),
-		test.CreateStatus(test.Pkg2020, "Person")).
+		test.CreateStatus(test.Pkg2020, "Person"),
+	).
 		WithDescription(person2020desc...)
 
 	address2020 := test.CreateResource(
 		test.Pkg2020,
 		"Address",
 		test.CreateSpec(test.Pkg2020, "Address"),
-		test.CreateStatus(test.Pkg2020, "Address"))
+		test.CreateStatus(test.Pkg2020, "Address"),
+	)
 
 	person2021desc := []string{
 		"This is a newer version",
@@ -49,20 +51,23 @@ func TestGolden_ReportAllResourceVersions(t *testing.T) {
 		test.Pkg2021,
 		"Person",
 		test.CreateSpec(test.Pkg2021, "Person"),
-		test.CreateStatus(test.Pkg2021, "Person")).
+		test.CreateStatus(test.Pkg2021, "Person"),
+	).
 		WithDescription(person2021desc...)
 
 	address2021 := test.CreateResource(
 		test.Pkg2021,
 		"Address",
 		test.CreateSpec(test.Pkg2021, "Address"),
-		test.CreateStatus(test.Pkg2021, "Address"))
+		test.CreateStatus(test.Pkg2021, "Address"),
+	)
 
 	batch2021 := test.CreateResource(
 		test.BatchPkg2021,
 		"BatchAccount",
 		test.CreateSpec(test.BatchPkg2021, "BatchAccount"),
-		test.CreateStatus(test.BatchPkg2021, "BatchAccount"))
+		test.CreateStatus(test.BatchPkg2021, "BatchAccount"),
+	)
 
 	defs := make(astmodel.TypeDefinitionSet)
 	defs.AddAll(person2020, address2020, person2021, address2021, batch2021)
@@ -92,7 +97,8 @@ func TestGolden_ReportAllResourceVersions(t *testing.T) {
 	var buffer strings.Builder
 	g.Expect(report.WriteAllResourcesReportToBuffer(
 		"", // No Frontmatter
-		&buffer)).
+		&buffer,
+	)).
 		To(Succeed())
 
 	gold.Assert(t, t.Name(), []byte(buffer.String()))

--- a/v2/tools/generator/internal/codegen/pipeline/report_type_versions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/report_type_versions.go
@@ -35,7 +35,8 @@ func ReportOnTypesAndVersions(configuration *config.Configuration) *Stage {
 			report.Summarize(definitions)
 			err := report.WriteTo(configuration.FullTypesOutputPath())
 			return state, err
-		})
+		},
+	)
 }
 
 type PackagesMatrixReport struct {

--- a/v2/tools/generator/internal/codegen/pipeline/report_upgradable_resources.go
+++ b/v2/tools/generator/internal/codegen/pipeline/report_upgradable_resources.go
@@ -64,7 +64,8 @@ func ReportUpgradableResources(configuration *config.Configuration) *Stage {
 			}
 
 			return state, nil
-		})
+		},
+	)
 
 	stage.RequiresPrerequisiteStages(CatalogKnownResourcesStageID)
 	return stage
@@ -330,7 +331,8 @@ func (r *UpgradableResourcesReport) writeTo(buffer *strings.Builder, now time.Ti
 				"Available Stable",
 				"Supported Stable",
 				"Available Preview",
-				"Supported Preview")
+				"Supported Preview",
+			)
 		}
 
 		stableSupported := pkgRefVersion(item.supportedStable)
@@ -368,7 +370,8 @@ func (r *UpgradableResourcesReport) writeTo(buffer *strings.Builder, now time.Ti
 			stableAvail,
 			orDash(stableSupported),
 			previewAvail,
-			orDash(previewSupported))
+			orDash(previewSupported),
+		)
 	}
 
 	flushTable()

--- a/v2/tools/generator/internal/codegen/pipeline/resource_conversion_test_cases.go
+++ b/v2/tools/generator/internal/codegen/pipeline/resource_conversion_test_cases.go
@@ -43,12 +43,14 @@ func InjectResourceConversionTestCases(idFactory astmodel.IdentifierFactory) *St
 			}
 
 			return state.WithOverlaidDefinitions(modifiedDefs), nil
-		})
+		},
+	)
 
 	stage.RequiresPrerequisiteStages(
 		InjectPropertyAssignmentFunctionsStageID, // Need PropertyAssignmentFunctions to test
 		ImplementConvertibleInterfaceStageID,     // Need the conversions.Convertible interface to be present
-		InjectJSONSerializationTestsID)           // We reuse the generators from the JSON tests
+		InjectJSONSerializationTestsID,
+	) // We reuse the generators from the JSON tests
 
 	return stage
 }

--- a/v2/tools/generator/internal/codegen/pipeline/resource_conversion_test_cases_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/resource_conversion_test_cases_test.go
@@ -29,7 +29,8 @@ func TestGolden_InjectResourceConversionTestCases(t *testing.T) {
 		"Person",
 		test.FullNameProperty,
 		test.FamilyNameProperty,
-		test.KnownAsProperty)
+		test.KnownAsProperty,
+	)
 	statusV1 := test.CreateStatus(test.Pkg2020, "Person")
 	resourceV1 := test.CreateResource(test.Pkg2020, "Person", specV1, statusV1)
 
@@ -42,7 +43,8 @@ func TestGolden_InjectResourceConversionTestCases(t *testing.T) {
 		test.FamilyNameProperty,
 		test.KnownAsProperty,
 		test.ResidentialAddress2021,
-		test.PostalAddress2021)
+		test.PostalAddress2021,
+	)
 	statusV2 := test.CreateStatus(test.Pkg2021, "Person")
 	resourceV2 := test.CreateResource(test.Pkg2021, "Person", specV2, statusV2)
 
@@ -62,7 +64,8 @@ func TestGolden_InjectResourceConversionTestCases(t *testing.T) {
 
 	finalState, err := RunTestPipeline(
 		initialState,
-		InjectResourceConversionTestCases(idFactory))
+		InjectResourceConversionTestCases(idFactory),
+	)
 	g.Expect(err).To(Succeed())
 
 	test.AssertPackagesGenerateExpectedCode(t, finalState.Definitions(), test.IncludeTestFiles())

--- a/v2/tools/generator/internal/codegen/pipeline/resource_registration_file.go
+++ b/v2/tools/generator/internal/codegen/pipeline/resource_registration_file.go
@@ -72,7 +72,8 @@ func (r *ResourceRegistrationFile) AsAst() (*dst.File, error) {
 		// Do we need a specific PackageReference type for this case?
 		astmodel.MakeNamedLocalPackageReference("", "controllers", ""), // TODO: This should come from a config
 		packageReferences,
-		nil)
+		nil,
+	)
 
 	r.storageVersionToVersionMap = r.getStorageVersionToVersionsMap(codeGenContext)
 
@@ -364,7 +365,9 @@ func (r *ResourceRegistrationFile) createGetKnownStorageTypesFunc(
 	resultIdent := dst.NewIdent("result")
 	resultType := astmodel.NewArrayType(
 		astmodel.NewOptionalType(
-			astmodel.StorageTypeRegistrationType))
+			astmodel.StorageTypeRegistrationType,
+		),
+	)
 	resultTypeExpr, err := resultType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
 		return nil, eris.Wrap(err, "creating type expression for StorageTypeRegistrationType")
@@ -373,7 +376,8 @@ func (r *ResourceRegistrationFile) createGetKnownStorageTypesFunc(
 	resultVar := astbuilder.LocalVariableDeclaration(
 		resultIdent.String(),
 		resultTypeExpr,
-		"")
+		"",
+	)
 
 	sort.Slice(r.storageVersionResources, orderByImportedTypeName(codeGenerationContext, r.storageVersionResources))
 
@@ -437,7 +441,8 @@ func (r *ResourceRegistrationFile) createGetKnownStorageTypesFunc(
 
 		appendStmt := astbuilder.AppendItemToSlice(
 			resultIdent,
-			astbuilder.AddrOf(newStorageTypeBuilder.Build()))
+			astbuilder.AddrOf(newStorageTypeBuilder.Build()),
+		)
 		resourceAppendStatements = append(resourceAppendStatements, appendStmt)
 	}
 
@@ -451,7 +456,8 @@ func (r *ResourceRegistrationFile) createGetKnownStorageTypesFunc(
 	}
 
 	f.AddReturn(
-		resultTypeExpr)
+		resultTypeExpr,
+	)
 	f.AddComments(funcComment)
 
 	return f.DefineFunc(), nil
@@ -474,7 +480,8 @@ func (r *ResourceRegistrationFile) createGetResourceExtensions(
 	resultVar := astbuilder.LocalVariableDeclaration(
 		resultIdent.String(),
 		resultTypeExpr,
-		"")
+		"",
+	)
 
 	resourceAppendStatements := make([]dst.Stmt, 0, len(r.resourceExtensions))
 	for _, typeName := range r.resourceExtensions {
@@ -535,7 +542,8 @@ func (r *ResourceRegistrationFile) createCreateSchemeFunc(codeGenerationContext 
 
 	clientGoSchemeAssign := astbuilder.SimpleAssignment(
 		dst.NewIdent(ignore),
-		astbuilder.CallQualifiedFunc(clientGoScheme, addToScheme, dst.NewIdent(scheme)))
+		astbuilder.CallQualifiedFunc(clientGoScheme, addToScheme, dst.NewIdent(scheme)),
+	)
 
 	importedPackages := r.getImportedPackages()
 	importedPackageNames := make([]string, 0, len(importedPackages))
@@ -556,7 +564,8 @@ func (r *ResourceRegistrationFile) createCreateSchemeFunc(codeGenerationContext 
 	for _, group := range importedPackageNames {
 		groupSchemeAssign := astbuilder.SimpleAssignment(
 			dst.NewIdent(ignore),
-			astbuilder.CallQualifiedFunc(group, addToScheme, dst.NewIdent(scheme)))
+			astbuilder.CallQualifiedFunc(group, addToScheme, dst.NewIdent(scheme)),
+		)
 
 		groupVersionAssignments = append(groupVersionAssignments, groupSchemeAssign)
 	}
@@ -623,7 +632,8 @@ func (r *ResourceRegistrationFile) makeWatchesExpr(
 		astmodel.SecretType,
 		"watchSecretsFactory",
 		r.secretPropertyKeys,
-		codeGenerationContext)
+		codeGenerationContext,
+	)
 	if err != nil {
 		return nil, eris.Wrap(err, "creating watches expression for secrets")
 	}
@@ -633,7 +643,8 @@ func (r *ResourceRegistrationFile) makeWatchesExpr(
 		astmodel.ConfigMapType,
 		"watchConfigMapsFactory",
 		r.configMapPropertyKeys,
-		codeGenerationContext)
+		codeGenerationContext,
+	)
 	if err != nil {
 		return nil, eris.Wrap(err, "creating watches expression for configmaps")
 	}
@@ -721,7 +732,8 @@ func (r *ResourceRegistrationFile) makeSimpleWatchesExpr(
 	eventHandler := astbuilder.CallFunc(
 		watchHelperFuncName,
 		slice,
-		astbuilder.AddrOf(astbuilder.NewCompositeLiteralBuilder(listTypeExpr).Build()))
+		astbuilder.AddrOf(astbuilder.NewCompositeLiteralBuilder(listTypeExpr).Build()),
+	)
 	newWatchBuilder.AddField("MakeEventHandler", eventHandler)
 
 	return newWatchBuilder.Build(), nil

--- a/v2/tools/generator/internal/codegen/pipeline/simplify_definitions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/simplify_definitions.go
@@ -39,7 +39,8 @@ func SimplifyDefinitions() *Stage {
 			}
 
 			return state.WithDefinitions(result), nil
-		})
+		},
+	)
 }
 
 func createSimplifyingVisitor() astmodel.TypeVisitor[any] {

--- a/v2/tools/generator/internal/codegen/pipeline/stage.go
+++ b/v2/tools/generator/internal/codegen/pipeline/stage.go
@@ -64,7 +64,8 @@ func (stage *Stage) RequiresPrerequisiteStages(prerequisites ...string) {
 			"Prerequisites of stage '%s' already set to '%s'; cannot modify to '%s'.",
 			stage.id,
 			strings.Join(stage.prerequisites, "; "),
-			strings.Join(prerequisites, "; ")))
+			strings.Join(prerequisites, "; "),
+		))
 	}
 
 	stage.prerequisites = prerequisites
@@ -88,7 +89,8 @@ func (stage *Stage) RequiresPostrequisiteStages(postrequisites ...string) {
 			"Postrequisites of stage '%s' already set to '%s'; cannot modify to '%s'.",
 			stage.id,
 			strings.Join(stage.postrequisites, "; "),
-			strings.Join(postrequisites, "; ")))
+			strings.Join(postrequisites, "; "),
+		))
 	}
 
 	stage.postrequisites = postrequisites

--- a/v2/tools/generator/internal/codegen/pipeline/stage_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/stage_test.go
@@ -96,5 +96,6 @@ func NewFakeStage(id string) *Stage {
 		"Stage "+id,
 		func(ctx context.Context, state *State) (*State, error) {
 			return state, nil
-		})
+		},
+	)
 }

--- a/v2/tools/generator/internal/codegen/pipeline/state.go
+++ b/v2/tools/generator/internal/codegen/pipeline/state.go
@@ -155,7 +155,8 @@ func GetStateData[I any](
 				"state information found for key %s of type %T, expected %T",
 				key,
 				value,
-				zero)
+				zero,
+			)
 
 	}
 

--- a/v2/tools/generator/internal/codegen/pipeline/strip_descriptions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/strip_descriptions.go
@@ -28,7 +28,8 @@ func StripDocumentation(configuration *config.Configuration, log logr.Logger) *S
 
 			walker := astmodel.NewTypeWalker(
 				state.Definitions(),
-				visitor)
+				visitor,
+			)
 			walker.AfterVisit = stripTypeDefinitionDescription
 
 			// TODO: This should be used sparingly as a stop-gap if a CRD gets too large.
@@ -66,11 +67,13 @@ func StripDocumentation(configuration *config.Configuration, log logr.Logger) *S
 			if err != nil {
 				return nil, eris.Wrap(
 					err,
-					"Found unused $stripDocumentation configurations; these can only be specified on top-level resources.")
+					"Found unused $stripDocumentation configurations; these can only be specified on top-level resources.",
+				)
 			}
 
 			return state.WithOverlaidDefinitions(result), nil
-		})
+		},
+	)
 
 	return stage
 }

--- a/v2/tools/generator/internal/codegen/pipeline/strip_unused_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/strip_unused_types.go
@@ -30,7 +30,8 @@ func StripUnreferencedTypeDefinitions() *Stage {
 			}
 
 			return state.WithDefinitions(result), nil
-		})
+		},
+	)
 }
 
 // StripUnusedDefinitions removes all types that aren't in roots or

--- a/v2/tools/generator/internal/codegen/pipeline/strip_unused_types_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/strip_unused_types_test.go
@@ -20,7 +20,8 @@ func TestConnectionChecker_Avoids_Cycles(t *testing.T) {
 	makeName := func(name string) astmodel.TypeName {
 		return astmodel.MakeInternalTypeName(
 			test.MakeLocalPackageReference("demo", "v1"),
-			name)
+			name,
+		)
 	}
 
 	makeSet := func(names ...string) astmodel.TypeNameSet {

--- a/v2/tools/generator/internal/codegen/pipeline/transform_validated_floats.go
+++ b/v2/tools/generator/internal/codegen/pipeline/transform_validated_floats.go
@@ -29,7 +29,8 @@ func TransformValidatedFloats() *Stage {
 			}
 
 			return state.WithOverlaidDefinitions(result), nil
-		})
+		},
+	)
 
 	stage.RequiresPrerequisiteStages(RemoveStatusPropertyValidationsStageID)
 

--- a/v2/tools/generator/internal/codegen/pipeline/unroll_recursive_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/unroll_recursive_types.go
@@ -80,5 +80,6 @@ func UnrollRecursiveTypes(log logr.Logger) *Stage {
 			result.AddTypes(fixer.Types())
 
 			return state.WithDefinitions(result), nil
-		})
+		},
+	)
 }

--- a/v2/tools/generator/internal/codegen/pipeline/verify_no_errored_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/verify_no_errored_types.go
@@ -41,7 +41,8 @@ func VerifyNoErroredTypes() *Stage {
 			// This stage doesn't change the generated types at all - if the verification
 			// has passed, just return the same defs we started with
 			return state, nil
-		})
+		},
+	)
 
 	return stage
 }
@@ -55,7 +56,8 @@ func newErrorCollectingVisitor() *errorCollectingVisitor {
 	includePropertyContext := astmodel.MakeIdentityVisitOfObjectType(
 		func(_ *astmodel.ObjectType, prop *astmodel.PropertyDefinition, ctx erroredTypeVisitorContext) (erroredTypeVisitorContext, error) {
 			return ctx.WithProperty(prop.PropertyName()), nil
-		})
+		},
+	)
 
 	result := &errorCollectingVisitor{}
 	result.visitor = astmodel.TypeVisitorBuilder[erroredTypeVisitorContext]{

--- a/v2/tools/generator/internal/codegen/storage/conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/storage/conversion_graph.go
@@ -84,7 +84,8 @@ func (graph *ConversionGraph) FindNextType(
 	// renamed in one version and renamed back in a later one)
 	if astmodel.ComparePathAndVersion(
 		nextType.InternalPackageReference().APIVersion(),
-		renamedType.InternalPackageReference().APIVersion()) < 0 {
+		renamedType.InternalPackageReference().APIVersion(),
+	) < 0 {
 		// nextType came first
 		return nextType, nil
 	}

--- a/v2/tools/generator/internal/codegen/storage/conversion_graph_test.go
+++ b/v2/tools/generator/internal/codegen/storage/conversion_graph_test.go
@@ -160,7 +160,9 @@ func Test_ConversionGraph_WhenRenameConfigured_FindsRenamedType(t *testing.T) {
 			func(tc *config.TypeConfiguration) error {
 				tc.NameInNextVersion.Set(party2021.Name().Name())
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 
 	// Create a builder use it to configure a graph to test
@@ -201,7 +203,9 @@ func Test_ConversionGraph_WhenRenameSpecifiesMissingType_ReturnsError(t *testing
 			func(tc *config.TypeConfiguration) error {
 				tc.NameInNextVersion.Set("Phantom")
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 
 	// Create a builder use it to configure a graph to test
@@ -245,7 +249,9 @@ func Test_ConversionGraph_WhenRenameSpecifiesConflictingType_ReturnsError(t *tes
 			func(tc *config.TypeConfiguration) error {
 				tc.NameInNextVersion.Set(party2021.Name().Name())
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 
 	// Create a builder use it to configure a graph to test
@@ -325,7 +331,8 @@ func TestConversionGraph_WithAResourceOnlyInPreviewVersions_HasExpectedTransitio
 				t.Parallel()
 				gg := NewGomegaWithT(t)
 				gg.Expect(graph.LookupTransition(c.from)).To(Equal(c.to))
-			})
+			},
+		)
 	}
 }
 
@@ -441,9 +448,11 @@ func Test_ConversionGraph_FindInPath_ReturnsExpectedResult(t *testing.T) {
 					func(t astmodel.InternalTypeName) bool {
 						count++
 						return t == c.end
-					})
+					},
+				)
 				gg.Expect(found).To(BeTrue())
 				gg.Expect(count).To(Equal(c.expectedTypes))
-			})
+			},
+		)
 	}
 }

--- a/v2/tools/generator/internal/codegen/storage/group_conversion_graph_builder.go
+++ b/v2/tools/generator/internal/codegen/storage/group_conversion_graph_builder.go
@@ -82,7 +82,8 @@ func (b *GroupConversionGraphBuilder) Build() (*GroupConversionGraph, error) {
 		packages,
 		func(left astmodel.InternalPackageReference, right astmodel.InternalPackageReference) int {
 			return astmodel.ComparePathAndVersion(left.ImportPath(), right.ImportPath())
-		})
+		},
+	)
 
 	for _, s := range stages {
 		s(packages)

--- a/v2/tools/generator/internal/codegen/storage/property_converter.go
+++ b/v2/tools/generator/internal/codegen/storage/property_converter.go
@@ -62,7 +62,8 @@ func (p *PropertyConverter) ConvertProperty(property *astmodel.PropertyDefinitio
 	return nil, fmt.Errorf(
 		"failed to find a conversion for property %s (%s)",
 		property.PropertyName(),
-		astmodel.DebugDescription(property.PropertyType()))
+		astmodel.DebugDescription(property.PropertyType()),
+	)
 }
 
 // stripAllValidations removes all validations

--- a/v2/tools/generator/internal/codegen/storage/resource_conversion_graph_builder.go
+++ b/v2/tools/generator/internal/codegen/storage/resource_conversion_graph_builder.go
@@ -57,8 +57,10 @@ func (b *ResourceConversionGraphBuilder) Build() (*ResourceConversionGraph, erro
 		func(i astmodel.InternalTypeName, j astmodel.InternalTypeName) int {
 			return astmodel.ComparePathAndVersion(
 				i.PackageReference().ImportPath(),
-				j.PackageReference().ImportPath())
-		})
+				j.PackageReference().ImportPath(),
+			)
+		},
+	)
 
 	for _, s := range stages {
 		s(toProcess)
@@ -70,7 +72,8 @@ func (b *ResourceConversionGraphBuilder) Build() (*ResourceConversionGraph, erro
 		return nil, eris.Errorf(
 			"expected to have linked all references in with name %q, but have %d left",
 			b.name,
-			len(toProcess))
+			len(toProcess),
+		)
 	}
 
 	result := &ResourceConversionGraph{
@@ -162,7 +165,8 @@ func isCompatibilityPackage(ref astmodel.PackageReference) bool {
 	default:
 		msg := fmt.Sprintf(
 			"unexpected PackageReference implementation %T",
-			ref)
+			ref,
+		)
 		panic(msg)
 	}
 }
@@ -196,7 +200,8 @@ func asNewStylePackageReference(
 	default:
 		msg := fmt.Sprintf(
 			"unexpected PackageReference implementation %T",
-			ref)
+			ref,
+		)
 		panic(msg)
 	}
 }

--- a/v2/tools/generator/internal/config/configuration.go
+++ b/v2/tools/generator/internal/config/configuration.go
@@ -79,7 +79,8 @@ func (config *Configuration) LocalPathPrefix() string {
 func (config *Configuration) FullTypesOutputPath() string {
 	return filepath.Join(
 		filepath.Dir(config.DestinationGoModuleFile),
-		config.TypesOutputPath)
+		config.TypesOutputPath,
+	)
 }
 
 func (config *Configuration) FullTypesRegistrationOutputFilePath() string {
@@ -89,7 +90,8 @@ func (config *Configuration) FullTypesRegistrationOutputFilePath() string {
 
 	return filepath.Join(
 		filepath.Dir(config.DestinationGoModuleFile),
-		config.TypeRegistrationOutputFile)
+		config.TypeRegistrationOutputFile,
+	)
 }
 
 func (config *Configuration) FullSamplesPath() string {
@@ -100,7 +102,8 @@ func (config *Configuration) FullSamplesPath() string {
 	if config.DestinationGoModuleFile != "" {
 		return filepath.Join(
 			filepath.Dir(config.DestinationGoModuleFile),
-			config.SamplesPath)
+			config.SamplesPath,
+		)
 	}
 
 	result, err := filepath.Abs(config.SamplesPath)
@@ -288,7 +291,8 @@ func (config *Configuration) ShouldPrune(typeName astmodel.InternalTypeName) (re
 	if !config.ObjectModelConfiguration.IsEmpty() &&
 		!config.ObjectModelConfiguration.IsGroupConfigured(typeName.InternalPackageReference()) {
 		return Prune, fmt.Sprintf(
-			"No resources configured for export from %s", typeName.InternalPackageReference().PackagePath())
+			"No resources configured for export from %s", typeName.InternalPackageReference().PackagePath(),
+		)
 	}
 
 	// By default, we include all types

--- a/v2/tools/generator/internal/config/configuration_visitor_test.go
+++ b/v2/tools/generator/internal/config/configuration_visitor_test.go
@@ -26,7 +26,8 @@ func TestConfigurationVisitor_WhenVisitingASpecificVersion_VisitsExpectedVersion
 		func(configuration *VersionConfiguration) error {
 			seen.Add(configuration.name)
 			return nil
-		})
+		},
+	)
 
 	g.Expect(visitor.visit(omc)).To(Succeed())
 	g.Expect(seen).To(HaveLen(1))
@@ -43,7 +44,8 @@ func TestConfigurationVisitor_WhenVisitingEveryType_VisitsExpectedTypes(t *testi
 		func(configuration *TypeConfiguration) error {
 			seen.Add(configuration.name)
 			return nil
-		})
+		},
+	)
 
 	g.Expect(visitor.visit(omc)).To(Succeed())
 	g.Expect(seen).To(HaveLen(2))
@@ -63,7 +65,8 @@ func TestConfigurationVisitor_WhenVisitingASpecificType_VisitsExpectedType(t *te
 		func(configuration *TypeConfiguration) error {
 			seen.Add(configuration.name)
 			return nil
-		})
+		},
+	)
 
 	g.Expect(visitor.visit(omc)).To(Succeed())
 	g.Expect(seen).To(HaveLen(1))
@@ -80,7 +83,8 @@ func TestConfigurationVisitor_WhenVisitingEveryProperty_VisitsExpectedProperties
 		func(configuration *PropertyConfiguration) error {
 			seen.Add(configuration.name)
 			return nil
-		})
+		},
+	)
 
 	g.Expect(visitor.visit(omc)).To(Succeed())
 	g.Expect(seen).To(HaveLen(5))
@@ -104,7 +108,8 @@ func TestConfigurationVisitor_WhenVisitingASpecificProperty_VisitsExpectedProper
 		func(configuration *PropertyConfiguration) error {
 			seen.Add(configuration.name)
 			return nil
-		})
+		},
+	)
 
 	g.Expect(visitor.visit(omc)).To(Succeed())
 	g.Expect(seen).To(HaveLen(1))
@@ -121,7 +126,8 @@ func TestConfigurationVisitor_WhenVisitingAllGroups_VisitsExpectedGroups(t *test
 		func(configuration *GroupConfiguration) error {
 			seen.Add(configuration.name)
 			return nil
-		})
+		},
+	)
 
 	g.Expect(visitor.visit(omc)).To(Succeed())
 	g.Expect(seen).To(HaveLen(2))
@@ -139,7 +145,8 @@ func TestConfigurationVisitor_WhenVisitingAllVersions_VisitsExpectedVersions(t *
 		func(configuration *VersionConfiguration) error {
 			seen.Add(configuration.name)
 			return nil
-		})
+		},
+	)
 
 	g.Expect(visitor.visit(omc)).To(Succeed())
 	g.Expect(seen).To(HaveLen(4))
@@ -181,10 +188,12 @@ func createTestObjectModelConfigurationForVisitor(t *testing.T) *ObjectModelConf
 	group2 := NewGroupConfiguration("OtherGroup")
 	g.Expect(group2.addVersion(
 		"v1",
-		NewVersionConfiguration("v1"))).To(Succeed())
+		NewVersionConfiguration("v1"),
+	)).To(Succeed())
 	g.Expect(group2.addVersion(
 		"v2",
-		NewVersionConfiguration("v2"))).To(Succeed())
+		NewVersionConfiguration("v2"),
+	)).To(Succeed())
 
 	modelConfig := NewObjectModelConfiguration()
 	g.Expect(modelConfig.addGroup(group.name, group)).To(Succeed())

--- a/v2/tools/generator/internal/config/field_matcher_test.go
+++ b/v2/tools/generator/internal/config/field_matcher_test.go
@@ -71,6 +71,7 @@ func TestFieldMatcher_IsRestrictive_GivesExpectedResults(t *testing.T) {
 				var h matcherHost
 				g.Expect(yaml.Unmarshal([]byte(c.yaml), &h)).To(Succeed())
 				g.Expect(h.Field.IsRestrictive()).To(Equal(c.restrictive))
-			})
+			},
+		)
 	}
 }

--- a/v2/tools/generator/internal/config/group_access.go
+++ b/v2/tools/generator/internal/config/group_access.go
@@ -44,7 +44,8 @@ func (a *groupAccess[T]) Lookup(
 		func(configuration *GroupConfiguration) error {
 			c = a.accessor(configuration)
 			return nil
-		})
+		},
+	)
 
 	err := visitor.visit(a.model)
 	if err != nil {
@@ -65,7 +66,8 @@ func (a *groupAccess[T]) VerifyConsumed() error {
 		func(configuration *GroupConfiguration) error {
 			c := a.accessor(configuration)
 			return c.VerifyConsumed()
-		})
+		},
+	)
 	return visitor.visit(a.model)
 }
 
@@ -75,7 +77,8 @@ func (a *groupAccess[T]) MarkUnconsumed() error {
 			c := a.accessor(configuration)
 			c.MarkUnconsumed()
 			return nil
-		})
+		},
+	)
 
 	return visitor.visit(a.model)
 }

--- a/v2/tools/generator/internal/config/group_access_test.go
+++ b/v2/tools/generator/internal/config/group_access_test.go
@@ -29,14 +29,16 @@ func Test_GroupAccess_Lookup_ReturnsConfiguredValue_WhenPresent(t *testing.T) {
 			func(gc *GroupConfiguration) error {
 				gc.PayloadType.Set(value)
 				return nil
-			}),
+			},
+		),
 	).To(Succeed())
 
 	access := makeGroupAccess[PayloadType](
 		model,
 		func(g *GroupConfiguration) *configurable[PayloadType] {
 			return &g.PayloadType
-		})
+		},
+	)
 
 	// Act
 	actual, ok := access.Lookup(ref)
@@ -62,7 +64,8 @@ func Test_GroupAccess_LookupWithTypeOverride_ReturnsOverriddenValue_WhenPresent(
 			func(tc *GroupConfiguration) error {
 				tc.PayloadType.Set(groupValue)
 				return nil
-			}),
+			},
+		),
 	).To(Succeed())
 	g.Expect(
 		model.ModifyType(
@@ -70,13 +73,15 @@ func Test_GroupAccess_LookupWithTypeOverride_ReturnsOverriddenValue_WhenPresent(
 			func(tc *TypeConfiguration) error {
 				tc.PayloadType.Set(typeValue)
 				return nil
-			}),
+			},
+		),
 	).To(Succeed())
 
 	access := makeGroupAccess[PayloadType](
 		model, func(g *GroupConfiguration) *configurable[PayloadType] {
 			return &g.PayloadType
-		}).
+		},
+	).
 		withTypeOverride(func(t *TypeConfiguration) *configurable[PayloadType] {
 			return &t.PayloadType
 		})
@@ -105,7 +110,8 @@ func Test_GroupAccess_LookupWithTypeOverride_ReturnsGroupValue_WhenNoOverridePre
 			func(tc *GroupConfiguration) error {
 				tc.PayloadType.Set(groupValue)
 				return nil
-			}),
+			},
+		),
 	).To(Succeed())
 	g.Expect(
 		model.ModifyType(
@@ -113,13 +119,15 @@ func Test_GroupAccess_LookupWithTypeOverride_ReturnsGroupValue_WhenNoOverridePre
 			func(tc *TypeConfiguration) error {
 				tc.PayloadType.Set(typeValue)
 				return nil
-			}),
+			},
+		),
 	).To(Succeed())
 
 	access := makeGroupAccess[PayloadType](
 		model, func(g *GroupConfiguration) *configurable[PayloadType] {
 			return &g.PayloadType
-		}).
+		},
+	).
 		withTypeOverride(func(t *TypeConfiguration) *configurable[PayloadType] {
 			return &t.PayloadType
 		})

--- a/v2/tools/generator/internal/config/group_configuration.go
+++ b/v2/tools/generator/internal/config/group_configuration.go
@@ -122,7 +122,8 @@ func (gc *GroupConfiguration) visitVersions(visitor *configurationVisitor) error
 	return eris.Wrapf(
 		kerrors.NewAggregate(errs),
 		"group %s",
-		gc.name)
+		gc.name,
+	)
 }
 
 // findVersion uses the provided PackageReference to work out which nested VersionConfiguration should be used
@@ -213,7 +214,8 @@ func (gc *GroupConfiguration) UnmarshalYAML(value *yaml.Node) error {
 
 		// No handler for this value, return an error
 		return eris.Errorf(
-			"group configuration, unexpected yaml value %s: %s (line %d col %d)", lastID, c.Value, c.Line, c.Column)
+			"group configuration, unexpected yaml value %s: %s (line %d col %d)", lastID, c.Value, c.Line, c.Column,
+		)
 
 	}
 

--- a/v2/tools/generator/internal/config/group_configuration_test.go
+++ b/v2/tools/generator/internal/config/group_configuration_test.go
@@ -120,7 +120,8 @@ func TestGroupConfiguration_WhenVersionConfigurationNotConsumed_ReturnsErrorWith
 	// Lookup $supportedFrom for our type - version is from 2021 but our config has 2022, so it won't be found
 	tn := astmodel.MakeInternalTypeName(
 		test.MakeLocalPackageReference(groupConfig.name, "2021-01-01"),
-		"Person")
+		"Person",
+	)
 
 	_, ok := omConfig.SupportedFrom.Lookup(tn)
 	g.Expect(ok).To(BeFalse())

--- a/v2/tools/generator/internal/config/object_model_configuration.go
+++ b/v2/tools/generator/internal/config/object_model_configuration.go
@@ -78,51 +78,72 @@ func NewObjectModelConfiguration() *ObjectModelConfiguration {
 
 	// Initialize type access fields here (alphabetical, please)
 	result.AzureGeneratedSecrets = makeTypeAccess[[]string](
-		result, func(c *TypeConfiguration) *configurable[[]string] { return &c.AzureGeneratedSecrets })
+		result, func(c *TypeConfiguration) *configurable[[]string] { return &c.AzureGeneratedSecrets },
+	)
 	result.DefaultAzureName = makeTypeAccess[bool](
-		result, func(c *TypeConfiguration) *configurable[bool] { return &c.DefaultAzureName })
+		result, func(c *TypeConfiguration) *configurable[bool] { return &c.DefaultAzureName },
+	)
 	result.ExportAs = makeTypeAccess[string](
-		result, func(c *TypeConfiguration) *configurable[string] { return &c.ExportAs })
+		result, func(c *TypeConfiguration) *configurable[string] { return &c.ExportAs },
+	)
 	result.GeneratedConfigs = makeTypeAccess[map[string]string](
-		result, func(c *TypeConfiguration) *configurable[map[string]string] { return &c.GeneratedConfigs })
+		result, func(c *TypeConfiguration) *configurable[map[string]string] { return &c.GeneratedConfigs },
+	)
 	result.Importable = makeTypeAccess[bool](
-		result, func(c *TypeConfiguration) *configurable[bool] { return &c.Importable })
+		result, func(c *TypeConfiguration) *configurable[bool] { return &c.Importable },
+	)
 	result.IsResource = makeTypeAccess[bool](
-		result, func(c *TypeConfiguration) *configurable[bool] { return &c.IsResource })
+		result, func(c *TypeConfiguration) *configurable[bool] { return &c.IsResource },
+	)
 	result.ManualConfigs = makeTypeAccess[[]string](
-		result, func(c *TypeConfiguration) *configurable[[]string] { return &c.ManualConfigs })
+		result, func(c *TypeConfiguration) *configurable[[]string] { return &c.ManualConfigs },
+	)
 	result.OperatorSpecProperties = makeTypeAccess[[]OperatorSpecPropertyConfiguration](
 		result, func(c *TypeConfiguration) *configurable[[]OperatorSpecPropertyConfiguration] {
 			return &c.OperatorSpecProperties
-		})
+		},
+	)
 	result.RenameTo = makeTypeAccess[string](
-		result, func(c *TypeConfiguration) *configurable[string] { return &c.RenameTo })
+		result, func(c *TypeConfiguration) *configurable[string] { return &c.RenameTo },
+	)
 	result.ResourceEmbeddedInParent = makeTypeAccess[string](
-		result, func(c *TypeConfiguration) *configurable[string] { return &c.ResourceEmbeddedInParent })
+		result, func(c *TypeConfiguration) *configurable[string] { return &c.ResourceEmbeddedInParent },
+	)
 	result.StripDocumentation = makeTypeAccess[bool](
-		result, func(c *TypeConfiguration) *configurable[bool] { return &c.StripDocumentation })
+		result, func(c *TypeConfiguration) *configurable[bool] { return &c.StripDocumentation },
+	)
 	result.SupportedFrom = makeTypeAccess[string](
-		result, func(c *TypeConfiguration) *configurable[string] { return &c.SupportedFrom })
+		result, func(c *TypeConfiguration) *configurable[string] { return &c.SupportedFrom },
+	)
 	result.TypeNameInNextVersion = makeTypeAccess[string](
-		result, func(c *TypeConfiguration) *configurable[string] { return &c.NameInNextVersion })
+		result, func(c *TypeConfiguration) *configurable[string] { return &c.NameInNextVersion },
+	)
 
 	// Initialize property access fields here (alphabetical, please)
 	result.ConversionStrategy = makePropertyAccess[ConversionStrategy](
-		result, func(c *PropertyConfiguration) *configurable[ConversionStrategy] { return &c.ConversionStrategy })
+		result, func(c *PropertyConfiguration) *configurable[ConversionStrategy] { return &c.ConversionStrategy },
+	)
 	result.Description = makePropertyAccess[string](
-		result, func(c *PropertyConfiguration) *configurable[string] { return &c.Description })
+		result, func(c *PropertyConfiguration) *configurable[string] { return &c.Description },
+	)
 	result.ImportConfigMapMode = makePropertyAccess[ImportConfigMapMode](
-		result, func(c *PropertyConfiguration) *configurable[ImportConfigMapMode] { return &c.ImportConfigMapMode })
+		result, func(c *PropertyConfiguration) *configurable[ImportConfigMapMode] { return &c.ImportConfigMapMode },
+	)
 	result.Secrecy = makePropertyAccess[astmodel.ImportSecretMode](
-		result, func(c *PropertyConfiguration) *configurable[astmodel.ImportSecretMode] { return &c.Secrecy })
+		result, func(c *PropertyConfiguration) *configurable[astmodel.ImportSecretMode] { return &c.Secrecy },
+	)
 	result.PropertyNameInNextVersion = makePropertyAccess[string](
-		result, func(c *PropertyConfiguration) *configurable[string] { return &c.NameInNextVersion })
+		result, func(c *PropertyConfiguration) *configurable[string] { return &c.NameInNextVersion },
+	)
 	result.ReferenceType = makePropertyAccess[ReferenceType](
-		result, func(c *PropertyConfiguration) *configurable[ReferenceType] { return &c.ReferenceType })
+		result, func(c *PropertyConfiguration) *configurable[ReferenceType] { return &c.ReferenceType },
+	)
 	result.RenamePropertyTo = makePropertyAccess[string](
-		result, func(c *PropertyConfiguration) *configurable[string] { return &c.RenameTo })
+		result, func(c *PropertyConfiguration) *configurable[string] { return &c.RenameTo },
+	)
 	result.ResourceLifecycleOwnedByParent = makePropertyAccess[string](
-		result, func(c *PropertyConfiguration) *configurable[string] { return &c.ResourceLifecycleOwnedByParent })
+		result, func(c *PropertyConfiguration) *configurable[string] { return &c.ResourceLifecycleOwnedByParent },
+	)
 
 	return result
 }
@@ -173,7 +194,8 @@ func (omc *ObjectModelConfiguration) AddTypeAlias(name astmodel.InternalTypeName
 		name.InternalPackageReference(),
 		func(configuration *VersionConfiguration) error {
 			return configuration.addTypeAlias(name.Name(), alias)
-		})
+		},
+	)
 
 	err := versionVisitor.visit(omc)
 	if err != nil {
@@ -197,7 +219,8 @@ func (omc *ObjectModelConfiguration) FindHandCraftedTypeNames(localPath string) 
 			name := astmodel.MakeInternalTypeName(currentPackage, typeConfig.name)
 			result.Add(name)
 			return nil
-		})
+		},
+	)
 
 	// Collect hand-crafted versions as we see them.
 	// They look like v<n> where n is a small number.
@@ -207,19 +230,22 @@ func (omc *ObjectModelConfiguration) FindHandCraftedTypeNames(localPath string) 
 				currentPackage = astmodel.MakeNamedLocalPackageReference(
 					localPath,
 					currentGroup,
-					verConfig.name)
+					verConfig.name,
+				)
 				return verConfig.visitTypes(typeVisitor)
 			}
 
 			return nil
-		})
+		},
+	)
 
 	// Look inside each group for hand-crafted versions
 	groupVisitor := newEveryGroupConfigurationVisitor(
 		func(groupConfig *GroupConfiguration) error {
 			currentGroup = groupConfig.name
 			return groupConfig.visitVersions(versionVisitor)
-		})
+		},
+	)
 
 	err := groupVisitor.visit(omc)
 	if err != nil {
@@ -323,7 +349,8 @@ func (omc *ObjectModelConfiguration) UnmarshalYAML(value *yaml.Node) error {
 
 		// No handler for this value, return an error
 		return eris.Errorf(
-			"object model configuration, unexpected yaml value %s: %s (line %d col %d)", lastID, c.Value, c.Line, c.Column)
+			"object model configuration, unexpected yaml value %s: %s (line %d col %d)", lastID, c.Value, c.Line, c.Column,
+		)
 
 	}
 
@@ -371,7 +398,8 @@ func (omc *ObjectModelConfiguration) ModifyVersion(
 			}
 
 			return action(ver)
-		})
+		},
+	)
 }
 
 // ModifyType allows the configuration of a specific type to be modified.
@@ -395,7 +423,8 @@ func (omc *ObjectModelConfiguration) ModifyType(
 			}
 
 			return action(typ)
-		})
+		},
+	)
 }
 
 // ModifyProperty allows the configuration of a specific property to be modified.
@@ -420,5 +449,6 @@ func (omc *ObjectModelConfiguration) ModifyProperty(
 			}
 
 			return action(prop)
-		})
+		},
+	)
 }

--- a/v2/tools/generator/internal/config/object_model_configuration_test.go
+++ b/v2/tools/generator/internal/config/object_model_configuration_test.go
@@ -60,7 +60,9 @@ func TestObjectModelConfiguration_TypeRename_WhenTypeFound_ReturnsExpectedResult
 			func(tc *TypeConfiguration) error {
 				tc.NameInNextVersion.Set("Party")
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 
 	nextName, ok := omc.TypeNameInNextVersion.Lookup(typeName)
@@ -80,7 +82,9 @@ func TestObjectModelConfiguration_TypeRename_WhenTypeNotFound_ReturnsExpectedErr
 			func(tc *TypeConfiguration) error {
 				tc.NameInNextVersion.Set("Party")
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 
 	otherName := astmodel.MakeInternalTypeName(test.Pkg2020, "Location")
@@ -101,7 +105,9 @@ func TestObjectModelConfiguration_VerifyTypeRenamesConsumed_WhenRenameUsed_Retur
 			func(tc *TypeConfiguration) error {
 				tc.NameInNextVersion.Set("Party")
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 
 	_, ok := omc.TypeNameInNextVersion.Lookup(typeName)
@@ -121,7 +127,9 @@ func TestObjectModelConfiguration_VerifyTypeRenamesConsumed_WhenRenameUnused_Ret
 			func(tc *TypeConfiguration) error {
 				tc.NameInNextVersion.Set("Party")
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 
 	g.Expect(omc.TypeNameInNextVersion.VerifyConsumed()).NotTo(Succeed())
@@ -144,7 +152,9 @@ func TestObjectModelConfiguration_ARMReference_WhenSpousePropertyFound_ReturnsEx
 			func(pc *PropertyConfiguration) error {
 				pc.ReferenceType.Set(ReferenceTypeARM)
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 
 	referenceType, ok := omc.ReferenceType.Lookup(typeName, "Spouse")
@@ -165,7 +175,9 @@ func TestObjectModelConfiguration_ARMReference_WhenFullNamePropertyFound_Returns
 			func(pc *PropertyConfiguration) error {
 				pc.ReferenceType.Set(ReferenceTypeSimple)
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 
 	referenceType, ok := omc.ReferenceType.Lookup(typeName, "FullName")
@@ -186,7 +198,9 @@ func TestObjectModelConfiguration_ARMReference_WhenPropertyNotFound_ReturnsExpec
 			func(pc *PropertyConfiguration) error {
 				pc.ReferenceType.Set(ReferenceTypeARM)
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 
 	_, ok := omc.ReferenceType.Lookup(typeName, "KnownAs")
@@ -206,7 +220,9 @@ func TestObjectModelConfiguration_VerifyARMReferencesConsumed_WhenReferenceUsed_
 			func(pc *PropertyConfiguration) error {
 				pc.ReferenceType.Set(ReferenceTypeARM)
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 
 	referenceType, ok := omc.ReferenceType.Lookup(typeName, "Spouse")
@@ -228,11 +244,14 @@ func TestObjectModelConfiguration_VerifyARMReferencesConsumed_WhenReferenceNotUs
 			func(pc *PropertyConfiguration) error {
 				pc.ReferenceType.Set(ReferenceTypeARM)
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 
 	g.Expect(
-		omc.ReferenceType.VerifyConsumed()).NotTo(Succeed())
+		omc.ReferenceType.VerifyConsumed(),
+	).NotTo(Succeed())
 }
 
 /*
@@ -252,7 +271,9 @@ func TestObjectModelConfiguration_LookupExportAs_AfterConsumption_CanLookupUsing
 				tc.ExportAs.Set("Person")
 				tc.NameInNextVersion.Set("Party")
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 
 	// Lookup the new name for the type
@@ -284,7 +305,9 @@ func TestObjectModelConfiguration_ModifyGroup_WhenGroupDoesNotExist_CallsActionW
 			func(configuration *GroupConfiguration) error {
 				cfg = configuration
 				return nil
-			})).To(Succeed())
+			},
+		),
+	).To(Succeed())
 
 	g.Expect(cfg).NotTo(BeNil())
 }
@@ -303,7 +326,9 @@ func TestObjectModelConfiguration_ModifyGroup_WhenGroupExists_CallsActionWithExi
 			func(configuration *GroupConfiguration) error {
 				first = configuration
 				return nil
-			})).To(Succeed())
+			},
+		),
+	).To(Succeed())
 
 	g.Expect(
 		omc.ModifyGroup(
@@ -311,7 +336,9 @@ func TestObjectModelConfiguration_ModifyGroup_WhenGroupExists_CallsActionWithExi
 			func(configuration *GroupConfiguration) error {
 				second = configuration
 				return nil
-			})).To(Succeed())
+			},
+		),
+	).To(Succeed())
 
 	g.Expect(first).To(Equal(second))
 }
@@ -333,7 +360,9 @@ func TestObjectModelConfiguration_ModifyVersion_WhenVersionDoesNotExist_CallsAct
 			func(configuration *VersionConfiguration) error {
 				cfg = configuration
 				return nil
-			})).To(Succeed())
+			},
+		),
+	).To(Succeed())
 
 	g.Expect(cfg).NotTo(BeNil())
 }
@@ -352,7 +381,9 @@ func TestObjectModelConfiguration_ModifyVersion_WhenVersionExists_CallsActionWit
 			func(configuration *VersionConfiguration) error {
 				first = configuration
 				return nil
-			})).To(Succeed())
+			},
+		),
+	).To(Succeed())
 
 	g.Expect(
 		omc.ModifyVersion(
@@ -360,7 +391,9 @@ func TestObjectModelConfiguration_ModifyVersion_WhenVersionExists_CallsActionWit
 			func(configuration *VersionConfiguration) error {
 				second = configuration
 				return nil
-			})).To(Succeed())
+			},
+		),
+	).To(Succeed())
 
 	g.Expect(first).To(Equal(second))
 }
@@ -383,7 +416,9 @@ func TestObjectModelConfiguration_ModifyType_WhenTypeDoesNotExist_CallsActionWit
 			func(configuration *TypeConfiguration) error {
 				cfg = configuration
 				return nil
-			})).To(Succeed())
+			},
+		),
+	).To(Succeed())
 
 	g.Expect(cfg).NotTo(BeNil())
 }
@@ -403,7 +438,9 @@ func TestObjectModelConfiguration_ModifyType_WhenTypeExists_CallsActionWithExist
 			func(configuration *TypeConfiguration) error {
 				first = configuration
 				return nil
-			})).To(Succeed())
+			},
+		),
+	).To(Succeed())
 
 	g.Expect(
 		omc.ModifyType(
@@ -411,7 +448,9 @@ func TestObjectModelConfiguration_ModifyType_WhenTypeExists_CallsActionWithExist
 			func(configuration *TypeConfiguration) error {
 				second = configuration
 				return nil
-			})).To(Succeed())
+			},
+		),
+	).To(Succeed())
 
 	g.Expect(first).To(Equal(second))
 }
@@ -435,7 +474,9 @@ func TestObjectModelConfiguration_ModifyProperty_WhenPropertyDoesNotExist_CallsA
 			func(configuration *PropertyConfiguration) error {
 				cfg = configuration
 				return nil
-			})).To(Succeed())
+			},
+		),
+	).To(Succeed())
 
 	g.Expect(cfg).NotTo(BeNil())
 }
@@ -456,7 +497,9 @@ func TestObjectModelConfiguration_ModifyProperty_WhenPropertyExists_CallsActionW
 			func(configuration *PropertyConfiguration) error {
 				first = configuration
 				return nil
-			})).To(Succeed())
+			},
+		),
+	).To(Succeed())
 
 	g.Expect(
 		omc.ModifyProperty(
@@ -465,7 +508,9 @@ func TestObjectModelConfiguration_ModifyProperty_WhenPropertyExists_CallsActionW
 			func(configuration *PropertyConfiguration) error {
 				second = configuration
 				return nil
-			})).To(Succeed())
+			},
+		),
+	).To(Succeed())
 
 	g.Expect(first).To(Equal(second))
 }
@@ -486,7 +531,9 @@ func TestObjectModelConfiguration_LookupSupportedFrom_WhenConfigured_ReturnsExpe
 			func(tc *TypeConfiguration) error {
 				tc.SupportedFrom.Set("beta.5")
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 
 	supportedFrom, ok := omc.SupportedFrom.Lookup(name)
@@ -506,7 +553,9 @@ func TestObjectModelConfiguration_LookupSupportedFrom_WhenNotConfigured_ReturnsE
 			func(tc *TypeConfiguration) error {
 				// No change, just provoking creation
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 
 	_, ok := omc.SupportedFrom.Lookup(name)
@@ -525,7 +574,9 @@ func TestObjectModelConfiguration_LookupSupportedFrom_WhenConsumed_ReturnsNoErro
 			func(tc *TypeConfiguration) error {
 				tc.SupportedFrom.Set("beta.5")
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 
 	_, ok := omc.SupportedFrom.Lookup(name)
@@ -547,7 +598,9 @@ func TestObjectModelConfiguration_LookupSupportedFrom_WhenUnconsumed_ReturnsErro
 			func(tc *TypeConfiguration) error {
 				tc.SupportedFrom.Set("beta.5")
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 
 	err := omc.SupportedFrom.VerifyConsumed()
@@ -570,7 +623,9 @@ func TestObjectModelConfiguration_LookupPayloadType_WhenConfigured_ReturnsExpect
 			func(gc *GroupConfiguration) error {
 				gc.PayloadType.Set(ExplicitProperties)
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 
 	payloadType, ok := omc.PayloadType.Lookup(name, "")
@@ -590,7 +645,9 @@ func TestObjectModelConfiguration_LookupPayloadType_WhenNotConfigured_ReturnsExp
 			func(_ *GroupConfiguration) error {
 				// No change, just provoking creation
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 
 	_, ok := omc.PayloadType.Lookup(name, "")
@@ -609,7 +666,9 @@ func TestObjectModelConfiguration_VerifyPayloadTypeConsumed_WhenConsumed_Returns
 			func(gc *GroupConfiguration) error {
 				gc.PayloadType.Set(OmitEmptyProperties)
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 
 	_, ok := omc.PayloadType.Lookup(name, "")
@@ -631,7 +690,9 @@ func TestObjectModelConfiguration_VerifyPayloadTypeConsumed_WhenUnconsumed_Retur
 			func(gc *GroupConfiguration) error {
 				gc.PayloadType.Set(ExplicitProperties)
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 
 	err := omc.PayloadType.VerifyConsumed()

--- a/v2/tools/generator/internal/config/property_access.go
+++ b/v2/tools/generator/internal/config/property_access.go
@@ -55,7 +55,8 @@ func (a *propertyAccess[T]) lookupCore(
 		func(configuration *PropertyConfiguration) error {
 			c = a.accessor(configuration)
 			return nil
-		})
+		},
+	)
 
 	err := visitor.visit(a.model)
 	if err != nil {
@@ -77,7 +78,8 @@ func (a *propertyAccess[T]) VerifyConsumed() error {
 		func(configuration *PropertyConfiguration) error {
 			c := a.accessor(configuration)
 			return c.VerifyConsumed()
-		})
+		},
+	)
 
 	err := visitor.visit(a.model)
 	if err != nil {
@@ -98,7 +100,8 @@ func (a *propertyAccess[T]) MarkUnconsumed() error {
 			c := a.accessor(configuration)
 			c.MarkUnconsumed()
 			return nil
-		})
+		},
+	)
 
 	return visitor.visit(a.model)
 }

--- a/v2/tools/generator/internal/config/property_access_test.go
+++ b/v2/tools/generator/internal/config/property_access_test.go
@@ -30,14 +30,16 @@ func Test_PropertyAccess_Lookup_ReturnsConfiguredValue_WhenPresent(t *testing.T)
 			func(tc *PropertyConfiguration) error {
 				tc.PayloadType.Set(value)
 				return nil
-			}),
+			},
+		),
 	).To(Succeed())
 
 	access := makePropertyAccess[PayloadType](
 		model,
 		func(t *PropertyConfiguration) *configurable[PayloadType] {
 			return &t.PayloadType
-		})
+		},
+	)
 
 	// Act
 	actual, ok := access.Lookup(ref, "Name")

--- a/v2/tools/generator/internal/config/property_configuration.go
+++ b/v2/tools/generator/internal/config/property_configuration.go
@@ -248,7 +248,8 @@ func (pc *PropertyConfiguration) UnmarshalYAML(value *yaml.Node) error {
 
 		// No handler for this value, return an error
 		return eris.Errorf(
-			"property configuration, unexpected yaml value %s: %s (line %d col %d)", lastID, c.Value, c.Line, c.Column)
+			"property configuration, unexpected yaml value %s: %s (line %d col %d)", lastID, c.Value, c.Line, c.Column,
+		)
 
 	}
 

--- a/v2/tools/generator/internal/config/supported_resources_report.go
+++ b/v2/tools/generator/internal/config/supported_resources_report.go
@@ -38,7 +38,8 @@ func (srr *SupportedResourcesReport) FullOutputPath() string {
 	return filepath.Join(
 		filepath.Dir(srr.cfg.DestinationGoModuleFile),
 		srr.OutputFolder,
-		"_index.md")
+		"_index.md",
+	)
 }
 
 // FullOutputPath returns the fully qualified path to the output file for a given group
@@ -47,12 +48,14 @@ func (srr *SupportedResourcesReport) GroupFullOutputPath(group string) string {
 		filepath.Dir(srr.cfg.DestinationGoModuleFile),
 		srr.OutputFolder,
 		group,
-		"_index.md")
+		"_index.md",
+	)
 }
 
 // FullFragmentFolderPath returns the fully qualified path to our fragment folder
 func (srr *SupportedResourcesReport) FullFragmentPath() string {
 	return filepath.Join(
 		filepath.Dir(srr.cfg.DestinationGoModuleFile),
-		srr.FragmentPath)
+		srr.FragmentPath,
+	)
 }

--- a/v2/tools/generator/internal/config/transform_result.go
+++ b/v2/tools/generator/internal/config/transform_result.go
@@ -116,7 +116,8 @@ func (tr *TransformResult) produceTargetNamedType(original astmodel.Type) (astmo
 	if !ok {
 		return nil, eris.Errorf(
 			"cannot apply type transformation; expected InternalTypeName, but have %s",
-			astmodel.DebugDescription(original))
+			astmodel.DebugDescription(original),
+		)
 	}
 
 	result := tn

--- a/v2/tools/generator/internal/config/transform_selector_test.go
+++ b/v2/tools/generator/internal/config/transform_selector_test.go
@@ -47,7 +47,9 @@ func TestTransformSelector_AppliesToType_ReturnsExpectedResult(t *testing.T) {
 	nameType := astmodel.NewOptionalType(
 		astmodel.MakeInternalTypeName(
 			test.MakeLocalPackageReference("definitions", "v1"),
-			"ResourceCopy"))
+			"ResourceCopy",
+		),
+	)
 
 	objectSelector := &TransformSelector{
 		Object: true,
@@ -84,6 +86,7 @@ func TestTransformSelector_AppliesToType_ReturnsExpectedResult(t *testing.T) {
 				g := NewGomegaWithT(t)
 
 				g.Expect(c.target.AppliesToType(c.subject)).To(Equal(c.expectation))
-			})
+			},
+		)
 	}
 }

--- a/v2/tools/generator/internal/config/type_access.go
+++ b/v2/tools/generator/internal/config/type_access.go
@@ -63,7 +63,8 @@ func (a *typeAccess[T]) lookupCore(
 		func(configuration *TypeConfiguration) error {
 			c = a.accessor(configuration)
 			return nil
-		})
+		},
+	)
 
 	err := visitor.visit(a.model)
 	if err != nil {
@@ -85,7 +86,8 @@ func (a *typeAccess[T]) VerifyConsumed() error {
 		func(configuration *TypeConfiguration) error {
 			c := a.accessor(configuration)
 			return c.VerifyConsumed()
-		})
+		},
+	)
 	err := visitor.visit(a.model)
 	if err != nil {
 		return err
@@ -105,7 +107,8 @@ func (a *typeAccess[T]) MarkUnconsumed() error {
 			c := a.accessor(configuration)
 			c.MarkUnconsumed()
 			return nil
-		})
+		},
+	)
 
 	return visitor.visit(a.model)
 }

--- a/v2/tools/generator/internal/config/type_access_test.go
+++ b/v2/tools/generator/internal/config/type_access_test.go
@@ -29,14 +29,16 @@ func Test_TypeAccess_Lookup_ReturnsConfiguredValue_WhenPresent(t *testing.T) {
 			func(tc *TypeConfiguration) error {
 				tc.PayloadType.Set(value)
 				return nil
-			}),
+			},
+		),
 	).To(Succeed())
 
 	access := makeTypeAccess[PayloadType](
 		model,
 		func(t *TypeConfiguration) *configurable[PayloadType] {
 			return &t.PayloadType
-		})
+		},
+	)
 
 	// Act
 	actual, ok := access.Lookup(ref)
@@ -62,7 +64,8 @@ func Test_TypeAccess_LookupWithPropertyOverride_ReturnsOverriddenValue_WhenPrese
 			func(tc *TypeConfiguration) error {
 				tc.PayloadType.Set(typeValue)
 				return nil
-			}),
+			},
+		),
 	).To(Succeed())
 	g.Expect(
 		model.ModifyProperty(
@@ -71,18 +74,21 @@ func Test_TypeAccess_LookupWithPropertyOverride_ReturnsOverriddenValue_WhenPrese
 			func(tc *PropertyConfiguration) error {
 				tc.PayloadType.Set(propertyValue)
 				return nil
-			}),
+			},
+		),
 	).To(Succeed())
 
 	access := makeTypeAccess[PayloadType](
 		model,
 		func(t *TypeConfiguration) *configurable[PayloadType] {
 			return &t.PayloadType
-		}).
+		},
+	).
 		withPropertyOverride(
 			func(p *PropertyConfiguration) *configurable[PayloadType] {
 				return &p.PayloadType
-			})
+			},
+		)
 
 	// Act
 	actual, ok := access.Lookup(ref, "Name")
@@ -108,7 +114,8 @@ func Test_TypeAccess_LookupWithPropertyOverride_ReturnsTypeValue_WhenNoOverrideP
 			func(tc *TypeConfiguration) error {
 				tc.PayloadType.Set(typeValue)
 				return nil
-			}),
+			},
+		),
 	).To(Succeed())
 	g.Expect(
 		model.ModifyProperty(
@@ -117,18 +124,21 @@ func Test_TypeAccess_LookupWithPropertyOverride_ReturnsTypeValue_WhenNoOverrideP
 			func(tc *PropertyConfiguration) error {
 				tc.PayloadType.Set(propertyValue)
 				return nil
-			}),
+			},
+		),
 	).To(Succeed())
 
 	access := makeTypeAccess[PayloadType](
 		model,
 		func(t *TypeConfiguration) *configurable[PayloadType] {
 			return &t.PayloadType
-		}).
+		},
+	).
 		withPropertyOverride(
 			func(p *PropertyConfiguration) *configurable[PayloadType] {
 				return &p.PayloadType
-			})
+			},
+		)
 
 	// Act
 	actual, ok := access.Lookup(ref, "Status")

--- a/v2/tools/generator/internal/config/type_configuration.go
+++ b/v2/tools/generator/internal/config/type_configuration.go
@@ -134,7 +134,8 @@ func (tc *TypeConfiguration) visitProperties(visitor *configurationVisitor) erro
 	return eris.Wrapf(
 		kerrors.NewAggregate(errs),
 		"type %s",
-		tc.name)
+		tc.name,
+	)
 }
 
 // findProperty uses the provided property name to work out which nested PropertyConfiguration should be used
@@ -182,7 +183,8 @@ func (tc *TypeConfiguration) UnmarshalYAML(value *yaml.Node) error {
 						"unexpected yam value for %s (line %d col %d)",
 						generatedConfigsTag,
 						content.Line,
-						content.Column)
+						content.Column,
+					)
 				}
 
 				// first value is the key
@@ -250,7 +252,8 @@ func (tc *TypeConfiguration) UnmarshalYAML(value *yaml.Node) error {
 						"unexpected yam value for %s (line %d col %d)",
 						azureGeneratedSecretsTag,
 						content.Line,
-						content.Column)
+						content.Column,
+					)
 				}
 			}
 
@@ -271,7 +274,8 @@ func (tc *TypeConfiguration) UnmarshalYAML(value *yaml.Node) error {
 						"unexpected yam value for %s (line %d col %d)",
 						manualConfigsTag,
 						content.Line,
-						content.Column)
+						content.Column,
+					)
 				}
 			}
 
@@ -379,7 +383,8 @@ func (tc *TypeConfiguration) UnmarshalYAML(value *yaml.Node) error {
 						"unexpected yam value for %s (line %d col %d)",
 						operatorSpecPropertiesTag,
 						content.Line,
-						content.Column)
+						content.Column,
+					)
 				}
 			}
 
@@ -389,7 +394,8 @@ func (tc *TypeConfiguration) UnmarshalYAML(value *yaml.Node) error {
 
 		// No handler for this value, return an error
 		return eris.Errorf(
-			"type configuration, unexpected yaml value %s: %s (line %d col %d)", lastID, c.Value, c.Line, c.Column)
+			"type configuration, unexpected yaml value %s: %s (line %d col %d)", lastID, c.Value, c.Line, c.Column,
+		)
 
 	}
 

--- a/v2/tools/generator/internal/config/type_configuration_test.go
+++ b/v2/tools/generator/internal/config/type_configuration_test.go
@@ -70,7 +70,7 @@ func TestTypeConfiguration_WhenAzureSecretsBadlyFormed_ReturnsError(t *testing.T
 	var typeConfig TypeConfiguration
 	err := yaml.Unmarshal(yamlBytes, &typeConfig)
 	g.Expect(err).NotTo(Succeed())
-	g.Expect(err.Error()).To((ContainSubstring(azureGeneratedSecretsTag)))
+	g.Expect(err.Error()).To(ContainSubstring(azureGeneratedSecretsTag))
 }
 
 func TestTypeConfiguration_WhenExportDeprecated_ReturnsError(t *testing.T) {

--- a/v2/tools/generator/internal/config/type_matcher.go
+++ b/v2/tools/generator/internal/config/type_matcher.go
@@ -67,21 +67,24 @@ func (t *TypeMatcher) WasMatched() error {
 		return eris.Wrapf(
 			err,
 			"type matcher [%s], incomplete match for group",
-			t.String())
+			t.String(),
+		)
 	}
 
 	if err := t.Version.WasMatched(); err != nil {
 		return eris.Wrapf(
 			err,
 			"type matcher [%s], incomplete match for version",
-			t.String())
+			t.String(),
+		)
 	}
 
 	if err := t.Name.WasMatched(); err != nil {
 		return eris.Wrapf(
 			err,
 			"type matcher [%s], incomplete match for name",
-			t.String())
+			t.String(),
+		)
 	}
 
 	// Everything matched, no error

--- a/v2/tools/generator/internal/config/type_transformer.go
+++ b/v2/tools/generator/internal/config/type_transformer.go
@@ -69,7 +69,8 @@ func (transformer *TypeTransformer) TransformDefinition(def astmodel.TypeDefinit
 	// Apply our rename if we have one configured
 	if transformer.RenameTo != "" {
 		def = def.WithName(
-			def.Name().WithName(transformer.RenameTo))
+			def.Name().WithName(transformer.RenameTo),
+		)
 	}
 
 	// Transform the whole type if we're not looking for a specific property
@@ -81,7 +82,8 @@ func (transformer *TypeTransformer) TransformDefinition(def astmodel.TypeDefinit
 				"type transformer for group: %s, version: %s, name: %s",
 				transformer.Group.String(),
 				transformer.Version.String(),
-				transformer.Name.String())
+				transformer.Name.String(),
+			)
 		}
 
 		def = def.WithType(resultType)
@@ -103,7 +105,8 @@ func (transformer *TypeTransformer) TransformDefinition(def astmodel.TypeDefinit
 			return astmodel.TypeDefinition{}, eris.Wrapf(
 				err,
 				"visiting definition %s",
-				def.Name())
+				def.Name(),
+			)
 		}
 
 		def = d
@@ -127,7 +130,8 @@ func (transformer *TypeTransformer) TransformTypeName(typeName astmodel.Internal
 				"type transformer for group: %s, version: %s, name: %s",
 				transformer.Group.String(),
 				transformer.Version.String(),
-				transformer.Name.String())
+				transformer.Name.String(),
+			)
 		}
 
 		return result, nil
@@ -176,14 +180,16 @@ type PropertyTransformResult struct {
 // String generates a printable representation of this result.
 func (r PropertyTransformResult) String() string {
 	if r.Removed {
-		return fmt.Sprintf("%s.%s removed because %s",
+		return fmt.Sprintf(
+			"%s.%s removed because %s",
 			r.TypeName,
 			r.Property,
 			r.Because,
 		)
 	}
 
-	return fmt.Sprintf("%s.%s -> %s because %s",
+	return fmt.Sprintf(
+		"%s.%s -> %s because %s",
 		r.TypeName,
 		r.Property,
 		r.NewPropertyType.String(),
@@ -198,7 +204,8 @@ func (r PropertyTransformResult) LogTo(log logr.Logger) {
 			"Removing property",
 			"type", r.TypeName,
 			"property", r.Property,
-			"because", r.Because)
+			"because", r.Because,
+		)
 		return
 	}
 
@@ -207,7 +214,8 @@ func (r PropertyTransformResult) LogTo(log logr.Logger) {
 		"type", r.TypeName,
 		"property", r.Property,
 		"newType", r.NewPropertyType.String(),
-		"because", r.Because)
+		"because", r.Because,
+	)
 }
 
 func (transformer *TypeTransformer) RequiredPropertiesWereMatched() error {
@@ -225,7 +233,8 @@ func (transformer *TypeTransformer) RequiredPropertiesWereMatched() error {
 		return eris.Wrapf(
 			err,
 			"%s matched types but all properties were excluded by name or type",
-			transformer.String())
+			transformer.String(),
+		)
 	}
 
 	return nil

--- a/v2/tools/generator/internal/config/type_transformer_test.go
+++ b/v2/tools/generator/internal/config/type_transformer_test.go
@@ -133,7 +133,8 @@ func Test_TransformTypeName_WhenConfiguredWithMap_ReturnsExpectedMapType(t *test
 
 	expected := astmodel.NewMapType(
 		astmodel.StringType,
-		astmodel.IntType)
+		astmodel.IntType,
+	)
 
 	g.Expect(transformer.TransformTypeName(tutor2019)).To(Equal(expected))
 }
@@ -161,7 +162,8 @@ func Test_TransformTypeName_WhenConfiguredWithEnum_ReturnsExpectedEnumType(t *te
 		astmodel.StringType,
 		astmodel.MakeEnumValue("Alpha", "\"alpha\""),
 		astmodel.MakeEnumValue("Beta", "\"beta\""),
-		astmodel.MakeEnumValue("Preview", "\"preview\""))
+		astmodel.MakeEnumValue("Preview", "\"preview\""),
+	)
 
 	g.Expect(transformer.TransformTypeName(tutor2019)).To(Equal(expected))
 }
@@ -247,7 +249,9 @@ func Test_TransformCanTransform_ToNestedMapType(t *testing.T) {
 		astmodel.StringType,
 		astmodel.NewMapType(
 			astmodel.IntType,
-			astmodel.FloatType))
+			astmodel.FloatType,
+		),
+	)
 
 	g.Expect(transformer.TransformTypeName(tutor2019)).To(Equal(expected))
 }
@@ -365,7 +369,8 @@ func Test_TransformWithBothNameAndMapTargets_ReportsError(t *testing.T) {
 	g.Expect(err.Error()).To(SatisfyAll(
 		ContainSubstring("cannot specify both"),
 		ContainSubstring("Map transformation"),
-		ContainSubstring("Name transformation")))
+		ContainSubstring("Name transformation"),
+	))
 }
 
 func Test_TransformWithBothNameAndEnumTargets_ReportsError(t *testing.T) {
@@ -397,7 +402,8 @@ func Test_TransformWithBothNameAndEnumTargets_ReportsError(t *testing.T) {
 	g.Expect(err.Error()).To(SatisfyAll(
 		ContainSubstring("cannot specify both"),
 		ContainSubstring("Enum transformation"),
-		ContainSubstring("Name transformation")))
+		ContainSubstring("Name transformation"),
+	))
 }
 
 func Test_TransformWithBothMapAndEnumTargets_ReportsError(t *testing.T) {
@@ -437,7 +443,8 @@ func Test_TransformWithBothMapAndEnumTargets_ReportsError(t *testing.T) {
 	g.Expect(err.Error()).To(SatisfyAll(
 		ContainSubstring("cannot specify both"),
 		ContainSubstring("Enum transformation"),
-		ContainSubstring("Map transformation")))
+		ContainSubstring("Map transformation"),
+	))
 }
 
 func Test_TypeTransformer_WhenTransformingTypeName_ReturnsExpectedTypeName(t *testing.T) {
@@ -479,7 +486,8 @@ func Test_TypeTransformer_WhenTransformingTypeName_ReturnsExpectedTypeName(t *te
 				actual, err := transformer.TransformTypeName(c.original)
 				g.Expect(actual).To(Equal(c.expected))
 				g.Expect(err).To(Succeed())
-			})
+			},
+		)
 	}
 }
 
@@ -669,7 +677,8 @@ func TestTransformProperty_DoesTransformProperty_IfTypeDoesMatch(t *testing.T) {
 				prop, ok := result.NewType.Property(c.propertyToInspect)
 				g.Expect(ok).To(BeTrue())
 				g.Expect(prop.PropertyType()).To(Equal(c.expectedType))
-			})
+			},
+		)
 	}
 }
 
@@ -714,7 +723,8 @@ func TestTransformProperty_CanRemoveProperty(t *testing.T) {
 
 	resourceCopyType := astmodel.MakeInternalTypeName(
 		test.MakeLocalPackageReference("deploymenttemplate", "2019-04-01"),
-		"ResourceCopy")
+		"ResourceCopy",
+	)
 	copyProperty := astmodel.NewPropertyDefinition("Copy", "copy", astmodel.NewOptionalType(resourceCopyType))
 	objectWithCopyProperty := astmodel.NewObjectType().WithProperties(copyProperty)
 
@@ -753,7 +763,8 @@ func TestTransformProperty_CanRemoveProperty(t *testing.T) {
 
 				_, ok := result.NewType.Property(c.propertyToInspect)
 				g.Expect(ok).To(BeFalse())
-			})
+			},
+		)
 	}
 }
 
@@ -837,7 +848,8 @@ func Test_TypeTransformer_RequiredTypesWereMatched_ReturnsExpectedResults(t *tes
 				} else {
 					g.Expect(err).To(MatchError(ContainSubstring(c.expectedError)))
 				}
-			})
+			},
+		)
 	}
 }
 
@@ -907,6 +919,7 @@ func Test_TypeTransformer_RequirePropertiesWereMatched_ReturnsExpectedResults(t 
 				} else {
 					g.Expect(err).To(MatchError(ContainSubstring(c.expectedError)))
 				}
-			})
+			},
+		)
 	}
 }

--- a/v2/tools/generator/internal/config/upgradable_resources_report.go
+++ b/v2/tools/generator/internal/config/upgradable_resources_report.go
@@ -37,5 +37,6 @@ func (urr *UpgradableResourcesReport) FullOutputPath() string {
 	return filepath.Join(
 		filepath.Dir(urr.cfg.DestinationGoModuleFile),
 		urr.OutputFolder,
-		"upgradable_resources.md")
+		"upgradable_resources.md",
+	)
 }

--- a/v2/tools/generator/internal/config/version_configuration.go
+++ b/v2/tools/generator/internal/config/version_configuration.go
@@ -81,7 +81,8 @@ func (vc *VersionConfiguration) visitTypes(visitor *configurationVisitor) error 
 	return eris.Wrapf(
 		kerrors.NewAggregate(errs),
 		"version %s",
-		vc.name)
+		vc.name,
+	)
 }
 
 // findType uses the provided name to work out which nested TypeConfiguration should be used
@@ -112,7 +113,8 @@ func (vc *VersionConfiguration) addTypeAlias(name string, alias string) error {
 		return eris.Errorf(
 			"unable to create type alias %s for %s because that would conflict with existing configuration",
 			alias,
-			name)
+			name,
+		)
 	}
 
 	// Add the alias as another route to the existing configuration
@@ -155,7 +157,8 @@ func (vc *VersionConfiguration) UnmarshalYAML(value *yaml.Node) error {
 
 		// No handler for this value, return an error
 		return eris.Errorf(
-			"version configuration, unexpected yaml value %s: %s (line %d col %d)", lastID, c.Value, c.Line, c.Column)
+			"version configuration, unexpected yaml value %s: %s (line %d col %d)", lastID, c.Value, c.Line, c.Column,
+		)
 
 	}
 

--- a/v2/tools/generator/internal/conversions/property_conversion_context.go
+++ b/v2/tools/generator/internal/conversions/property_conversion_context.go
@@ -196,7 +196,8 @@ func (c *PropertyConversionContext) PathExists(
 		start,
 		func(name astmodel.InternalTypeName) bool {
 			return name == finish
-		})
+		},
+	)
 
 	return found
 }
@@ -213,14 +214,16 @@ func (c *PropertyConversionContext) FindPivotType(
 		func(name astmodel.InternalTypeName) bool {
 			candidates.Add(name)
 			return false
-		})
+		},
+	)
 
 	// Walk the path from 'finish' to find the first type that's also visible from 'start'
 	pivot, found := c.conversionGraph.FindInPath(
 		finish,
 		func(name astmodel.InternalTypeName) bool {
 			return candidates.Contains(name)
-		})
+		},
+	)
 	return pivot, found
 }
 
@@ -267,7 +270,8 @@ func (c *PropertyConversionContext) validateTypeRename(
 		return eris.Errorf(
 			"no configuration to rename %s to %s",
 			earlier.Name(),
-			later.Name())
+			later.Name(),
+		)
 	}
 
 	if later.Name() != name {
@@ -277,7 +281,8 @@ func (c *PropertyConversionContext) validateTypeRename(
 			"configuration includes rename of %s to %s, but found %s",
 			earlier.Name(),
 			name,
-			later.Name())
+			later.Name(),
+		)
 	}
 
 	return nil

--- a/v2/tools/generator/internal/conversions/property_conversions.go
+++ b/v2/tools/generator/internal/conversions/property_conversions.go
@@ -326,7 +326,8 @@ func writeToBagItem(
 				conversionContext.PropertyBagName(),
 				"Add",
 				astbuilder.StringLiteral(destinationEndpoint.Name()),
-				expr)
+				expr,
+			)
 
 			return astbuilder.Statements(addToBag)
 		}
@@ -335,7 +336,8 @@ func writeToBagItem(
 		removeFromBag := astbuilder.CallQualifiedFuncAsStmt(
 			conversionContext.PropertyBagName(),
 			"Remove",
-			astbuilder.StringLiteral(destinationEndpoint.Name()))
+			astbuilder.StringLiteral(destinationEndpoint.Name()),
+		)
 
 		// condition is a test to use to see whether we have a value to write to the property bag
 		// If we unilaterally write to the bag, this will be nil
@@ -364,13 +366,15 @@ func writeToBagItem(
 			reader,
 			createAddToBag,
 			knownLocals,
-			generationContext)
+			generationContext,
+		)
 		if err != nil {
 			return nil, eris.Wrapf(
 				err,
 				"unable to convert %s to %s writing property bag",
 				sourceEndpoint.Name(),
-				destinationEndpoint.Name())
+				destinationEndpoint.Name(),
+			)
 		}
 
 		// If we only conditionally write to the bag, we need wrap with an if statement
@@ -378,7 +382,8 @@ func writeToBagItem(
 			writer := astbuilder.SimpleIfElse(
 				condition,
 				addToBag,
-				astbuilder.Statements(removeFromBag))
+				astbuilder.Statements(removeFromBag),
+			)
 			return astbuilder.Statements(writer), nil
 		}
 
@@ -536,7 +541,8 @@ func pullFromBagItem(
 		condition := astbuilder.CallQualifiedFunc(
 			conversionContext.PropertyBagName(),
 			"Contains",
-			astbuilder.StringLiteral(sourceEndpoint.Name()))
+			astbuilder.StringLiteral(sourceEndpoint.Name()),
+		)
 
 		// var <local> <sourceBagItemType>
 		sourceBagItemExpr, err := sourceBagItem.AsTypeExpr(generationContext)
@@ -545,12 +551,14 @@ func pullFromBagItem(
 				err,
 				"converting %s to %s reading property bag",
 				sourceEndpoint.Name(),
-				destinationEndpoint.Name())
+				destinationEndpoint.Name(),
+			)
 		}
 
 		declare := astbuilder.NewVariableWithType(
 			local,
-			sourceBagItemExpr)
+			sourceBagItemExpr,
+		)
 
 		// We're wrapping the conversion in a nested block, so any locals are independent
 		knownLocals = knownLocals.Clone()
@@ -570,7 +578,9 @@ func pullFromBagItem(
 				conversionContext.PropertyBagName(),
 				"Pull",
 				astbuilder.StringLiteral(sourceEndpoint.Name()),
-				astbuilder.AddrOf(dst.NewIdent(local))))
+				astbuilder.AddrOf(dst.NewIdent(local)),
+			),
+		)
 
 		// if err != nil {
 		//     return ...
@@ -580,7 +590,9 @@ func pullFromBagItem(
 			astbuilder.WrappedErrorf(
 				errorsPkg,
 				"pulling '%s' from propertyBag",
-				sourceEndpoint.Name()))
+				sourceEndpoint.Name(),
+			),
+		)
 		returnIfErr.Decorations().After = dst.EmptyLine
 
 		var reader dst.Expr
@@ -597,13 +609,15 @@ func pullFromBagItem(
 				err,
 				"unable to convert %s to %s reading property bag",
 				sourceEndpoint.Name(),
-				destinationEndpoint.Name())
+				destinationEndpoint.Name(),
+			)
 		}
 
 		// Generate code to clear the value if we don't have one
 		assignZero := writer(
 			destinationEndpoint.Type().AsZero(conversionContext.Types(),
-				generationContext))
+				generationContext),
+		)
 
 		// if <condition> {
 		//   <declare, pull, returnIfErr, assignValue>
@@ -613,7 +627,8 @@ func pullFromBagItem(
 		ifStatement := astbuilder.SimpleIfElse(
 			condition,
 			astbuilder.Statements(declare, pull, returnIfErr, assignValue),
-			assignZero)
+			assignZero,
+		)
 
 		return astbuilder.Statements(ifStatement), nil
 	}, nil
@@ -653,7 +668,8 @@ func assignFromOptional(
 	conversion, err := CreateTypeConversion(
 		unwrappedEndpoint,
 		destinationEndpoint,
-		conversionContext)
+		conversionContext,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -694,22 +710,26 @@ func assignFromOptional(
 			astbuilder.Dereference(actualReader),
 			writer,
 			knownLocals.Clone(),
-			generationContext)
+			generationContext,
+		)
 		if err != nil {
 			return nil, eris.Wrapf(
 				err,
 				"unable to convert %s to %s",
 				sourceEndpoint.Name(),
-				destinationEndpoint.Name())
+				destinationEndpoint.Name(),
+			)
 		}
 
 		writeZeroValue := writer(
-			destinationEndpoint.Type().AsZero(conversionContext.Types(), generationContext))
+			destinationEndpoint.Type().AsZero(conversionContext.Types(), generationContext),
+		)
 
 		stmt := astbuilder.SimpleIfElse(
 			checkForNil,
 			writeActualValue,
-			writeZeroValue)
+			writeZeroValue,
+		)
 
 		return astbuilder.Statements(cacheOriginal, stmt), nil
 	}, nil
@@ -792,7 +812,8 @@ func assignToEnumeration(
 				err,
 				"unable to convert %s to %s",
 				sourceEndpoint.Name(),
-				destinationEndpoint.Name())
+				destinationEndpoint.Name(),
+			)
 		}
 
 		if dstEnum.NeedsMappingConversion(dstName) {
@@ -806,19 +827,22 @@ func assignToEnumeration(
 				genruntimePkg,
 				"ToEnum",
 				actualReader,
-				dst.NewIdent(mapperID))
+				dst.NewIdent(mapperID),
+			)
 
 			convert, err := conversion(
 				toEnum,
 				writer,
 				knownLocals,
-				generationContext)
+				generationContext,
+			)
 			if err != nil {
 				return nil, eris.Wrapf(
 					err,
 					"unable to convert %s to %s",
 					sourceEndpoint.Name(),
-					destinationEndpoint.Name())
+					destinationEndpoint.Name(),
+				)
 			}
 
 			return astbuilder.Statements(cacheOriginal, convert), nil
@@ -837,7 +861,8 @@ func assignToEnumeration(
 			reader,
 			castingWriter,
 			knownLocals,
-			generationContext)
+			generationContext,
+		)
 	}, nil
 }
 
@@ -1306,13 +1331,15 @@ func assignArrayFromArray(
 	conversion, err := CreateTypeConversion(
 		unwrappedSourceEndpoint,
 		unwrappedDestinationEndpoint,
-		conversionContext)
+		conversionContext,
+	)
 	if err != nil {
 		return nil, eris.Wrapf(
 			err,
 			"finding array conversion from %s to %s",
 			astmodel.DebugDescription(sourceEndpoint.Type()),
-			astmodel.DebugDescription(destinationEndpoint.Type()))
+			astmodel.DebugDescription(destinationEndpoint.Type()),
+		)
 	}
 	if conversion == nil {
 		return nil, nil
@@ -1363,12 +1390,14 @@ func assignArrayFromArray(
 				err,
 				"converting %s to %s",
 				sourceEndpoint.Name(),
-				destinationEndpoint.Name())
+				destinationEndpoint.Name(),
+			)
 		}
 
 		declaration := astbuilder.ShortDeclaration(
 			tempID,
-			astbuilder.MakeSlice(destinationArrayExpr, astbuilder.CallFunc("len", actualReader)))
+			astbuilder.MakeSlice(destinationArrayExpr, astbuilder.CallFunc("len", actualReader)),
+		)
 
 		writeToElement := func(expr dst.Expr) []dst.Stmt {
 			return astbuilder.Statements(
@@ -1377,7 +1406,8 @@ func assignArrayFromArray(
 						X:     dst.NewIdent(tempID),
 						Index: dst.NewIdent(indexID),
 					},
-					expr),
+					expr,
+				),
 			)
 		}
 
@@ -1387,7 +1417,8 @@ func assignArrayFromArray(
 				err,
 				"creating conversion for array element from %s to %s",
 				astmodel.DebugDescription(sourceEndpoint.Type()),
-				astmodel.DebugDescription(destinationEndpoint.Type()))
+				astmodel.DebugDescription(destinationEndpoint.Type()),
+			)
 		}
 
 		assignValue := writer(dst.NewIdent(tempID))
@@ -1398,7 +1429,8 @@ func assignArrayFromArray(
 
 		return astbuilder.Statements(
 			cacheOriginal,
-			astbuilder.SimpleIfElse(checkForNil, trueBranch, assignZero)), nil
+			astbuilder.SimpleIfElse(checkForNil, trueBranch, assignZero),
+		), nil
 	}, nil
 }
 
@@ -1450,13 +1482,15 @@ func assignMapFromMap(
 	conversion, err := CreateTypeConversion(
 		unwrappedSourceEndpoint,
 		unwrappedDestinationEndpoint,
-		conversionContext)
+		conversionContext,
+	)
 	if err != nil {
 		return nil, eris.Wrapf(
 			err,
 			"finding map conversion from %s to %s",
 			astmodel.DebugDescription(sourceEndpoint.Type()),
-			astmodel.DebugDescription(destinationEndpoint.Type()))
+			astmodel.DebugDescription(destinationEndpoint.Type()),
+		)
 	}
 	if conversion == nil {
 		return nil, nil
@@ -1507,7 +1541,8 @@ func assignMapFromMap(
 			return nil, eris.Wrapf(
 				err,
 				"creating map key type expression for %s",
-				astmodel.DebugDescription(destinationMap.KeyType()))
+				astmodel.DebugDescription(destinationMap.KeyType()),
+			)
 		}
 
 		valueTypeExpr, err := destinationMap.ValueType().AsTypeExpr(generationContext)
@@ -1515,7 +1550,8 @@ func assignMapFromMap(
 			return nil, eris.Wrapf(
 				err,
 				"creating map value type expression for %s",
-				astmodel.DebugDescription(destinationMap.ValueType()))
+				astmodel.DebugDescription(destinationMap.ValueType()),
+			)
 		}
 
 		declaration := astbuilder.ShortDeclaration(
@@ -1523,7 +1559,9 @@ func assignMapFromMap(
 			astbuilder.MakeMapWithCapacity(
 				keyTypeExpr,
 				valueTypeExpr,
-				astbuilder.CallFunc("len", actualReader)))
+				astbuilder.CallFunc("len", actualReader),
+			),
+		)
 
 		assignToItem := func(expr dst.Expr) []dst.Stmt {
 			return astbuilder.Statements(
@@ -1532,7 +1570,8 @@ func assignMapFromMap(
 						X:     dst.NewIdent(tempID),
 						Index: dst.NewIdent(keyID),
 					},
-					expr),
+					expr,
+				),
 			)
 		}
 
@@ -1542,7 +1581,8 @@ func assignMapFromMap(
 				err,
 				"creating map item conversion from %s to %s",
 				astmodel.DebugDescription(sourceMap.ValueType()),
-				astmodel.DebugDescription(destinationMap.ValueType()))
+				astmodel.DebugDescription(destinationMap.ValueType()),
+			)
 		}
 
 		loop := astbuilder.IterateOverMapWithValue(keyID, itemID, actualReader, elemConv...)
@@ -1553,7 +1593,8 @@ func assignMapFromMap(
 
 		return astbuilder.Statements(
 			cacheOriginal,
-			astbuilder.SimpleIfElse(checkForNil, trueBranch, assignNil)), nil
+			astbuilder.SimpleIfElse(checkForNil, trueBranch, assignNil),
+		), nil
 	}, nil
 }
 
@@ -1623,13 +1664,15 @@ func assignUserAssignedIdentityMapFromArray(
 	conversion, err := CreateTypeConversion(
 		sourceEndpoint.WithType(astmodel.StringType),
 		destinationEndpoint.WithType(astmodel.ResourceReferenceType),
-		conversionContext)
+		conversionContext,
+	)
 	if err != nil {
 		return nil, eris.Wrapf(
 			err,
 			"finding UserAssignedIdentities conversion from %s to %s",
 			astmodel.DebugDescription(astmodel.StringType),
-			astmodel.DebugDescription(astmodel.ResourceReferenceType))
+			astmodel.DebugDescription(astmodel.ResourceReferenceType),
+		)
 	}
 
 	return func(
@@ -1646,12 +1689,14 @@ func assignUserAssignedIdentityMapFromArray(
 				err,
 				"creating UserAssignedIdentities conversion from %s to %s",
 				astmodel.DebugDescription(astmodel.StringType),
-				astmodel.DebugDescription(astmodel.ResourceReferenceType))
+				astmodel.DebugDescription(astmodel.ResourceReferenceType),
+			)
 		}
 
 		declaration := astbuilder.ShortDeclaration(
 			tempID,
-			astbuilder.MakeEmptySlice(destinationArrayExpr, astbuilder.CallFunc("len", reader)))
+			astbuilder.MakeEmptySlice(destinationArrayExpr, astbuilder.CallFunc("len", reader)),
+		)
 
 		loopLocals := knownLocals.Clone()
 		keyID := loopLocals.CreateLocal(sourceEndpoint.Name(), "Key")
@@ -1663,7 +1708,8 @@ func assignUserAssignedIdentityMapFromArray(
 				err,
 				"creating UserAssignedIdentities conversion from %s to %s",
 				astmodel.DebugDescription(astmodel.StringType),
-				astmodel.DebugDescription(astmodel.ResourceReferenceType))
+				astmodel.DebugDescription(astmodel.ResourceReferenceType),
+			)
 		}
 
 		uaiBuilder := astbuilder.NewCompositeLiteralBuilder(destinationTypeExpr)
@@ -1671,7 +1717,8 @@ func assignUserAssignedIdentityMapFromArray(
 
 		writeToElement := func(expr dst.Expr) []dst.Stmt {
 			return astbuilder.Statements(
-				astbuilder.ShortDeclaration(intermediateDestination, expr))
+				astbuilder.ShortDeclaration(intermediateDestination, expr),
+			)
 		}
 
 		//	for key, _ := range source.UserAssignedIdentities {
@@ -1684,7 +1731,8 @@ func assignUserAssignedIdentityMapFromArray(
 				err,
 				"creating UserAssignedIdentities conversion from %s to %s",
 				astmodel.DebugDescription(astmodel.StringType),
-				astmodel.DebugDescription(astmodel.ResourceReferenceType))
+				astmodel.DebugDescription(astmodel.ResourceReferenceType),
+			)
 		}
 
 		loopBody := astbuilder.Statements(
@@ -1714,10 +1762,12 @@ func assignUserAssignedIdentityMapFromArray(
 		trueBranch := astbuilder.Statements(
 			declaration,
 			loop,
-			assignValue)
+			assignValue,
+		)
 
 		return astbuilder.Statements(
-			astbuilder.SimpleIfElse(checkForNil, trueBranch, assignNil)), nil
+			astbuilder.SimpleIfElse(checkForNil, trueBranch, assignNil),
+		), nil
 	}, nil
 }
 
@@ -1768,7 +1818,8 @@ func assignEnumFromEnum(
 		return nil, eris.Errorf(
 			"no conversion from %s to %s",
 			astmodel.DebugDescription(sourceEnum.BaseType()),
-			astmodel.DebugDescription(destinationEnum.BaseType()))
+			astmodel.DebugDescription(destinationEnum.BaseType()),
+		)
 	}
 
 	return func(
@@ -1791,7 +1842,8 @@ func assignEnumFromEnum(
 				genruntimePkg,
 				"ToEnum",
 				astbuilder.CallFunc("string", reader),
-				dst.NewIdent(mapperID))
+				dst.NewIdent(mapperID),
+			)
 
 			declare = astbuilder.ShortDeclaration(local, toEnum)
 		} else {
@@ -1920,7 +1972,8 @@ func assignObjectDirectlyFromObject(
 			return nil, eris.Wrapf(
 				err,
 				"looking up next type for %s",
-				astmodel.DebugDescription(destinationEndpoint.Type()))
+				astmodel.DebugDescription(destinationEndpoint.Type()),
+			)
 		}
 
 		if !nextType.IsEmpty() && !astmodel.TypeEquals(nextType, sourceName) {
@@ -1964,12 +2017,14 @@ func assignObjectDirectlyFromObject(
 		declaration := astbuilder.LocalVariableDeclaration(copyVar, createTypeDeclaration(destinationName, generationContext), "")
 
 		functionName := NameOfPropertyAssignmentFunction(
-			conversionContext.FunctionBaseName(), sourceName, ConvertFrom, conversionContext.idFactory)
+			conversionContext.FunctionBaseName(), sourceName, ConvertFrom, conversionContext.idFactory,
+		)
 
 		conversion := astbuilder.AssignmentStatement(
 			errLocal,
 			tok,
-			astbuilder.CallExpr(localID, functionName, astbuilder.AsReference(reader)))
+			astbuilder.CallExpr(localID, functionName, astbuilder.AsReference(reader)),
+		)
 
 		checkForError := astbuilder.ReturnIfNotNil(
 			errLocal,
@@ -1977,7 +2032,9 @@ func assignObjectDirectlyFromObject(
 				errorsPackageName,
 				"calling %s() to %s",
 				functionName,
-				describeAssignment(sourceEndpoint, destinationEndpoint)))
+				describeAssignment(sourceEndpoint, destinationEndpoint),
+			),
+		)
 
 		assignment := writer(localID)
 		return astbuilder.Statements(declaration, conversion, checkForError, assignment), nil
@@ -2045,7 +2102,8 @@ func assignObjectDirectlyToObject(
 			return nil, eris.Wrapf(
 				err,
 				"looking up next type for %s",
-				astmodel.DebugDescription(sourceEndpoint.Type()))
+				astmodel.DebugDescription(sourceEndpoint.Type()),
+			)
 		}
 
 		if !nextType.IsEmpty() && !astmodel.TypeEquals(nextType, destinationName) {
@@ -2089,11 +2147,13 @@ func assignObjectDirectlyToObject(
 		declaration := astbuilder.LocalVariableDeclaration(copyVar, createTypeDeclaration(destinationName, generationContext), "")
 
 		functionName := NameOfPropertyAssignmentFunction(
-			conversionContext.FunctionBaseName(), destinationName, ConvertTo, conversionContext.idFactory)
+			conversionContext.FunctionBaseName(), destinationName, ConvertTo, conversionContext.idFactory,
+		)
 		conversion := astbuilder.AssignmentStatement(
 			errLocal,
 			tok,
-			astbuilder.CallExpr(reader, functionName, astbuilder.AddrOf(localID)))
+			astbuilder.CallExpr(reader, functionName, astbuilder.AddrOf(localID)),
+		)
 
 		checkForError := astbuilder.ReturnIfNotNil(
 			errLocal,
@@ -2101,7 +2161,9 @@ func assignObjectDirectlyToObject(
 				errorsPackageName,
 				"calling %s() to %s",
 				functionName,
-				describeAssignment(sourceEndpoint, destinationEndpoint)))
+				describeAssignment(sourceEndpoint, destinationEndpoint),
+			),
+		)
 
 		assignment := writer(dst.NewIdent(copyVar))
 		return astbuilder.Statements(declaration, conversion, checkForError, assignment), nil
@@ -2174,7 +2236,8 @@ func assignInlineObjectsViaIntermediateObject(
 			return nil, eris.Wrapf(
 				err,
 				"looking up next type for %s",
-				astmodel.DebugDescription(destinationEndpoint.Type()))
+				astmodel.DebugDescription(destinationEndpoint.Type()),
+			)
 		}
 	} else if conversionContext.PathExists(destinationName, sourceName) {
 		var err error
@@ -2183,7 +2246,8 @@ func assignInlineObjectsViaIntermediateObject(
 			return nil, eris.Wrapf(
 				err,
 				"looking up next type for %s",
-				astmodel.DebugDescription(destinationEndpoint.Type()))
+				astmodel.DebugDescription(destinationEndpoint.Type()),
+			)
 		}
 	} else {
 		// No path between the two types, we can't handle the required conversion
@@ -2205,14 +2269,16 @@ func assignInlineObjectsViaIntermediateObject(
 	// Need a pair of conversions, using our intermediate type
 	intermediateEndpoint := NewTypedConversionEndpoint(
 		intermediateName,
-		intermediateName.Name()+"Stash")
+		intermediateName.Name()+"Stash",
+	)
 	firstConversion, err := CreateTypeConversion(sourceEndpoint, intermediateEndpoint, conversionContext)
 	if err != nil {
 		return nil, eris.Wrapf(
 			err,
 			"finding first intermediate conversion, from %s to %s",
 			astmodel.DebugDescription(sourceName),
-			astmodel.DebugDescription(intermediateName))
+			astmodel.DebugDescription(intermediateName),
+		)
 	}
 	if firstConversion == nil {
 		return nil, nil
@@ -2224,7 +2290,8 @@ func assignInlineObjectsViaIntermediateObject(
 			err,
 			"finding second intermediate conversion, from %s to %s",
 			astmodel.DebugDescription(intermediateName),
-			astmodel.DebugDescription(destinationType))
+			astmodel.DebugDescription(destinationType),
+		)
 	}
 
 	if secondConversion == nil {
@@ -2253,7 +2320,8 @@ func assignInlineObjectsViaIntermediateObject(
 				err,
 				"converting from %s to %s",
 				astmodel.DebugDescription(sourceName),
-				astmodel.DebugDescription(intermediateName))
+				astmodel.DebugDescription(intermediateName),
+			)
 		}
 
 		secondStep, err := secondConversion(capture, writer, knownLocals, generationContext)
@@ -2262,12 +2330,14 @@ func assignInlineObjectsViaIntermediateObject(
 				err,
 				"converting from %s to %s",
 				astmodel.DebugDescription(intermediateName),
-				astmodel.DebugDescription(destinationName))
+				astmodel.DebugDescription(destinationName),
+			)
 		}
 
 		return astbuilder.Statements(
 			firstStep,
-			secondStep), nil
+			secondStep,
+		), nil
 	}, nil
 }
 
@@ -2354,17 +2424,20 @@ func assignNonInlineObjectsViaPivotObject(
 	// have to use ConvertTo to write to it
 	pivotEndpoint := NewTypedConversionEndpoint(
 		pivotName,
-		pivotName.Name()+"Pivot")
+		pivotName.Name()+"Pivot",
+	)
 	firstConversion, err := CreateTypeConversion(
 		sourceEndpoint,
 		pivotEndpoint,
-		conversionContext.WithDirection(ConvertTo))
+		conversionContext.WithDirection(ConvertTo),
+	)
 	if err != nil {
 		return nil, eris.Wrapf(
 			err,
 			"finding first intermediate conversion, from %s to %s",
 			astmodel.DebugDescription(sourceName),
-			astmodel.DebugDescription(pivotName))
+			astmodel.DebugDescription(pivotName),
+		)
 	}
 	if firstConversion == nil {
 		return nil, nil
@@ -2374,13 +2447,15 @@ func assignNonInlineObjectsViaPivotObject(
 	secondConversion, err := CreateTypeConversion(
 		pivotEndpoint,
 		destinationEndpoint,
-		conversionContext.WithDirection(ConvertFrom))
+		conversionContext.WithDirection(ConvertFrom),
+	)
 	if err != nil {
 		return nil, eris.Wrapf(
 			err,
 			"finding second intermediate conversion, from %s to %s",
 			astmodel.DebugDescription(pivotName),
-			astmodel.DebugDescription(destinationType))
+			astmodel.DebugDescription(destinationType),
+		)
 	}
 
 	if secondConversion == nil {
@@ -2409,7 +2484,8 @@ func assignNonInlineObjectsViaPivotObject(
 				err,
 				"converting from %s to %s",
 				astmodel.DebugDescription(sourceName),
-				astmodel.DebugDescription(pivotName))
+				astmodel.DebugDescription(pivotName),
+			)
 		}
 
 		secondStep, err := secondConversion(capture, writer, knownLocals, generationContext)
@@ -2418,12 +2494,14 @@ func assignNonInlineObjectsViaPivotObject(
 				err,
 				"converting from %s to %s",
 				astmodel.DebugDescription(pivotName),
-				astmodel.DebugDescription(destinationName))
+				astmodel.DebugDescription(destinationName),
+			)
 		}
 
 		return astbuilder.Statements(
 			firstStep,
-			secondStep), nil
+			secondStep,
+		), nil
 	}, nil
 }
 

--- a/v2/tools/generator/internal/conversions/property_conversions_test.go
+++ b/v2/tools/generator/internal/conversions/property_conversions_test.go
@@ -26,19 +26,23 @@ func TestCreateTypeConversion_GivenIncompatibleEndpoints_ReturnsExpectedError(t 
 
 	stringEnum := astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(test.Pkg2020, "StringEnum"),
-		astmodel.NewEnumType(astmodel.StringType))
+		astmodel.NewEnumType(astmodel.StringType),
+	)
 
 	intEnum := astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(test.Pkg2020, "IntEnum"),
-		astmodel.NewEnumType(astmodel.IntType))
+		astmodel.NewEnumType(astmodel.IntType),
+	)
 
 	addressObject := astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(test.Pkg2020, "Address"),
-		astmodel.NewObjectType())
+		astmodel.NewObjectType(),
+	)
 
 	locationObject := astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(test.Pkg2022, "Location"),
-		astmodel.NewObjectType())
+		astmodel.NewObjectType(),
+	)
 
 	cases := []struct {
 		name           string

--- a/v2/tools/generator/internal/conversions/writable_conversion_endpoint.go
+++ b/v2/tools/generator/internal/conversions/writable_conversion_endpoint.go
@@ -43,7 +43,9 @@ func NewWritableConversionEndpointWritingProperty(
 			return astbuilder.Statements(
 				astbuilder.SimpleAssignment(
 					astbuilder.Selector(destination, name),
-					value))
+					value,
+				),
+			)
 		},
 		description: fmt.Sprintf("write to property %s", name),
 	}
@@ -61,7 +63,9 @@ func NewWritableConversionEndpointWritingPropertyBagMember(
 			return astbuilder.Statements(
 				astbuilder.SimpleAssignment(
 					astbuilder.Selector(destination, itemName),
-					value))
+					value,
+				),
+			)
 		},
 		description: fmt.Sprintf("write %s to property bag", itemName),
 	}

--- a/v2/tools/generator/internal/functions/chained_conversion_function.go
+++ b/v2/tools/generator/internal/functions/chained_conversion_function.go
@@ -112,13 +112,15 @@ func (fn *ChainedConversionFunction) RequiredPackageReferences() *astmodel.Packa
 		astmodel.FmtReference,
 		astmodel.GenRuntimeReference,
 		fn.parameterType.PackageReference(),
-		fn.propertyAssignmentParameterType.PackageReference())
+		fn.propertyAssignmentParameterType.PackageReference(),
+	)
 }
 
 func (fn *ChainedConversionFunction) References() astmodel.TypeNameSet {
 	return astmodel.NewTypeNameSet(
 		fn.parameterType,
-		fn.propertyAssignmentParameterType)
+		fn.propertyAssignmentParameterType,
+	)
 }
 
 func (fn *ChainedConversionFunction) AsFunc(
@@ -198,21 +200,26 @@ func (fn *ChainedConversionFunction) bodyForConvert(
 
 	// return <receiver>.AssignProperties(From|To)(<local>)
 	directConversion := astbuilder.Returns(
-		astbuilder.CallExpr(receiver, fn.propertyAssignmentFunctionName, local))
+		astbuilder.CallExpr(receiver, fn.propertyAssignmentFunctionName, local),
+	)
 	astbuilder.AddComment(
 		&directConversion.Decorations().Start,
 		fn.direction.SelectString(
 			fmt.Sprintf("// Populate our instance from %s", parameter),
-			fmt.Sprintf("// Populate %s from our instance", parameter)))
+			fmt.Sprintf("// Populate %s from our instance", parameter),
+		),
+	)
 
 	// if ok { ...elided... }
 	returnDirectConversion := astbuilder.IfOk(
-		directConversion)
+		directConversion,
+	)
 
 	// <local> = &<intermediateType>{}
 	initializeLocal := astbuilder.SimpleAssignment(
 		local,
-		astbuilder.AddrOf(astbuilder.NewCompositeLiteralBuilder(intermediateType).Build()))
+		astbuilder.AddrOf(astbuilder.NewCompositeLiteralBuilder(intermediateType).Build()),
+	)
 	initializeLocal.Decs.Before = dst.EmptyLine
 	astbuilder.AddComment(&initializeLocal.Decs.Start, "// Convert to an intermediate form")
 
@@ -227,12 +234,15 @@ func (fn *ChainedConversionFunction) bodyForConvert(
 		"err",
 		fn.direction.SelectExpr(
 			astbuilder.CallExpr(local, fn.Name(), parameter),
-			astbuilder.CallExpr(receiver, fn.propertyAssignmentFunctionName, local)))
+			astbuilder.CallExpr(receiver, fn.propertyAssignmentFunctionName, local),
+		),
+	)
 
 	// if err != nil { ...elided...}
 	checkInitialStepForError := astbuilder.CheckErrorAndWrap(
 		errorsPackage,
-		fmt.Sprintf("initial step of conversion in %s()", fn.Name()))
+		fmt.Sprintf("initial step of conversion in %s()", fn.Name()),
+	)
 	checkInitialStepForError.Decorations().After = dst.EmptyLine
 
 	//
@@ -246,17 +256,22 @@ func (fn *ChainedConversionFunction) bodyForConvert(
 		errIdent,
 		fn.direction.SelectExpr(
 			astbuilder.CallExpr(receiver, fn.propertyAssignmentFunctionName, local),
-			astbuilder.CallExpr(local, fn.Name(), parameter)))
+			astbuilder.CallExpr(local, fn.Name(), parameter),
+		),
+	)
 	astbuilder.AddComment(
 		&finalStep.Decorations().Start,
 		fn.direction.SelectString(
 			fmt.Sprintf("// Update our instance from %s", local),
-			fmt.Sprintf("// Update %s from our instance", local)))
+			fmt.Sprintf("// Update %s from our instance", local),
+		),
+	)
 
 	// if err != nil { ...elided...}
 	checkFinalStepForError := astbuilder.CheckErrorAndWrap(
 		errorsPackage,
-		fmt.Sprintf("final step of conversion in %s()", fn.Name()))
+		fmt.Sprintf("final step of conversion in %s()", fn.Name()),
+	)
 	checkFinalStepForError.Decorations().After = dst.EmptyLine
 
 	returnNil := astbuilder.Returns(astbuilder.Nil())
@@ -269,7 +284,8 @@ func (fn *ChainedConversionFunction) bodyForConvert(
 		checkInitialStepForError,
 		finalStep,
 		checkFinalStepForError,
-		returnNil)
+		returnNil,
+	)
 }
 
 // localVariableID returns a good identifier to use for a local variable in our function,
@@ -281,7 +297,8 @@ func (fn *ChainedConversionFunction) localVariableID() string {
 func (fn *ChainedConversionFunction) declarationDocComment(receiver astmodel.TypeName, parameter string) string {
 	return fn.direction.SelectString(
 		fmt.Sprintf("populates our %s from the provided %s", receiver.Name(), parameter),
-		fmt.Sprintf("populates the provided %s from our %s", parameter, receiver.Name()))
+		fmt.Sprintf("populates the provided %s from our %s", parameter, receiver.Name()),
+	)
 }
 
 func (fn *ChainedConversionFunction) Equals(otherFn astmodel.Function, override astmodel.EqualityOverrides) bool {

--- a/v2/tools/generator/internal/functions/chained_conversion_function_test.go
+++ b/v2/tools/generator/internal/functions/chained_conversion_function_test.go
@@ -28,7 +28,8 @@ func TestGolden_NewSpecChainedConversionFunction_Conversion_GeneratesExpectedCod
 		"Person",
 		test.FullNameProperty,
 		test.KnownAsProperty,
-		test.FamilyNameProperty)
+		test.FamilyNameProperty,
+	)
 
 	// Create our downstream type
 	personSpec2021 := test.CreateSpec(
@@ -37,7 +38,8 @@ func TestGolden_NewSpecChainedConversionFunction_Conversion_GeneratesExpectedCod
 		test.FullNameProperty,
 		test.KnownAsProperty,
 		test.FamilyNameProperty,
-		test.CityProperty)
+		test.CityProperty,
+	)
 
 	// Create Property Assignment functions
 	defs := make(astmodel.TypeDefinitionSet)
@@ -68,7 +70,8 @@ func TestGolden_NewSpecChainedConversionFunction_Conversion_GeneratesExpectedCod
 	 * and check that the implementations of ConvertSpecTo() and ConvertSpecFrom() are what you expect.
 	 */
 	test.AssertSingleTypeDefinitionGeneratesExpectedCode(
-		t, "Person", personSpec2020updated, test.DiffWith(personSpec2020))
+		t, "Person", personSpec2020updated, test.DiffWith(personSpec2020),
+	)
 }
 
 // TestGolden_NewStatusChainedConversionFunction_Conversion_GeneratesExpectedCode tests the code when the ConvertToStatus()
@@ -113,5 +116,6 @@ func TestGolden_NewStatusChainedConversionFunction_Conversion_GeneratesExpectedC
 	 * and check that the implementations of ConvertSpecTo() and ConvertSpecFrom() are what you expect.
 	 */
 	test.AssertSingleTypeDefinitionGeneratesExpectedCode(
-		t, "Person", personStatus2020updated, test.DiffWith(personStatus2020))
+		t, "Person", personStatus2020updated, test.DiffWith(personStatus2020),
+	)
 }

--- a/v2/tools/generator/internal/functions/common.go
+++ b/v2/tools/generator/internal/functions/common.go
@@ -23,7 +23,8 @@ func createBodyReturningLiteralString(
 		astbuilder.StringLiteral(result),
 		astmodel.StringType,
 		comment,
-		receiverTypeEnum)
+		receiverTypeEnum,
+	)
 }
 
 func createBodyReturningValue(

--- a/v2/tools/generator/internal/functions/conditions_functions.go
+++ b/v2/tools/generator/internal/functions/conditions_functions.go
@@ -91,7 +91,8 @@ func SetConditionsFunction(
 
 	fn.AddParameter(
 		conditionsParameterName,
-		conditionsTypeExpr)
+		conditionsTypeExpr,
+	)
 	fn.AddComments("sets the conditions on the resource status")
 
 	return fn.DefineFunc(), nil

--- a/v2/tools/generator/internal/functions/dynamic_exports.go
+++ b/v2/tools/generator/internal/functions/dynamic_exports.go
@@ -66,7 +66,8 @@ func NewConfigMapExporterInterface(
 		[]string{"Spec", astmodel.OperatorSpecProperty, astmodel.OperatorSpecConfigMapExpressionsProperty},
 		"ConfigMapDestinationExpressions",
 		astmodel.DestinationExpressionCollectionType,
-		astmodel.ConfigMapExporterType)
+		astmodel.ConfigMapExporterType,
+	)
 }
 
 func NewSecretsExporterInterface(
@@ -82,7 +83,8 @@ func NewSecretsExporterInterface(
 		[]string{"Spec", astmodel.OperatorSpecProperty, astmodel.OperatorSpecSecretExpressionsProperty},
 		"SecretDestinationExpressions",
 		astmodel.DestinationExpressionCollectionType,
-		astmodel.SecretExporterType)
+		astmodel.SecretExporterType,
+	)
 }
 
 func (d *PropertyExporter) ToInterfaceImplementation() *astmodel.InterfaceImplementation {
@@ -91,12 +93,14 @@ func (d *PropertyExporter) ToInterfaceImplementation() *astmodel.InterfaceImplem
 			d.functionName,
 			d.resource,
 			d.idFactory,
-			d.getPropertyFunction),
+			d.getPropertyFunction,
+		),
 	}
 
 	return astmodel.NewInterfaceImplementation(
 		d.interfaceName,
-		funcs...)
+		funcs...,
+	)
 }
 
 // getPropertyFunction returns a function declaration for getting the property.
@@ -125,7 +129,8 @@ func (d *PropertyExporter) getPropertyFunction(
 			nilChecks,
 			astbuilder.ReturnIfNil(
 				astbuilder.Selector(
-					dst.NewIdent(receiverIdent), check...), astbuilder.Nil(),
+					dst.NewIdent(receiverIdent), check...,
+				), astbuilder.Nil(),
 			),
 		)
 	}
@@ -138,7 +143,8 @@ func (d *PropertyExporter) getPropertyFunction(
 		Name:          d.functionName,
 		Body: astbuilder.Statements(
 			nilChecks,
-			ret),
+			ret,
+		),
 	}
 
 	exportTypeExpr, err := d.exportType.AsTypeExpr(genContext)

--- a/v2/tools/generator/internal/functions/empty_status_function.go
+++ b/v2/tools/generator/internal/functions/empty_status_function.go
@@ -21,7 +21,8 @@ func NewEmptyStatusFunction(
 	result := NewObjectFunction(
 		"NewEmptyStatus",
 		idFactory,
-		createNewEmptyStatusFunction(status))
+		createNewEmptyStatusFunction(status),
+	)
 	result.AddReferencedTypes(astmodel.ConvertibleStatusInterfaceType)
 	return result
 }
@@ -53,7 +54,9 @@ func createNewEmptyStatusFunction(
 			Name:          "NewEmptyStatus",
 			Body: astbuilder.Statements(
 				astbuilder.Returns(
-					astbuilder.AddrOf(literal))),
+					astbuilder.AddrOf(literal),
+				),
+			),
 		}
 
 		convertibleStatusInterfaceExpr, err := astmodel.ConvertibleStatusInterfaceType.AsTypeExpr(genContext)

--- a/v2/tools/generator/internal/functions/get_extended_resources_function.go
+++ b/v2/tools/generator/internal/functions/get_extended_resources_function.go
@@ -72,7 +72,8 @@ func sortResources(resources []astmodel.InternalTypeName) []astmodel.InternalTyp
 			}
 
 			return 0
-		})
+		},
+	)
 
 	return resources
 }

--- a/v2/tools/generator/internal/functions/get_resource_apiversion_function.go
+++ b/v2/tools/generator/internal/functions/get_resource_apiversion_function.go
@@ -25,7 +25,8 @@ func NewGetAPIVersionFunction(
 			astbuilder.TextLiteral(apiVersionEnumValue.Value),
 			astmodel.StringType,
 			comment,
-			ReceiverTypeStruct))
+			ReceiverTypeStruct,
+		))
 
 	return result
 }

--- a/v2/tools/generator/internal/functions/get_resource_type_function.go
+++ b/v2/tools/generator/internal/functions/get_resource_type_function.go
@@ -33,6 +33,7 @@ func NewGetTypeFunction(
 		"Get"+astmodel.TypeProperty,
 		idFactory,
 		createBodyReturningLiteralString(armType, comment, receiverType),
-		astmodel.GenRuntimeReference)
+		astmodel.GenRuntimeReference,
+	)
 	return result
 }

--- a/v2/tools/generator/internal/functions/get_status_function.go
+++ b/v2/tools/generator/internal/functions/get_status_function.go
@@ -39,7 +39,9 @@ func createGetStatusFunction(
 		Name:          "GetStatus",
 		Body: astbuilder.Statements(
 			astbuilder.Returns(
-				astbuilder.AddrOf(astbuilder.Selector(dst.NewIdent(receiverIdent), "Status")))),
+				astbuilder.AddrOf(astbuilder.Selector(dst.NewIdent(receiverIdent), "Status")),
+			),
+		),
 	}
 
 	convertibleStatusInterfaceExpr, err := astmodel.ConvertibleStatusInterfaceType.AsTypeExpr(genContext)

--- a/v2/tools/generator/internal/functions/hub_function.go
+++ b/v2/tools/generator/internal/functions/hub_function.go
@@ -21,7 +21,8 @@ func NewHubFunction(idFactory astmodel.IdentifierFactory) astmodel.Function {
 	result := NewObjectFunction(
 		"Hub",
 		idFactory,
-		createHubFunctionBody)
+		createHubFunctionBody,
+	)
 	return result
 }
 

--- a/v2/tools/generator/internal/functions/index_registration_function.go
+++ b/v2/tools/generator/internal/functions/index_registration_function.go
@@ -93,7 +93,8 @@ func (f *IndexRegistrationFunction) AsFunc(
 	cast := astbuilder.TypeAssert(
 		dst.NewIdent(objName),
 		dst.NewIdent(rawObjName),
-		astbuilder.PointerTo(resourceTypeNameExpr))
+		astbuilder.PointerTo(resourceTypeNameExpr),
+	)
 
 	// if !ok { return nil }
 	checkAssert := astbuilder.ReturnIfNotOk(astbuilder.Nil())
@@ -114,7 +115,8 @@ func (f *IndexRegistrationFunction) AsFunc(
 		Body: astbuilder.Statements(
 			cast,
 			checkAssert,
-			stmts),
+			stmts,
+		),
 	}
 
 	controllerRuntimeObjectExpr, err := astmodel.ControllerRuntimeObjectType.AsTypeExpr(codeGenerationContext)
@@ -160,7 +162,8 @@ func (f *IndexRegistrationFunction) multipleValues(selector *dst.SelectorExpr) (
 		&dst.ArrayType{
 			Elt: dst.NewIdent("string"),
 		},
-		"")
+		"",
+	)
 
 	locals := astmodel.NewKnownLocalsSet(f.idFactory)
 
@@ -181,7 +184,8 @@ func (f *IndexRegistrationFunction) multipleValues(selector *dst.SelectorExpr) (
 	return astbuilder.Statements(
 		resultVar,
 		stmts,
-		ret), nil
+		ret,
+	), nil
 }
 
 func (f *IndexRegistrationFunction) makeStatements(
@@ -242,7 +246,8 @@ func (f *IndexRegistrationFunction) handleArray(
 	loop := astbuilder.IterateOverSlice(
 		local,
 		astbuilder.Selector(ident, p.PropertyName().String()),
-		loopStatements...)
+		loopStatements...,
+	)
 	return astbuilder.Statements(loop), nil
 }
 
@@ -267,7 +272,8 @@ func (f *IndexRegistrationFunction) handleMap(
 		key,
 		value,
 		astbuilder.Selector(ident, p.PropertyName().String()),
-		loopStatements...)
+		loopStatements...,
+	)
 
 	return astbuilder.Statements(loop), nil
 }

--- a/v2/tools/generator/internal/functions/initialize_spec_function.go
+++ b/v2/tools/generator/internal/functions/initialize_spec_function.go
@@ -61,7 +61,9 @@ func NewInitializeSpecFunction(
 			astbuilder.CallExpr(
 				astbuilder.Selector(dst.NewIdent(receiverName), "Spec"),
 				specInitializeFunction,
-				dst.NewIdent(statusLocal)))
+				dst.NewIdent(statusLocal),
+			),
+		)
 
 		// if s, ok := fromStatus.(<type of status>); ok {
 		//   return receiver.Spec.InitializeFromStatus(s)
@@ -75,14 +77,17 @@ func NewInitializeSpecFunction(
 			dst.NewIdent(statusParam),
 			astbuilder.Dereference(statusTypeExpr),
 			statusLocal,
-			returnConversion)
+			returnConversion,
+		)
 
 		// return fmt.Errorf("expected Status of type <type of status> but received %T instead", fromStatus)
 		returnError := astbuilder.Returns(
 			astbuilder.FormatError(
 				fmtPackage,
 				fmt.Sprintf("expected Status of type %s but received %%T instead", statusType.Name()),
-				dst.NewIdent(statusParam)))
+				dst.NewIdent(statusParam),
+			),
+		)
 		returnError.Decorations().Before = dst.EmptyLine
 
 		funcDetails := astbuilder.FuncDetails{
@@ -91,7 +96,8 @@ func NewInitializeSpecFunction(
 			ReceiverType:  astbuilder.Dereference(receiverType),
 			Body: astbuilder.Statements(
 				initialize,
-				returnError),
+				returnError,
+			),
 		}
 
 		funcDetails.AddComments("initializes the spec for this resource from the given status")

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_defaulter.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_defaulter.go
@@ -40,7 +40,8 @@ func NewDefaultFunction(
 		data,
 		idFactory,
 		asFunc,
-		requiredPackages...)
+		requiredPackages...,
+	)
 }
 
 // DefaulterBuilder helps in building an interface implementation for webhook.CustomDefaulter.
@@ -103,7 +104,8 @@ func (d *DefaulterBuilder) ToInterfaceImplementation() *astmodel.InterfaceImplem
 		grp,
 		resource,
 		ver,
-		name)
+		name,
+	)
 
 	funcs := make([]astmodel.Function, 0, 2+len(d.defaults))
 	funcs = append(funcs,
@@ -114,14 +116,16 @@ func (d *DefaulterBuilder) ToInterfaceImplementation() *astmodel.InterfaceImplem
 			d.defaultFunction,
 			d.resourceName.PackageReference(),
 			astmodel.FmtReference,
-			astmodel.GenRuntimeReference),
+			astmodel.GenRuntimeReference,
+		),
 		NewDefaultFunction(
 			"defaultImpl",
 			d.resourceName,
 			d.idFactory,
 			d.localDefault,
 			astmodel.FmtReference,
-			astmodel.GenRuntimeReference))
+			astmodel.GenRuntimeReference,
+		))
 
 	// Add the actual individual default functions
 	for _, def := range d.defaults {
@@ -130,7 +134,8 @@ func (d *DefaulterBuilder) ToInterfaceImplementation() *astmodel.InterfaceImplem
 
 	return astmodel.NewInterfaceImplementation(
 		astmodel.DefaulterInterfaceName,
-		funcs...).WithAnnotation(annotation)
+		funcs...,
+	).WithAnnotation(annotation)
 }
 
 func (d *DefaulterBuilder) localDefault(
@@ -154,13 +159,15 @@ func (d *DefaulterBuilder) localDefault(
 		call := astbuilder.AssignmentStatement(
 			dst.NewIdent("err"),
 			tok,
-			astbuilder.CallQualifiedFunc(receiverIdent, def.Name(), dst.NewIdent(contextIdent), dst.NewIdent(objIdent)))
+			astbuilder.CallQualifiedFunc(receiverIdent, def.Name(), dst.NewIdent(contextIdent), dst.NewIdent(objIdent)),
+		)
 		check := astbuilder.CheckErrorAndReturn()
 		tok = token.ASSIGN
 		defaults = append(
 			defaults,
 			call,
-			check)
+			check,
+		)
 	}
 
 	defaults = append(defaults, astbuilder.Returns(astbuilder.Nil()))
@@ -250,12 +257,14 @@ func (d *DefaulterBuilder) defaultFunction(
 	defaultImplCall := astbuilder.AssignmentStatement(
 		dst.NewIdent("err"),
 		token.DEFINE,
-		astbuilder.CallQualifiedFunc(receiverIdent, "defaultImpl", dst.NewIdent(contextIdent), dst.NewIdent(resourceIdent)))
+		astbuilder.CallQualifiedFunc(receiverIdent, "defaultImpl", dst.NewIdent(contextIdent), dst.NewIdent(resourceIdent)),
+	)
 
 	customDefaultCall := astbuilder.AssignmentStatement(
 		dst.NewIdent("err"),
 		token.ASSIGN,
-		astbuilder.CallQualifiedFunc(runtimeDefaulterIdent, "CustomDefault", dst.NewIdent(contextIdent), dst.NewIdent(resourceIdent)))
+		astbuilder.CallQualifiedFunc(runtimeDefaulterIdent, "CustomDefault", dst.NewIdent(contextIdent), dst.NewIdent(resourceIdent)),
+	)
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_defaults.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_defaults.go
@@ -28,7 +28,8 @@ func NewDefaultAzureNameFunction(resource astmodel.TypeDefinition, idFactory ast
 		resource.Name(),
 		idFactory,
 		defaultAzureNameFunction,
-		astmodel.GenRuntimeReference)
+		astmodel.GenRuntimeReference,
+	)
 }
 
 func defaultAzureNameFunction(
@@ -57,8 +58,10 @@ func defaultAzureNameFunction(
 			astbuilder.IfEqual(
 				azureNameProp,
 				astbuilder.StringLiteral(""),
-				astbuilder.SimpleAssignment(azureNameProp, nameProp)),
-			astbuilder.Returns(astbuilder.Nil())),
+				astbuilder.SimpleAssignment(azureNameProp, nameProp),
+			),
+			astbuilder.Returns(astbuilder.Nil()),
+		),
 	}
 
 	contextTypeExpr, err := astmodel.ContextType.AsTypeExpr(codeGenerationContext)

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_validations.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_validations.go
@@ -31,7 +31,8 @@ func NewValidateResourceReferencesFunction(resource astmodel.TypeDefinition, idF
 		idFactory,
 		validateResourceReferences,
 		astmodel.GenRuntimeReference,
-		astmodel.ReflectHelpersReference)
+		astmodel.ReflectHelpersReference,
+	)
 }
 
 // NewValidateOwnerReferenceFunction creates a function for validating the owner reference, if it exists
@@ -45,7 +46,8 @@ func NewValidateOwnerReferenceFunction(resource astmodel.TypeDefinition, idFacto
 		resource.Name(),
 		idFactory,
 		validateOwnerReferences,
-		astmodel.GenRuntimeReference)
+		astmodel.GenRuntimeReference,
+	)
 }
 
 // NewValidateWriteOncePropertiesFunction creates a function for validating write-once properties
@@ -58,7 +60,8 @@ func NewValidateWriteOncePropertiesFunction(resource astmodel.TypeDefinition, id
 		"validateWriteOnceProperties",
 		resource.Name(),
 		idFactory,
-		validateWriteOncePropertiesFunction)
+		validateWriteOncePropertiesFunction,
+	)
 }
 
 // NewValidateOptionalConfigMapReferenceFunction creates a function for validating optional configmap references
@@ -77,7 +80,8 @@ func NewValidateOptionalConfigMapReferenceFunction(resource astmodel.TypeDefinit
 		idFactory,
 		validateOptionalConfigMapReferences,
 		astmodel.GenRuntimeConfigMapsReference,
-		astmodel.ReflectHelpersReference)
+		astmodel.ReflectHelpersReference,
+	)
 }
 
 // NewValidateOptionalSecretReferenceFunction creates a function for validating optional secret references
@@ -96,7 +100,8 @@ func NewValidateOptionalSecretReferenceFunction(resource astmodel.TypeDefinition
 		idFactory,
 		validateOptionalSecretReferences,
 		astmodel.GenRuntimeSecretsReference,
-		astmodel.ReflectHelpersReference)
+		astmodel.ReflectHelpersReference,
+	)
 }
 
 func validateResourceReferences(
@@ -160,7 +165,10 @@ func validateResourceReferencesBody(codeGenerationContext *astmodel.CodeGenerati
 			astbuilder.CallQualifiedFunc(
 				reflectHelpers,
 				"FindResourceReferences",
-				astbuilder.AddrOf(astbuilder.Selector(dst.NewIdent(objIdent), "Spec")))))
+				astbuilder.AddrOf(astbuilder.Selector(dst.NewIdent(objIdent), "Spec")),
+			),
+		),
+	)
 	body = append(body, astbuilder.CheckErrorAndReturn(astbuilder.Nil()))
 	body = append(
 		body,
@@ -168,7 +176,10 @@ func validateResourceReferencesBody(codeGenerationContext *astmodel.CodeGenerati
 			astbuilder.CallQualifiedFunc(
 				genRuntime,
 				"ValidateResourceReferences",
-				dst.NewIdent("refs"))))
+				dst.NewIdent("refs"),
+			),
+		),
+	)
 
 	return body
 }
@@ -229,7 +240,10 @@ func validateOwnerReferencesBody(codeGenerationContext *astmodel.CodeGenerationC
 			astbuilder.CallQualifiedFunc(
 				genRuntime,
 				"ValidateOwner",
-				dst.NewIdent(objIdent))))
+				dst.NewIdent(objIdent),
+			),
+		),
+	)
 
 	return body
 }
@@ -299,7 +313,9 @@ func validateWriteOncePropertiesFunctionBody(
 			genRuntime,
 			"ValidateWriteOnceProperties",
 			dst.NewIdent(oldObjIdent),
-			dst.NewIdent(newObjIdent)))
+			dst.NewIdent(newObjIdent),
+		),
+	)
 	return astbuilder.Statements(returnStmt)
 }
 
@@ -364,7 +380,10 @@ func validateOptionalConfigMapReferencesBody(codeGenerationContext *astmodel.Cod
 			astbuilder.CallQualifiedFunc(
 				reflectHelpers,
 				"FindOptionalConfigMapReferences",
-				astbuilder.AddrOf(astbuilder.Selector(dst.NewIdent(objIdent), "Spec")))))
+				astbuilder.AddrOf(astbuilder.Selector(dst.NewIdent(objIdent), "Spec")),
+			),
+		),
+	)
 	body = append(body, astbuilder.CheckErrorAndReturn(astbuilder.Nil()))
 	body = append(
 		body,
@@ -372,7 +391,10 @@ func validateOptionalConfigMapReferencesBody(codeGenerationContext *astmodel.Cod
 			astbuilder.CallQualifiedFunc(
 				genRuntimeConfigMaps,
 				"ValidateOptionalReferences",
-				dst.NewIdent("refs"))))
+				dst.NewIdent("refs"),
+			),
+		),
+	)
 
 	return body
 }
@@ -438,7 +460,10 @@ func validateOptionalSecretReferencesBody(codeGenerationContext *astmodel.CodeGe
 			astbuilder.CallQualifiedFunc(
 				reflectHelpers,
 				"FindOptionalSecretReferences",
-				astbuilder.AddrOf(astbuilder.Selector(dst.NewIdent(objIdent), "Spec")))))
+				astbuilder.AddrOf(astbuilder.Selector(dst.NewIdent(objIdent), "Spec")),
+			),
+		),
+	)
 	body = append(body, astbuilder.CheckErrorAndReturn(astbuilder.Nil()))
 	body = append(
 		body,
@@ -446,7 +471,10 @@ func validateOptionalSecretReferencesBody(codeGenerationContext *astmodel.CodeGe
 			astbuilder.CallQualifiedFunc(
 				genRuntimeSecrets,
 				"ValidateOptionalReferences",
-				dst.NewIdent("refs"))))
+				dst.NewIdent("refs"),
+			),
+		),
+	)
 
 	return body
 }

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_validator.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_validator.go
@@ -50,7 +50,8 @@ func NewValidateFunction(
 		data,
 		idFactory,
 		asFunc,
-		requiredPackages...)
+		requiredPackages...,
+	)
 }
 
 // ValidatorBuilder helps in building an interface implementation for webhook.CustomValidator.
@@ -118,7 +119,8 @@ func (v *ValidatorBuilder) ToInterfaceImplementation() *astmodel.InterfaceImplem
 		group,
 		resource,
 		version,
-		name)
+		name,
+	)
 
 	// Count total validations for preallocation
 	totalValidations := 0
@@ -135,7 +137,8 @@ func (v *ValidatorBuilder) ToInterfaceImplementation() *astmodel.InterfaceImplem
 			v.validateCreate,
 			v.resourceName.PackageReference(),
 			astmodel.FmtReference,
-			astmodel.GenRuntimeReference),
+			astmodel.GenRuntimeReference,
+		),
 		NewValidateFunction(
 			"ValidateUpdate",
 			v.resourceName,
@@ -143,7 +146,8 @@ func (v *ValidatorBuilder) ToInterfaceImplementation() *astmodel.InterfaceImplem
 			v.validateUpdate,
 			v.resourceName.PackageReference(),
 			astmodel.FmtReference,
-			astmodel.GenRuntimeReference),
+			astmodel.GenRuntimeReference,
+		),
 		NewValidateFunction(
 			"ValidateDelete",
 			v.resourceName,
@@ -151,22 +155,26 @@ func (v *ValidatorBuilder) ToInterfaceImplementation() *astmodel.InterfaceImplem
 			v.validateDelete,
 			v.resourceName.PackageReference(),
 			astmodel.FmtReference,
-			astmodel.GenRuntimeReference),
+			astmodel.GenRuntimeReference,
+		),
 		NewValidateFunction(
 			"createValidations",
 			v.resourceName,
 			v.idFactory,
-			v.localCreateValidations),
+			v.localCreateValidations,
+		),
 		NewValidateFunction(
 			"updateValidations",
 			v.resourceName,
 			v.idFactory,
-			v.localUpdateValidations),
+			v.localUpdateValidations,
+		),
 		NewValidateFunction(
 			"deleteValidations",
 			v.resourceName,
 			v.idFactory,
-			v.localDeleteValidations))
+			v.localDeleteValidations,
+		))
 
 	// Add the actual individual validation functions
 	for _, validations := range v.validations {
@@ -206,7 +214,8 @@ func (v *ValidatorBuilder) validateCreate(
 		"createValidations",
 		"CreateValidations",
 		"ValidateCreate",
-		"")
+		"",
+	)
 	if err != nil {
 		return nil, eris.Wrap(err, "creating validation body")
 	}
@@ -263,7 +272,8 @@ func (v *ValidatorBuilder) validateUpdate(
 		"updateValidations",
 		"UpdateValidations",
 		"ValidateUpdate",
-		oldResourceIdent)
+		oldResourceIdent,
+	)
 	if err != nil {
 		return nil, eris.Wrap(err, "creating validation body")
 	}
@@ -320,7 +330,8 @@ func (v *ValidatorBuilder) validateDelete(
 		"deleteValidations",
 		"DeleteValidations",
 		"ValidateDelete",
-		"")
+		"",
+	)
 	if err != nil {
 		return nil, eris.Wrap(err, "creating validation body")
 	}
@@ -433,14 +444,16 @@ func (v *ValidatorBuilder) validateBody(
 		castStmts,
 		astbuilder.ShortDeclaration(
 			validationsIdent,
-			astbuilder.CallQualifiedFunc(receiverIdent, implFunctionName)),
+			astbuilder.CallQualifiedFunc(receiverIdent, implFunctionName),
+		),
 		astbuilder.AssignToInterface(tempVarIdent, dst.NewIdent(receiverIdent)),
 		astbuilder.IfType(
 			dst.NewIdent(tempVarIdent),
 			overrideInterfaceType,
 			runtimeValidatorIdent,
 			// Not using astbuilder.AppendList here as we want to tack on a "..." at the end
-			astbuilder.SimpleAssignment(dst.NewIdent(validationsIdent), appendFuncCall)),
+			astbuilder.SimpleAssignment(dst.NewIdent(validationsIdent), appendFuncCall),
+		),
 		astbuilder.Returns(astbuilder.CallQualifiedFunc(astmodel.GenRuntimeReference.PackageName(), validationFunctionName, args...)),
 	)
 
@@ -568,7 +581,8 @@ func (v *ValidatorBuilder) localValidationFuncBody(
 	if len(errs) > 0 {
 		return nil, eris.Wrap(
 			kerrors.NewAggregate(errs),
-			"failed to create local validation function body")
+			"failed to create local validation function body",
+		)
 	}
 
 	if len(elements) == 0 {

--- a/v2/tools/generator/internal/functions/kubernetes_config_exporter_function.go
+++ b/v2/tools/generator/internal/functions/kubernetes_config_exporter_function.go
@@ -53,11 +53,13 @@ func (d *KubernetesConfigExporterBuilder) ToInterfaceImplementation() *astmodel.
 			astmodel.GenericARMClientReference,
 			astmodel.LogrReference,
 			astmodel.ControllerRuntimeClient,
-			astmodel.ContextReference),
+			astmodel.ContextReference,
+		),
 	}
 	return astmodel.NewInterfaceImplementation(
 		astmodel.KuberentesConfigExporterType,
-		funcs...)
+		funcs...,
+	)
 }
 
 // exportKubernetesResource returns the body of the ExportKubernetesResources function, which implements
@@ -97,7 +99,8 @@ func (d *KubernetesConfigExporterBuilder) exportKubernetesConfigMaps(
 	collectorCreationStmt := astbuilder.AssignmentStatement(
 		dst.NewIdent(collectorIdent),
 		token.DEFINE,
-		astbuilder.CallQualifiedFunc(configMapsReference, "NewCollector", astbuilder.Selector(dst.NewIdent(receiverIdent), "Namespace")))
+		astbuilder.CallQualifiedFunc(configMapsReference, "NewCollector", astbuilder.Selector(dst.NewIdent(receiverIdent), "Namespace")),
+	)
 
 	operatorSpecSelector := astbuilder.Selector(dst.NewIdent(receiverIdent), "Spec", astmodel.OperatorSpecProperty)
 	operatorSpecConfigMapsSelector := astbuilder.Selector(operatorSpecSelector, astmodel.OperatorSpecConfigMapsProperty)
@@ -125,14 +128,16 @@ func (d *KubernetesConfigExporterBuilder) exportKubernetesConfigMaps(
 				return nil, eris.Errorf(
 					"Exporting Map elements as configmaps is not supported currently. Property %s has type %s",
 					propertyNames[i],
-					propType.String())
+					propType.String(),
+				)
 			}
 
 			if _, ok := astmodel.AsArrayType(propType); ok {
 				return nil, eris.Errorf(
 					"Exporting Slice elements as configmaps is not supported currently. Property %s has type %s",
 					propertyNames[i],
-					propType.String())
+					propType.String(),
+				)
 			}
 
 			if _, ok := astmodel.AsOptionalType(propType); !ok {
@@ -148,12 +153,14 @@ func (d *KubernetesConfigExporterBuilder) exportKubernetesConfigMaps(
 					collectorIdent,
 					propertyPath,
 					propertyNames,
-					operatorSpecPropertyName)
+					operatorSpecPropertyName,
+				)
 			}
 
 			ifBlock = astbuilder.IfNotNil(
 				astbuilder.Selector(dst.NewIdent(receiverIdent), propertyNames[:i+1]...),
-				inner)
+				inner,
+			)
 		}
 
 		//	if <receiver>.Spec.OperatorSpec != nil && <receiver>.Spec.OperatorSpec.ConfigMaps != nil {
@@ -163,7 +170,8 @@ func (d *KubernetesConfigExporterBuilder) exportKubernetesConfigMaps(
 		//	}
 		condition := astbuilder.JoinAnd(
 			astbuilder.NotNil(operatorSpecSelector),
-			astbuilder.NotNil(operatorSpecConfigMapsSelector))
+			astbuilder.NotNil(operatorSpecConfigMapsSelector),
+		)
 
 		if ifBlock == nil {
 			ifBlock = d.addCollectorStmt(
@@ -171,12 +179,14 @@ func (d *KubernetesConfigExporterBuilder) exportKubernetesConfigMaps(
 				collectorIdent,
 				propertyPath,
 				propertyNames,
-				operatorSpecPropertyName)
+				operatorSpecPropertyName,
+			)
 		}
 
 		collectStmts = append(
 			collectStmts,
-			astbuilder.SimpleIf(condition, ifBlock))
+			astbuilder.SimpleIf(condition, ifBlock),
+		)
 	}
 
 	//	result, err := collector.Values()
@@ -187,14 +197,17 @@ func (d *KubernetesConfigExporterBuilder) exportKubernetesConfigMaps(
 	collectorValues := astbuilder.SimpleAssignmentWithErr(
 		dst.NewIdent("result"),
 		token.DEFINE,
-		astbuilder.CallQualifiedFunc(collectorIdent, "Values"))
+		astbuilder.CallQualifiedFunc(collectorIdent, "Values"),
+	)
 	returnIfErrNotNil := astbuilder.CheckErrorAndReturn(astbuilder.Nil())
 	sliceToClientObjectSlice := astbuilder.Returns(
 		astbuilder.CallQualifiedFunc(
 			configMapsReference,
 			"SliceToClientObjectSlice",
-			dst.NewIdent("result")),
-		astbuilder.Nil())
+			dst.NewIdent("result"),
+		),
+		astbuilder.Nil(),
+	)
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
@@ -205,7 +218,8 @@ func (d *KubernetesConfigExporterBuilder) exportKubernetesConfigMaps(
 			collectStmts,
 			collectorValues,
 			returnIfErrNotNil,
-			sliceToClientObjectSlice),
+			sliceToClientObjectSlice,
+		),
 	}
 
 	contextTypeExpr, err := astmodel.ContextType.AsTypeExpr(codeGenerationContext)
@@ -263,5 +277,6 @@ func (d *KubernetesConfigExporterBuilder) addCollectorStmt(
 		collectorIdent,
 		"AddValue",
 		astbuilder.Selector(operatorSpecConfigMapsSelector, d.idFactory.CreateIdentifier(operatorSpecPropertyName, astmodel.Exported)),
-		valueExpr)
+		valueExpr,
+	)
 }

--- a/v2/tools/generator/internal/functions/locatable_resource_function.go
+++ b/v2/tools/generator/internal/functions/locatable_resource_function.go
@@ -21,7 +21,8 @@ func NewLocatableResource(
 		"Location",
 		resourceType,
 		idFactory,
-		locatableResourceLocationFunc)
+		locatableResourceLocationFunc,
+	)
 
 	return astmodel.NewInterfaceImplementation(astmodel.LocatableResourceInterfaceName, f)
 }
@@ -45,7 +46,8 @@ func locatableResourceLocationFunc(
 
 	body := astbuilder.Statements(
 		returnIfLocationNil,
-		returnLocation)
+		returnLocation,
+	)
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,

--- a/v2/tools/generator/internal/functions/new_empty_arm_value_function.go
+++ b/v2/tools/generator/internal/functions/new_empty_arm_value_function.go
@@ -23,7 +23,8 @@ func NewNewEmptyARMValueFunc(
 		"NewEmptyARMValue",
 		idFactory,
 		newEmptyARMValueBody(armType),
-		armType.InternalPackageReference())
+		armType.InternalPackageReference(),
+	)
 
 	return result
 }

--- a/v2/tools/generator/internal/functions/one_of_json_marshal_function.go
+++ b/v2/tools/generator/internal/functions/one_of_json_marshal_function.go
@@ -95,13 +95,17 @@ func (f *OneOfJSONMarshalFunction) AsFunc(
 			astbuilder.CallQualifiedFunc(
 				jsonPackage,
 				"Marshal",
-				astbuilder.Selector(receiverIdent, propName)))
+				astbuilder.Selector(receiverIdent, propName),
+			),
+		)
 
 		ifStatement := astbuilder.IfNotNil(
 			astbuilder.Selector(
 				receiverIdent,
-				string(property.PropertyName())),
-			ret)
+				string(property.PropertyName()),
+			),
+			ret,
+		)
 		ifStatement.Decorations().After = dst.EmptyLine
 		statements = append(statements, ifStatement)
 	}
@@ -117,7 +121,8 @@ func (f *OneOfJSONMarshalFunction) AsFunc(
 
 	fn.AddComments(fmt.Sprintf(
 		"defers JSON marshaling to the first non-nil property, because %s represents a discriminated union (JSON OneOf)",
-		receiver.Name()))
+		receiver.Name(),
+	))
 	fn.AddReturns("[]byte", "error")
 	return fn.DefineFunc(), nil
 }

--- a/v2/tools/generator/internal/functions/original_version_function.go
+++ b/v2/tools/generator/internal/functions/original_version_function.go
@@ -63,7 +63,8 @@ func (o *OriginalVersionFunction) AsFunc(
 	}
 
 	returnVersion := astbuilder.Returns(
-		astbuilder.Selector(groupVersionPackageGlobal, "Version"))
+		astbuilder.Selector(groupVersionPackageGlobal, "Version"),
+	)
 
 	funcDetails := &astbuilder.FuncDetails{
 		ReceiverIdent: receiverName,

--- a/v2/tools/generator/internal/functions/pivot_conversion_function.go
+++ b/v2/tools/generator/internal/functions/pivot_conversion_function.go
@@ -126,12 +126,14 @@ func (fn *PivotConversionFunction) RequiredPackageReferences() *astmodel.Package
 		astmodel.ControllerRuntimeConversion,
 		astmodel.FmtReference,
 		astmodel.GenRuntimeReference,
-		fn.parameterType.PackageReference())
+		fn.parameterType.PackageReference(),
+	)
 }
 
 func (fn *PivotConversionFunction) References() astmodel.TypeNameSet {
 	return astmodel.NewTypeNameSet(
-		fn.parameterType)
+		fn.parameterType,
+	)
 }
 
 func (fn *PivotConversionFunction) AsFunc(
@@ -188,10 +190,12 @@ func (fn *PivotConversionFunction) bodyForPivot(
 
 	errorMessage := astbuilder.StringLiteralf(
 		"attempted conversion between unrelated implementations of %s",
-		fn.parameterType)
+		fn.parameterType,
+	)
 	recursionCheck := astbuilder.ReturnIfExpr(
 		astbuilder.AreEqual(parameter, receiver),
-		astbuilder.CallQualifiedFunc(errorsPkg, "New", errorMessage))
+		astbuilder.CallQualifiedFunc(errorsPkg, "New", errorMessage),
+	)
 	recursionCheck.Decorations().After = dst.EmptyLine
 
 	callAndReturn := astbuilder.Returns(astbuilder.CallExpr(parameter, fnNameForOtherDirection, receiver))
@@ -202,7 +206,8 @@ func (fn *PivotConversionFunction) bodyForPivot(
 func (fn *PivotConversionFunction) declarationDocComment(receiver astmodel.TypeName, parameter string) string {
 	return fn.direction.SelectString(
 		fmt.Sprintf("populates our %s from the provided %s", receiver.Name(), parameter),
-		fmt.Sprintf("populates the provided %s from our %s", parameter, receiver.Name()))
+		fmt.Sprintf("populates the provided %s from our %s", parameter, receiver.Name()),
+	)
 }
 
 func (fn *PivotConversionFunction) Equals(otherFn astmodel.Function, _ astmodel.EqualityOverrides) bool {

--- a/v2/tools/generator/internal/functions/property_assignment_function.go
+++ b/v2/tools/generator/internal/functions/property_assignment_function.go
@@ -132,7 +132,8 @@ func (fn *PropertyAssignmentFunction) AsFunc(
 ) (*dst.FuncDecl, error) {
 	description := fn.direction.SelectString(
 		fmt.Sprintf("populates our %s from the provided source %s", receiver.Name(), fn.ParameterType().Name()),
-		fmt.Sprintf("populates the provided destination %s from our %s", fn.ParameterType().Name(), receiver.Name()))
+		fmt.Sprintf("populates the provided destination %s from our %s", fn.ParameterType().Name(), receiver.Name()),
+	)
 
 	// We always use a pointer receiver, so we can modify it
 	receiverType := astmodel.NewOptionalType(receiver)
@@ -205,7 +206,8 @@ func (fn *PropertyAssignmentFunction) generateBody(
 		assignments,
 		bagEpilogue,
 		handleOverrideInterface,
-		astbuilder.ReturnNoError()), nil
+		astbuilder.ReturnNoError(),
+	), nil
 }
 
 // createPropertyBagPrologue creates any introductory statements needed to set up our property bag before we start doing
@@ -240,18 +242,21 @@ func (fn *PropertyAssignmentFunction) createPropertyBagPrologue(
 		createBag = astbuilder.CallQualifiedFunc(
 			genruntimePkg,
 			"NewPropertyBag",
-			astbuilder.Selector(dst.NewIdent(source), string(fn.sourcePropertyBag.PropertyName())))
+			astbuilder.Selector(dst.NewIdent(source), string(fn.sourcePropertyBag.PropertyName())),
+		)
 		comment = "// Clone the existing property bag"
 	} else {
 		createBag = astbuilder.CallQualifiedFunc(
 			genruntimePkg,
-			"NewPropertyBag")
+			"NewPropertyBag",
+		)
 		comment = "// Create a new property bag"
 	}
 
 	initializeBag := astbuilder.ShortDeclaration(
 		fn.conversionContext.PropertyBagName(),
-		createBag)
+		createBag,
+	)
 	initializeBag.Decs.Before = dst.NewLine
 	astbuilder.AddComment(&initializeBag.Decorations().Start, comment)
 
@@ -282,7 +287,8 @@ func (fn *PropertyAssignmentFunction) propertyBagEpilogue(
 		store := astbuilder.SimpleIfElse(
 			condition,
 			astbuilder.Statements(storeBag),
-			astbuilder.Statements(storeNil))
+			astbuilder.Statements(storeNil),
+		)
 		store.Decs.Before = dst.EmptyLine
 		astbuilder.AddComment(&store.Decorations().Start, "// Update the property bag")
 
@@ -330,25 +336,30 @@ func (fn *PropertyAssignmentFunction) handleAugmentationInterface(
 	conversionFuncName := fn.Direction().SelectString("AssignPropertiesFrom", "AssignPropertiesTo")
 	callAssignOverride := astbuilder.ShortDeclaration(
 		"err",
-		astbuilder.CallQualifiedFunc(augmentedReceiverIdent, conversionFuncName, dst.NewIdent(parameter)))
+		astbuilder.CallQualifiedFunc(augmentedReceiverIdent, conversionFuncName, dst.NewIdent(parameter)),
+	)
 	returnIfNotNil := astbuilder.ReturnIfNotNil(
 		dst.NewIdent("err"),
 		astbuilder.WrappedError(
 			generationContext.MustGetImportedPackageName(astmodel.ErisReference),
-			fmt.Sprintf("calling augmented %s() for conversion", conversionFuncName)))
+			fmt.Sprintf("calling augmented %s() for conversion", conversionFuncName),
+		),
+	)
 
 	ifStmt := astbuilder.IfType(
 		dst.NewIdent(receiverAsAnyIdent),
 		augmentationInterfaceExpr,
 		augmentedReceiverIdent,
 		callAssignOverride,
-		returnIfNotNil)
+		returnIfNotNil,
+	)
 	sourceAsAny.Decorations().Before = dst.EmptyLine
 	sourceAsAny.Decorations().Start.Prepend(fmt.Sprintf("// Invoke the %s interface (if implemented) to customize the conversion", fn.augmentationInterface.Name()))
 
 	return astbuilder.Statements(
 		sourceAsAny,
-		ifStmt), nil
+		ifStmt,
+	), nil
 }
 
 // generateAssignments generates a sequence of statements to copy information between the two types

--- a/v2/tools/generator/internal/functions/property_assignment_function_builder.go
+++ b/v2/tools/generator/internal/functions/property_assignment_function_builder.go
@@ -110,7 +110,8 @@ func (builder *PropertyAssignmentFunctionBuilder) AddAssignmentSelector(selector
 			} else {
 				return 0
 			}
-		})
+		},
+	)
 }
 
 // AddSuffixMatchingAssignmentSelector adds a new assignment selector that will match a property with the specified
@@ -120,7 +121,8 @@ func (builder *PropertyAssignmentFunctionBuilder) AddSuffixMatchingAssignmentSel
 	destinationSuffix string,
 ) {
 	builder.AddAssignmentSelector(
-		builder.createSuffixMatchingAssignmentSelector(sourceSuffix, destinationSuffix))
+		builder.createSuffixMatchingAssignmentSelector(sourceSuffix, destinationSuffix),
+	)
 }
 
 func (builder *PropertyAssignmentFunctionBuilder) Build(
@@ -134,7 +136,8 @@ func (builder *PropertyAssignmentFunctionBuilder) Build(
 		conversionContext.FunctionBaseName(),
 		builder.otherDefinition.Name(),
 		builder.direction,
-		idFactory)
+		idFactory,
+	)
 
 	// Select names for receiver and parameter
 	receiverName := idFactory.CreateReceiver(builder.receiverDefinition.Name().Name())
@@ -161,7 +164,8 @@ func (builder *PropertyAssignmentFunctionBuilder) Build(
 		astmodel.ErisReference,
 		astmodel.GenRuntimeReference,
 		builder.otherDefinition.Name().PackageReference(),
-		compatPkg)
+		compatPkg,
+	)
 
 	cc := conversionContext.WithDirection(builder.direction).
 		WithPropertyBag(propertyBagName).
@@ -272,7 +276,8 @@ func (builder *PropertyAssignmentFunctionBuilder) createConversions(
 				err,
 				"creating conversion to %s by %s",
 				destinationEndpoint,
-				sourceEndpoint)
+				sourceEndpoint,
+			)
 		}
 
 		if conv != nil {
@@ -330,12 +335,14 @@ func (builder *PropertyAssignmentFunctionBuilder) createConversion(
 	conversion, err := conversions.CreateTypeConversion(
 		sourceEndpoint.Endpoint(),
 		destinationEndpoint.Endpoint(),
-		conversionContext)
+		conversionContext,
+	)
 	if err != nil {
 		return nil, eris.Wrapf(
 			err,
 			"trying to %s and %s",
-			sourceEndpoint, destinationEndpoint)
+			sourceEndpoint, destinationEndpoint,
+		)
 	}
 
 	return func(
@@ -354,7 +361,8 @@ func (builder *PropertyAssignmentFunctionBuilder) createConversion(
 			return nil, eris.Wrapf(
 				err,
 				"converting %s to %s",
-				sourceEndpoint, destinationEndpoint)
+				sourceEndpoint, destinationEndpoint,
+			)
 		}
 
 		return stmts, nil
@@ -460,7 +468,8 @@ func (builder *PropertyAssignmentFunctionBuilder) selectPropertiesWithIdenticalP
 				return eris.Errorf(
 					"multiple source properties with path %s are compatible with destination %s, no way to select",
 					path,
-					destinationName)
+					destinationName,
+				)
 			}
 
 			sourceEndpoint = src
@@ -498,7 +507,8 @@ func (builder *PropertyAssignmentFunctionBuilder) selectRenamedProperties(
 		for source := range sourceProperties {
 			if name, renamed := conversionContext.PropertyRename(
 				builder.receiverDefinition.Name(),
-				astmodel.PropertyName(source)); renamed {
+				astmodel.PropertyName(source),
+			); renamed {
 				renames[source] = name
 			}
 		}
@@ -507,7 +517,8 @@ func (builder *PropertyAssignmentFunctionBuilder) selectRenamedProperties(
 		for destination := range destinationProperties {
 			if name, renamed := conversionContext.PropertyRename(
 				builder.receiverDefinition.Name(),
-				astmodel.PropertyName(destination)); renamed {
+				astmodel.PropertyName(destination),
+			); renamed {
 				renames[name] = destination
 			}
 		}
@@ -665,7 +676,8 @@ func (builder *PropertyAssignmentFunctionBuilder) findTypeForBag(
 	// If t is a TypeName, check for the existence of a compatibility type in a subpackage under the receiver
 	if tn, ok := astmodel.AsInternalTypeName(t); ok {
 		compatPkg := astmodel.MakeCompatPackageReference(
-			builder.receiverDefinition.Name().InternalPackageReference())
+			builder.receiverDefinition.Name().InternalPackageReference(),
+		)
 		compatType := tn.WithPackageReference(compatPkg)
 		if conversionContext.Types().Contains(compatType) {
 			// Compatibility type exists - use that

--- a/v2/tools/generator/internal/functions/property_assignment_function_test.go
+++ b/v2/tools/generator/internal/functions/property_assignment_function_test.go
@@ -307,7 +307,10 @@ func (factory *StorageConversionPropertyTestCaseFactory) createPathologicalTestC
 		astmodel.NewMapType(
 			astmodel.StringType,
 			astmodel.NewArrayType(
-				astmodel.NewMapType(astmodel.StringType, astmodel.BoolType))))
+				astmodel.NewMapType(astmodel.StringType, astmodel.BoolType),
+			),
+		),
+	)
 
 	factory.createPropertyAssignmentTest("NastyTest", nastyProperty, nastyProperty)
 }
@@ -350,48 +353,56 @@ func (factory *StorageConversionPropertyTestCaseFactory) createPathBasedTestCase
 	factory.createPropertyAssignmentTest(
 		"No assignment when identically named properties have different paths",
 		typeProperty,
-		flattenedTypeProperty)
+		flattenedTypeProperty,
+	)
 
 	factory.createPropertyAssignmentTest(
 		"Assignment when properties have same paths even with different names",
 		flattenedTypeProperty,
-		propertiesTypeProperty)
+		propertiesTypeProperty,
+	)
 
 	// Test case: When property names haven't been mangled by flattening, we generate the expected assignment
 	// copying Type to Type and ignoring TypeFromConfig
 	currentDefinition := astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(factory.currentPackage, "Person"),
 		astmodel.NewObjectType().
-			WithProperty(flattenedTypeProperty))
+			WithProperty(flattenedTypeProperty),
+	)
 
 	otherDefinition := astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(factory.nextPackage, "Person"),
 		astmodel.NewObjectType().
 			WithProperty(flattenedTypeProperty).
-			WithProperty(configurableTypeProperty))
+			WithProperty(configurableTypeProperty),
+	)
 
 	factory.createDefinitionAssignmentTest(
 		"Assigns to property with same name and path",
 		currentDefinition,
-		otherDefinition)
+		otherDefinition,
+	)
 
 	// Test case: When property names HAVE been mangled by inconsistent flattening, we generate the expected assignment
 	// copying PropertiesType to Type and ignoring PropertiesTypeFromConfig
 	currentDefinition = astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(factory.currentPackage, "Person"),
 		astmodel.NewObjectType().
-			WithProperty(flattenedTypeProperty))
+			WithProperty(flattenedTypeProperty),
+	)
 
 	otherDefinition = astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(factory.nextPackage, "Person"),
 		astmodel.NewObjectType().
 			WithProperty(propertiesTypeProperty).
-			WithProperty(configurablePropertiesTypeProperty))
+			WithProperty(configurablePropertiesTypeProperty),
+	)
 
 	factory.createDefinitionAssignmentTest(
 		"Does not try to assign to configurable variant of property",
 		currentDefinition,
-		otherDefinition)
+		otherDefinition,
+	)
 }
 
 func (factory *StorageConversionPropertyTestCaseFactory) createPropertyAssignmentTest(
@@ -403,12 +414,14 @@ func (factory *StorageConversionPropertyTestCaseFactory) createPropertyAssignmen
 	currentType := astmodel.NewObjectType().WithProperty(currentProperty)
 	currentDefinition := astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(factory.currentPackage, "Person"),
-		currentType)
+		currentType,
+	)
 
 	hubType := astmodel.NewObjectType().WithProperty(hubProperty)
 	hubDefinition := astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(factory.nextPackage, "Person"),
-		hubType)
+		hubType,
+	)
 
 	defs := make(astmodel.TypeDefinitionSet)
 	defs.Add(currentDefinition)
@@ -425,7 +438,8 @@ func (factory *StorageConversionPropertyTestCaseFactory) createPropertyAssignmen
 			func(tc *config.PropertyConfiguration) error {
 				tc.NameInNextVersion.Set(string(hubProperty.PropertyName()))
 				return nil
-			})
+			},
+		)
 		if err != nil {
 			panic(err)
 		}
@@ -471,12 +485,14 @@ func (factory *StorageConversionPropertyTestCaseFactory) createFunctionAssignmen
 	currentType := astmodel.NewObjectType().WithFunction(function)
 	currentDefinition := astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(factory.currentPackage, "Person"),
-		currentType)
+		currentType,
+	)
 
 	hubType := astmodel.NewObjectType().WithProperty(property)
 	hubDefinition := astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(factory.nextPackage, "Person"),
-		hubType)
+		hubType,
+	)
 
 	defs := make(astmodel.TypeDefinitionSet)
 	defs.Add(currentDefinition)
@@ -543,13 +559,15 @@ func TestGolden_PropertyAssignmentFunction_WhenPropertyBagPresent(t *testing.T) 
 		"Person",
 		test.FullNameProperty,
 		test.KnownAsProperty,
-		test.FamilyNameProperty)
+		test.FamilyNameProperty,
+	)
 
 	person2021 := test.CreateObjectDefinition(
 		test.Pkg2021,
 		"Person",
 		test.FullNameProperty,
-		test.PropertyBagProperty)
+		test.PropertyBagProperty,
+	)
 
 	conversionContext := conversions.NewPropertyConversionContext(conversions.AssignPropertiesMethodPrefix, make(astmodel.TypeDefinitionSet), idFactory)
 	assignFromBuilder := NewPropertyAssignmentFunctionBuilder(person2020, person2021, conversions.ConvertFrom)
@@ -577,28 +595,32 @@ func TestGolden_PropertyAssignmentFunction_WhenTypeRenamed(t *testing.T) {
 		test.Pkg2020,
 		"Location",
 		test.FullAddressProperty,
-		test.CityProperty)
+		test.CityProperty,
+	)
 
 	// ... which gets renamed to Venue in a later version
 	venue := test.CreateObjectDefinition(
 		test.Pkg2021,
 		"Venue",
 		test.FullAddressProperty,
-		test.CityProperty)
+		test.CityProperty,
+	)
 
 	// The earlier version of Event has a property "Where" of type "Location" ...
 	whereLocationProperty := astmodel.NewPropertyDefinition("Where", "where", location.Name())
 	event2020 := test.CreateObjectDefinition(
 		test.Pkg2020,
 		"Event",
-		whereLocationProperty)
+		whereLocationProperty,
+	)
 
 	// ... in the later version of Event, the property "Where" is now of type "Venue"
 	whereVenueProperty := astmodel.NewPropertyDefinition("Where", "where", venue.Name())
 	event2021 := test.CreateObjectDefinition(
 		test.Pkg2021,
 		"Event",
-		whereVenueProperty)
+		whereVenueProperty,
+	)
 
 	omc := config.NewObjectModelConfiguration()
 	g.Expect(
@@ -607,7 +629,9 @@ func TestGolden_PropertyAssignmentFunction_WhenTypeRenamed(t *testing.T) {
 			func(tc *config.TypeConfiguration) error {
 				tc.NameInNextVersion.Set(venue.Name().Name())
 				return nil
-			})).
+			},
+		),
+	).
 		To(Succeed())
 
 	defs := make(astmodel.TypeDefinitionSet)
@@ -658,17 +682,20 @@ func TestGolden_PropertyAssignmentFunction_WhenPropertyTypeHasIntermediateVersio
 	location2020 := test.CreateObjectDefinition(
 		test.Pkg2020,
 		"Location",
-		test.FullAddressProperty)
+		test.FullAddressProperty,
+	)
 
 	location2021 := test.CreateObjectDefinition(
 		test.Pkg2021,
 		"Location",
-		test.FullAddressProperty)
+		test.FullAddressProperty,
+	)
 
 	location2022 := test.CreateObjectDefinition(
 		test.Pkg2022,
 		"Location",
-		test.FullAddressProperty)
+		test.FullAddressProperty,
+	)
 
 	// Arrange - create two different version of Person - in packages v2020, and v2022.
 	// Each has a property "Residence" of type "Location",
@@ -676,12 +703,14 @@ func TestGolden_PropertyAssignmentFunction_WhenPropertyTypeHasIntermediateVersio
 	person2020 := test.CreateObjectDefinition(
 		test.Pkg2020,
 		"Person",
-		astmodel.NewPropertyDefinition("Residence", "residence", location2020.Name()))
+		astmodel.NewPropertyDefinition("Residence", "residence", location2020.Name()),
+	)
 
 	person2022 := test.CreateObjectDefinition(
 		test.Pkg2022,
 		"Person",
-		astmodel.NewPropertyDefinition("Residence", "residence", location2022.Name()))
+		astmodel.NewPropertyDefinition("Residence", "residence", location2022.Name()),
+	)
 
 	// Arrange - create the conversion graph between all these object versions
 	definitions := make(astmodel.TypeDefinitionSet)
@@ -741,38 +770,45 @@ func TestGolden_PropertyAssignmentFunction_WhenPropertyTypeHasMultipleIntermedia
 	location2020 := test.CreateObjectDefinition(
 		test.Pkg2020,
 		"Location",
-		test.FullAddressProperty)
+		test.FullAddressProperty,
+	)
 
 	location202101 := test.CreateObjectDefinition(
 		test.MakeLocalPackageReference(test.Group, "v20210301"),
 		"Location",
-		test.FullAddressProperty)
+		test.FullAddressProperty,
+	)
 
 	location202106 := test.CreateObjectDefinition(
 		test.MakeLocalPackageReference(test.Group, "v20210306"),
 		"Location",
-		test.FullAddressProperty)
+		test.FullAddressProperty,
+	)
 
 	location202112 := test.CreateObjectDefinition(
 		test.MakeLocalPackageReference(test.Group, "v20210312"),
 		"Location",
-		test.FullAddressProperty)
+		test.FullAddressProperty,
+	)
 
 	location2022 := test.CreateObjectDefinition(
 		test.Pkg2022,
 		"Location",
-		test.FullAddressProperty)
+		test.FullAddressProperty,
+	)
 
 	// Arrange - create two different version of Person - in packages v2020, and v2022.
 	person2020 := test.CreateObjectDefinition(
 		test.Pkg2020,
 		"Person",
-		astmodel.NewPropertyDefinition("Residence", "residence", location2020.Name()))
+		astmodel.NewPropertyDefinition("Residence", "residence", location2020.Name()),
+	)
 
 	person2022 := test.CreateObjectDefinition(
 		test.Pkg2022,
 		"Person",
-		astmodel.NewPropertyDefinition("Residence", "residence", location2022.Name()))
+		astmodel.NewPropertyDefinition("Residence", "residence", location2022.Name()),
+	)
 
 	definitions := make(astmodel.TypeDefinitionSet)
 	definitions.AddAll(location2020, location202101, location202106, location202112, location2022)
@@ -788,7 +824,8 @@ func TestGolden_PropertyAssignmentFunction_WhenPropertyTypeHasMultipleIntermedia
 		location202101.Name(),
 		location202106.Name(),
 		location202112.Name(),
-		location2022.Name())
+		location2022.Name(),
+	)
 
 	graph, err := builder.Build()
 	g.Expect(err).To(BeNil())
@@ -843,38 +880,45 @@ func TestGolden_PropertyAssignmentFunction_WhenPropertyTypeVersionsAreNotInline_
 	location2020 := test.CreateObjectDefinition(
 		test.MakeLocalPackageReference(test.Group, "v20200101"),
 		"Location",
-		test.FullAddressProperty)
+		test.FullAddressProperty,
+	)
 
 	location2020p := test.CreateObjectDefinition(
 		test.MakeLocalPackageReference(test.Group, "v20200601preview"),
 		"Location",
-		test.FullAddressProperty)
+		test.FullAddressProperty,
+	)
 
 	location2021 := test.CreateObjectDefinition(
 		test.MakeLocalPackageReference(test.Group, "v20210101"),
 		"Location",
-		test.FullAddressProperty)
+		test.FullAddressProperty,
+	)
 
 	location2021p := test.CreateObjectDefinition(
 		test.MakeLocalPackageReference(test.Group, "v20210601preview"),
 		"Location",
-		test.FullAddressProperty)
+		test.FullAddressProperty,
+	)
 
 	location2022 := test.CreateObjectDefinition(
 		test.MakeLocalPackageReference(test.Group, "v20220101"),
 		"Location",
-		test.FullAddressProperty)
+		test.FullAddressProperty,
+	)
 
 	// Arrange - create two different version of Person - in packages v2020p, and v2022p.
 	person2020p := test.CreateObjectDefinition(
 		test.MakeLocalPackageReference(test.Group, "v20200601preview"),
 		"Person",
-		astmodel.NewPropertyDefinition("Residence", "residence", location2020p.Name()))
+		astmodel.NewPropertyDefinition("Residence", "residence", location2020p.Name()),
+	)
 
 	person2021p := test.CreateObjectDefinition(
 		test.MakeLocalPackageReference(test.Group, "v20210601preview"),
 		"Person",
-		astmodel.NewPropertyDefinition("Residence", "residence", location2021p.Name()))
+		astmodel.NewPropertyDefinition("Residence", "residence", location2021p.Name()),
+	)
 
 	definitions := make(astmodel.TypeDefinitionSet)
 	definitions.AddAll(location2020, location2020p, location2021, location2021p, location2022)
@@ -890,7 +934,8 @@ func TestGolden_PropertyAssignmentFunction_WhenPropertyTypeVersionsAreNotInline_
 		location2020p.Name(),
 		location2021.Name(),
 		location2021p.Name(),
-		location2022.Name())
+		location2022.Name(),
+	)
 
 	graph, err := builder.Build()
 	g.Expect(err).To(BeNil())
@@ -930,13 +975,15 @@ func TestGolden_PropertyAssignmentFunction_WhenOverrideInterfacePresent(t *testi
 		"Person",
 		test.FullNameProperty,
 		test.KnownAsProperty,
-		test.FamilyNameProperty)
+		test.FamilyNameProperty,
+	)
 
 	person2021 := test.CreateObjectDefinition(
 		test.Pkg2021,
 		"Person",
 		test.FullNameProperty,
-		test.PropertyBagProperty)
+		test.PropertyBagProperty,
+	)
 
 	overrideInterfaceName := astmodel.MakeInternalTypeName(test.Pkg2020, "personAssignable")
 

--- a/v2/tools/generator/internal/functions/resource_conversion_function.go
+++ b/v2/tools/generator/internal/functions/resource_conversion_function.go
@@ -184,22 +184,27 @@ func (fn *ResourceConversionFunction) directConversion(
 	assignLocal := astbuilder.TypeAssert(
 		localIdent,
 		hubIdent,
-		astbuilder.PointerTo(hubExpr))
+		astbuilder.PointerTo(hubExpr),
+	)
 
 	checkAssert := astbuilder.ReturnIfNotOk(
 		astbuilder.FormatError(
 			fmtPackage,
 			fmt.Sprintf("expected %s/%s but received %%T instead", hubPackage, fn.Hub().Name()),
-			hubIdent))
+			hubIdent,
+		),
+	)
 
 	copyAndReturn := astbuilder.Returns(
-		astbuilder.CallExpr(dst.NewIdent(receiverName), fn.propertyFunction.Name(), localIdent))
+		astbuilder.CallExpr(dst.NewIdent(receiverName), fn.propertyFunction.Name(), localIdent),
+	)
 	copyAndReturn.Decorations().Before = dst.EmptyLine
 
 	return astbuilder.Statements(
 		assignLocal,
 		checkAssert,
-		copyAndReturn), nil
+		copyAndReturn,
+	), nil
 }
 
 // indirectConversionFromHub generates a conversion when the type we know about isn't the hub type, but is closer to it
@@ -233,26 +238,31 @@ func (fn *ResourceConversionFunction) indirectConversionFromHub(
 	}
 
 	declareLocal := astbuilder.LocalVariableDeclaration(
-		localID, intermediateTypeExpr, "// intermediate variable for conversion")
+		localID, intermediateTypeExpr, "// intermediate variable for conversion",
+	)
 	declareLocal.Decorations().Before = dst.NewLine
 
 	populateLocalFromHub := astbuilder.ShortDeclaration(
 		"err",
-		astbuilder.CallExpr(dst.NewIdent(localID), fn.Name(), dst.NewIdent("hub")))
+		astbuilder.CallExpr(dst.NewIdent(localID), fn.Name(), dst.NewIdent("hub")),
+	)
 	populateLocalFromHub.Decs.Before = dst.EmptyLine
 
 	checkForErrorsPopulatingLocal := astbuilder.CheckErrorAndWrap(
 		errorsPackage,
-		fmt.Sprintf("converting from hub to %s", localID))
+		fmt.Sprintf("converting from hub to %s", localID),
+	)
 
 	populateReceiverFromLocal := astbuilder.SimpleAssignment(
 		errIdent,
-		astbuilder.CallExpr(dst.NewIdent(receiverName), fn.propertyFunction.Name(), astbuilder.AddrOf(dst.NewIdent(localID))))
+		astbuilder.CallExpr(dst.NewIdent(receiverName), fn.propertyFunction.Name(), astbuilder.AddrOf(dst.NewIdent(localID))),
+	)
 	populateReceiverFromLocal.Decs.Before = dst.EmptyLine
 
 	checkForErrorsPopulatingReceiver := astbuilder.CheckErrorAndWrap(
 		errorsPackage,
-		fmt.Sprintf("converting from %s to %s", localID, receiverName))
+		fmt.Sprintf("converting from %s to %s", localID, receiverName),
+	)
 
 	returnNil := astbuilder.Returns(dst.NewIdent("nil"))
 	returnNil.Decorations().Before = dst.EmptyLine
@@ -263,7 +273,8 @@ func (fn *ResourceConversionFunction) indirectConversionFromHub(
 		checkForErrorsPopulatingLocal,
 		populateReceiverFromLocal,
 		checkForErrorsPopulatingReceiver,
-		returnNil), nil
+		returnNil,
+	), nil
 }
 
 // indirectConversionToHub generates a conversion when the type we know about isn't the hub type, but is closer to it in
@@ -297,24 +308,29 @@ func (fn *ResourceConversionFunction) indirectConversionToHub(
 	}
 
 	declareLocal := astbuilder.LocalVariableDeclaration(
-		localID, intermediateTypeExpr, "// intermediate variable for conversion")
+		localID, intermediateTypeExpr, "// intermediate variable for conversion",
+	)
 	declareLocal.Decorations().Before = dst.NewLine
 
 	populateLocalFromReceiver := astbuilder.ShortDeclaration(
 		"err",
-		astbuilder.CallExpr(dst.NewIdent(receiverName), fn.propertyFunction.Name(), astbuilder.AddrOf(dst.NewIdent(localID))))
+		astbuilder.CallExpr(dst.NewIdent(receiverName), fn.propertyFunction.Name(), astbuilder.AddrOf(dst.NewIdent(localID))),
+	)
 
 	checkForErrorsPopulatingLocal := astbuilder.CheckErrorAndWrap(
 		errorsPackage,
-		fmt.Sprintf("converting to %s from %s", localID, receiverName))
+		fmt.Sprintf("converting to %s from %s", localID, receiverName),
+	)
 
 	populateHubFromLocal := astbuilder.SimpleAssignment(
 		errIdent,
-		astbuilder.CallExpr(dst.NewIdent(localID), fn.Name(), dst.NewIdent("hub")))
+		astbuilder.CallExpr(dst.NewIdent(localID), fn.Name(), dst.NewIdent("hub")),
+	)
 
 	checkForErrorsPopulatingHub := astbuilder.CheckErrorAndWrap(
 		errorsPackage,
-		fmt.Sprintf("converting from %s to hub", localID))
+		fmt.Sprintf("converting from %s to hub", localID),
+	)
 
 	returnNil := astbuilder.Returns(dst.NewIdent("nil"))
 	returnNil.Decorations().Before = dst.EmptyLine
@@ -325,7 +341,8 @@ func (fn *ResourceConversionFunction) indirectConversionToHub(
 		checkForErrorsPopulatingLocal,
 		populateHubFromLocal,
 		checkForErrorsPopulatingHub,
-		returnNil), nil
+		returnNil,
+	), nil
 }
 
 // localVariableID returns a good identifier to use for a local variable in our function,
@@ -337,7 +354,8 @@ func (fn *ResourceConversionFunction) localVariableID() string {
 func (fn *ResourceConversionFunction) declarationDocComment(receiver astmodel.TypeName) string {
 	return fn.propertyFunction.direction.SelectString(
 		fmt.Sprintf("populates our %s from the provided hub %s", receiver.Name(), fn.hub.Name()),
-		fmt.Sprintf("populates the provided hub %s from our %s", fn.hub.Name(), receiver.Name()))
+		fmt.Sprintf("populates the provided hub %s from our %s", fn.hub.Name(), receiver.Name()),
+	)
 }
 
 func (fn *ResourceConversionFunction) Equals(otherFn astmodel.Function, override astmodel.EqualityOverrides) bool {

--- a/v2/tools/generator/internal/functions/resource_status_setter_function.go
+++ b/v2/tools/generator/internal/functions/resource_status_setter_function.go
@@ -74,7 +74,8 @@ func (fn ResourceStatusSetterFunction) AsFunc(
 
 	// <receiver>.Status = st
 	assignFromStatus := astbuilder.SimpleAssignment(
-		astbuilder.Selector(dst.NewIdent(receiverIdent), "Status"), astbuilder.Dereference(dst.NewIdent(statusLocal)))
+		astbuilder.Selector(dst.NewIdent(receiverIdent), "Status"), astbuilder.Dereference(dst.NewIdent(statusLocal)),
+	)
 
 	// if st, ok := status.(<type>); ok {
 	//     <receiver>.Status = st
@@ -84,7 +85,8 @@ func (fn ResourceStatusSetterFunction) AsFunc(
 		dst.NewIdent(statusParameter),
 		astbuilder.PointerTo(dst.NewIdent(fn.nameOfStatusType)),
 		statusLocal,
-		assignFromStatus, astbuilder.Returns(astbuilder.Nil()))
+		assignFromStatus, astbuilder.Returns(astbuilder.Nil()),
+	)
 	astbuilder.AddComment(&simplePath.Decorations().Start, "// If we have exactly the right type of status, assign it")
 	simplePath.Decorations().Before = dst.NewLine
 
@@ -92,7 +94,8 @@ func (fn ResourceStatusSetterFunction) AsFunc(
 	declareLocal := astbuilder.LocalVariableDeclaration(
 		statusLocal,
 		dst.NewIdent(fn.nameOfStatusType),
-		"// Convert status to required version")
+		"// Convert status to required version",
+	)
 	declareLocal.Decorations().Before = dst.EmptyLine
 
 	// err := status.ConvertStatusTo(&st)
@@ -101,7 +104,9 @@ func (fn ResourceStatusSetterFunction) AsFunc(
 		astbuilder.CallQualifiedFunc(
 			statusParameter,
 			"ConvertStatusTo",
-			astbuilder.AddrOf(dst.NewIdent(statusLocal))))
+			astbuilder.AddrOf(dst.NewIdent(statusLocal)),
+		),
+	)
 
 	// if err != nil {
 	//     return errors.Wrap(err, "failed to convert status")
@@ -111,7 +116,8 @@ func (fn ResourceStatusSetterFunction) AsFunc(
 
 	// <receiver>.Status = st
 	assignFromLocal := astbuilder.SimpleAssignment(
-		astbuilder.Selector(dst.NewIdent(receiverIdent), "Status"), dst.NewIdent(statusLocal))
+		astbuilder.Selector(dst.NewIdent(receiverIdent), "Status"), dst.NewIdent(statusLocal),
+	)
 	assignFromLocal.Decorations().Before = dst.EmptyLine
 
 	returnNil := astbuilder.Returns(astbuilder.Nil())
@@ -126,7 +132,8 @@ func (fn ResourceStatusSetterFunction) AsFunc(
 			convert,
 			returnIfErr,
 			assignFromLocal,
-			returnNil),
+			returnNil,
+		),
 	}
 
 	convertibleStatusInterfaceTypeExpr, err := astmodel.ConvertibleStatusInterfaceType.AsTypeExpr(codeGenerationContext)

--- a/v2/tools/generator/internal/interfaces/kubernetes_resource_interface.go
+++ b/v2/tools/generator/internal/interfaces/kubernetes_resource_interface.go
@@ -72,14 +72,16 @@ func AddKubernetesResourceInterfaceImpls(
 		astmodel.AzureNameProperty,
 		idFactory,
 		nameFns.getNameFunction,
-		astmodel.GenRuntimeReference)
+		astmodel.GenRuntimeReference,
+	)
 
 	getOwnerProperty := functions.NewResourceFunction(
 		astmodel.OwnerProperty,
 		r,
 		idFactory,
 		getOwnerFunction,
-		astmodel.GenRuntimeReference)
+		astmodel.GenRuntimeReference,
+	)
 
 	getSpecFunction := functions.NewGetSpecFunction(idFactory)
 
@@ -90,14 +92,16 @@ func AddKubernetesResourceInterfaceImpls(
 		r,
 		idFactory,
 		getResourceScopeFunction,
-		astmodel.GenRuntimeReference)
+		astmodel.GenRuntimeReference,
+	)
 
 	getSupportedOperationsFunc := functions.NewResourceFunction(
 		"GetSupportedOperations",
 		r,
 		idFactory,
 		getSupportedOperationsFunction,
-		astmodel.GenRuntimeReference)
+		astmodel.GenRuntimeReference,
+	)
 
 	getAPIVersionFunc := functions.NewGetAPIVersionFunction(r.APIVersionEnumValue(), idFactory)
 
@@ -118,7 +122,8 @@ func AddKubernetesResourceInterfaceImpls(
 			msg := fmt.Sprintf(
 				"Unable to create NewEmptyStatus() for resource %s (expected Status to be a TypeName but had %T)",
 				resourceDef.Name(),
-				r.StatusType())
+				r.StatusType(),
+			)
 			return nil, eris.New(msg)
 		}
 
@@ -145,7 +150,8 @@ func AddKubernetesResourceInterfaceImpls(
 			astmodel.SetAzureNameFunc,
 			idFactory,
 			nameFns.setNameFunction,
-			astmodel.GenRuntimeReference)
+			astmodel.GenRuntimeReference,
+		)
 
 		updated, err := functionInjector.Inject(specDef, setFn)
 		if err != nil {
@@ -286,7 +292,9 @@ func getEnumAzureNameFunction(enumType astmodel.TypeName) functions.ObjectFuncti
 			ReceiverType:  astbuilder.PointerTo(receiverExpr),
 			Body: astbuilder.Statements(
 				astbuilder.Returns(
-					astbuilder.CallFunc("string", astbuilder.Selector(dst.NewIdent(receiverIdent), "Spec", astmodel.AzureNameProperty)))),
+					astbuilder.CallFunc("string", astbuilder.Selector(dst.NewIdent(receiverIdent), "Spec", astmodel.AzureNameProperty)),
+				),
+			),
 		}
 
 		fn.AddComments(fmt.Sprintf("returns the Azure name of the resource (string representation of %s)", enumType.String()))
@@ -319,7 +327,9 @@ func setEnumAzureNameFunction(enumType astmodel.TypeName) functions.ObjectFuncti
 			Body: astbuilder.Statements(
 				astbuilder.SimpleAssignment(
 					azureNameProp,
-					astbuilder.CallFunc(enumType.Name(), dst.NewIdent("azureName")))),
+					astbuilder.CallFunc(enumType.Name(), dst.NewIdent("azureName")),
+				),
+			),
 		}
 
 		fn.AddComments(fmt.Sprintf("sets the Azure name from the given %s value", enumType.String()))
@@ -358,7 +368,9 @@ func fixedValueGetAzureNameFunction(fixedValue string) functions.ObjectFunctionH
 			ReceiverType:  astbuilder.PointerTo(receiverExpr),
 			Body: astbuilder.Statements(
 				astbuilder.Returns(
-					astbuilder.TextLiteral(fixedValue))),
+					astbuilder.TextLiteral(fixedValue),
+				),
+			),
 		}
 
 		fn.AddComments(fmt.Sprintf("returns the Azure name of the resource (always %s)", fixedValue))
@@ -424,13 +436,15 @@ func getOwnerFunction(
 		fn.AddStatements(
 			nilOwnerCheck,
 			lookupGroupAndKindStmt(groupLocal, kindLocal, specSelector),
-			astbuilder.Returns(createResourceReferenceWithGroupKind(dst.NewIdent(groupLocal), dst.NewIdent(kindLocal), owner)))
+			astbuilder.Returns(createResourceReferenceWithGroupKind(dst.NewIdent(groupLocal), dst.NewIdent(kindLocal), owner)),
+		)
 
 	case astmodel.ResourceScopeExtension:
 		fn.AddComments("returns the ResourceReference of the owner")
 		fn.AddStatements(
 			nilOwnerCheck,
-			astbuilder.Returns(createResourceReference(owner)))
+			astbuilder.Returns(createResourceReference(owner)),
+		)
 
 	case astmodel.ResourceScopeTenant:
 		// Tenant resources never have an owner, just return nil
@@ -488,7 +502,9 @@ func getResourceScopeFunction(
 		Params:        nil,
 		Body: astbuilder.Statements(
 			astbuilder.Returns(
-				astbuilder.Selector(dst.NewIdent(astmodel.GenRuntimeReference.PackageName()), resourceScope))),
+				astbuilder.Selector(dst.NewIdent(astmodel.GenRuntimeReference.PackageName()), resourceScope),
+			),
+		),
 	}
 
 	fn.AddComments("returns the scope of the resource")
@@ -590,7 +606,8 @@ func lookupGroupAndKindStmt(
 			astbuilder.CallExpr(
 				dst.NewIdent(astmodel.GenRuntimeReference.PackageName()),
 				"LookupOwnerGroupKind",
-				specSelector),
+				specSelector,
+			),
 		},
 	}
 }
@@ -632,7 +649,8 @@ func setStringAzureNameFunction(
 				dst.NewIdent(receiverIdent),
 				astmodel.AzureNameProperty,
 				token.ASSIGN,
-				dst.NewIdent("azureName")),
+				dst.NewIdent("azureName"),
+			),
 		),
 	}
 
@@ -660,7 +678,9 @@ func getStringAzureNameFunction(
 		ReceiverType:  astbuilder.PointerTo(receiverTypeExpr),
 		Body: astbuilder.Statements(
 			astbuilder.Returns(
-				astbuilder.Selector(astbuilder.Selector(dst.NewIdent(receiverIdent), "Spec"), astmodel.AzureNameProperty))),
+				astbuilder.Selector(astbuilder.Selector(dst.NewIdent(receiverIdent), "Spec"), astmodel.AzureNameProperty),
+			),
+		),
 	}
 
 	fn.AddComments("returns the Azure name of the resource")

--- a/v2/tools/generator/internal/jsonast/jsonast.go
+++ b/v2/tools/generator/internal/jsonast/jsonast.go
@@ -135,7 +135,8 @@ func (scanner *SchemaScanner) RunHandlersForSchemas(ctx context.Context, schemas
 					scanner.log.V(2).Info(
 						"skipping description-only schema type",
 						"schema", unknownSchema.Schema.url(),
-						"description", *unknownSchema.Schema.description())
+						"description", *unknownSchema.Schema.description(),
+					)
 					continue
 				}
 			}
@@ -173,7 +174,8 @@ func (scanner *SchemaScanner) GenerateAllDefinitions(ctx context.Context, schema
 
 	rootPackage := scanner.configuration.MakeLocalPackageReference(
 		scanner.idFactory.CreateGroupName(rootGroup),
-		rootVersion)
+		rootVersion,
+	)
 	rootTypeName := astmodel.MakeInternalTypeName(rootPackage, rootName)
 
 	_, err = generateDefinitionsFor(ctx, scanner, rootTypeName, schema)
@@ -297,7 +299,8 @@ func formatToPattern(format string, log logr.Logger) *regexp.Regexp {
 	default:
 		log.V(0).Info(
 			"Unknown property format",
-			"format", format)
+			"format", format,
+		)
 		return nil
 	}
 }
@@ -523,7 +526,8 @@ func getProperties(
 			// TODO: https://github.com/Azure/azure-service-operator/issues/1517
 			log.V(2).Info(
 				"Property omitted due to nil propType (probably due to type filter)",
-				"property", propName)
+				"property", propName,
+			)
 			continue
 		}
 
@@ -586,7 +590,8 @@ func getProperties(
 				additionalProperties := astmodel.NewPropertyDefinition(
 					astmodel.AdditionalPropertiesPropertyName,
 					astmodel.AdditionalPropertiesJSONName,
-					astmodel.NewStringMapType(astmodel.AnyType))
+					astmodel.NewStringMapType(astmodel.AnyType),
+				)
 
 				properties = append(properties, additionalProperties)
 			}
@@ -618,7 +623,8 @@ func getProperties(
 			additionalProperties := astmodel.NewPropertyDefinition(
 				astmodel.AdditionalPropertiesPropertyName,
 				astmodel.AdditionalPropertiesJSONName,
-				astmodel.NewStringMapType(additionalPropsType))
+				astmodel.NewStringMapType(additionalPropsType),
+			)
 
 			properties = append(properties, additionalProperties)
 		}
@@ -650,7 +656,8 @@ func refHandler(ctx context.Context, scanner *SchemaScanner, schema Schema, log 
 		log.V(2).Info(
 			"Skipping type",
 			"type", typeName,
-			"because", because)
+			"because", because,
+		)
 		return nil, nil // Skip entirely
 	}
 
@@ -795,7 +802,8 @@ func oneOfHandler(ctx context.Context, scanner *SchemaScanner, schema Schema, _ 
 		obj, ok := t.(*astmodel.ObjectType)
 		if !ok {
 			return nil, eris.Errorf(
-				"expected object type for properties of %s, got %T", schema.ID(), t)
+				"expected object type for properties of %s, got %T", schema.ID(), t,
+			)
 		}
 
 		result = result.WithAdditionalPropertyObject(obj)
@@ -829,7 +837,8 @@ func anyOfHandler(ctx context.Context, scanner *SchemaScanner, schema Schema, lo
 	// See https://github.com/Azure/azure-service-operator/issues/1518 for details about why this is treated as oneOf
 	log.V(1).Info(
 		"Handling anyOf type as if it were oneOf",
-		"url", schema.url())
+		"url", schema.url(),
+	)
 	return oneOfHandler(ctx, scanner, schema, log)
 }
 
@@ -846,7 +855,8 @@ func arrayHandler(ctx context.Context, scanner *SchemaScanner, schema Schema, lo
 		// there is no type to the elements, so we must assume interface{}
 		log.V(1).Info(
 			"Interface assumption unproven",
-			"url", schema.url())
+			"url", schema.url(),
+		)
 
 		result := astmodel.NewArrayType(astmodel.AnyType)
 		return withArrayValidations(schema, result), nil

--- a/v2/tools/generator/internal/jsonast/schema_abstraction_gojson.go
+++ b/v2/tools/generator/internal/jsonast/schema_abstraction_gojson.go
@@ -272,8 +272,10 @@ func (schema GoJSONSchema) refTypeName() (astmodel.InternalTypeName, error) {
 	return astmodel.MakeInternalTypeName(
 		schema.makeLocalPackageReference(
 			schema.idFactory.CreateGroupName(group),
-			version),
-		schema.idFactory.CreateIdentifier(name, astmodel.Exported)), nil
+			version,
+		),
+		schema.idFactory.CreateIdentifier(name, astmodel.Exported),
+	), nil
 }
 
 func (schema GoJSONSchema) refObjectName() (string, error) {

--- a/v2/tools/generator/internal/jsonast/schema_abstraction_openapi.go
+++ b/v2/tools/generator/internal/jsonast/schema_abstraction_openapi.go
@@ -195,7 +195,8 @@ func (schema *OpenAPISchema) pattern() *regexp.Regexp {
 	if err != nil {
 		schema.log.V(1).Info(
 			"Ignoring regexp we can't compile",
-			"pattern", p)
+			"pattern", p,
+		)
 		return nil
 	}
 
@@ -375,7 +376,8 @@ func (schema *OpenAPISchema) refTypeName() (astmodel.InternalTypeName, error) {
 						name,
 						absRefPath,
 						pkg,
-						otherFile)
+						otherFile,
+					)
 				}
 			}
 		}
@@ -408,7 +410,8 @@ func (schema *OpenAPISchema) refSchema() Schema {
 		outputPackage,
 		schema.idFactory,
 		schema.loader,
-		schema.log)
+		schema.log,
+	)
 }
 
 // findFileForRef identifies the schema path for a ref, relative to the give schema path

--- a/v2/tools/generator/internal/jsonast/schema_abstraction_openapi_test.go
+++ b/v2/tools/generator/internal/jsonast/schema_abstraction_openapi_test.go
@@ -57,7 +57,8 @@ func Test_CanExtractTypeNameFromSameFile(t *testing.T) {
 		schemaPackage,
 		astmodel.NewIdentifierFactory(),
 		loader,
-		logr.Discard())
+		logr.Discard(),
+	)
 
 	typeName, err := wrappedSchema.refTypeName()
 	g.Expect(err).ToNot(HaveOccurred())
@@ -107,7 +108,8 @@ func Test_CanExtractTypeNameFromDifferentFile_AndInheritPackage(t *testing.T) {
 		schemaPackage,
 		astmodel.NewIdentifierFactory(),
 		loader,
-		logr.Discard())
+		logr.Discard(),
+	)
 
 	typeName, err := wrappedSchema.refTypeName()
 	g.Expect(err).ToNot(HaveOccurred())
@@ -159,7 +161,8 @@ func Test_CanExtractTypeNameFromDifferentFile_AndUsePresetPackage(t *testing.T) 
 		schemaPackage,
 		astmodel.NewIdentifierFactory(),
 		loader,
-		logr.Discard())
+		logr.Discard(),
+	)
 
 	typeName, err := wrappedSchema.refTypeName()
 	g.Expect(err).ToNot(HaveOccurred())
@@ -209,7 +212,8 @@ func Test_GeneratingCollidingTypeNamesReturnsError(t *testing.T) {
 		schemaPackage,
 		astmodel.NewIdentifierFactory(),
 		loader,
-		logr.Discard())
+		logr.Discard(),
+	)
 
 	_, err := wrappedSchema.refTypeName()
 	g.Expect(err).To(HaveOccurred())
@@ -278,7 +282,8 @@ func Test_GeneratingCollidingTypeNamesWithSiblingFilesReturnsError(t *testing.T)
 		schemaPackage,
 		astmodel.NewIdentifierFactory(),
 		loader,
-		logr.Discard())
+		logr.Discard(),
+	)
 
 	_, err := wrappedSchema.refTypeName()
 	g.Expect(err).To(HaveOccurred())

--- a/v2/tools/generator/internal/jsonast/swagger_type_extractor.go
+++ b/v2/tools/generator/internal/jsonast/swagger_type_extractor.go
@@ -165,7 +165,8 @@ func (extractor *SwaggerTypeExtractor) ExtractResourceTypes(ctx context.Context,
 				statusSchema,
 				nameParameterType,
 				operationPath,
-				getSupportedOperations(op))
+				getSupportedOperations(op),
+			)
 			if err != nil {
 				return err
 			}
@@ -199,7 +200,8 @@ func (extractor *SwaggerTypeExtractor) extractOneResourceType(
 		extractor.log.V(1).Info(
 			"Error extracting resource name",
 			"swaggerPath", dir,
-			"error", err)
+			"error", err,
+		)
 		return nil
 	}
 
@@ -208,7 +210,8 @@ func (extractor *SwaggerTypeExtractor) extractOneResourceType(
 		extractor.log.V(1).Info(
 			"Skipping resource",
 			"name", resourceName,
-			"because", because)
+			"because", because,
+		)
 		return nil
 	}
 
@@ -310,7 +313,8 @@ func (extractor *SwaggerTypeExtractor) ExtractOneOfTypes(
 			extractor.outputPackage,
 			extractor.idFactory,
 			extractor.cache,
-			extractor.log)
+			extractor.log,
+		)
 
 		// Run a handler to generate our type
 		t, err := scanner.RunHandlerForSchema(ctx, schema)
@@ -382,7 +386,8 @@ func (extractor *SwaggerTypeExtractor) findARMResourceSchema(op spec.PathItem, r
 		extractor.log.V(1).Info(
 			"overriding parameters",
 			"operation", rawOperationPath,
-			"swagger", extractor.swaggerPath)
+			"swagger", extractor.swaggerPath,
+		)
 		params = op.Parameters
 	}
 
@@ -412,12 +417,14 @@ func (extractor *SwaggerTypeExtractor) findARMResourceSchema(op spec.PathItem, r
 		if noBody {
 			extractor.log.V(1).Info(
 				"no body parameter found for PUT operation",
-				"operation", rawOperationPath)
+				"operation", rawOperationPath,
+			)
 		} else {
 			extractor.log.V(1).Info(
 				"no schema found for PUT operation",
 				"operation", rawOperationPath,
-				"swagger", extractor.swaggerPath)
+				"swagger", extractor.swaggerPath,
+			)
 			return nil, nil, false
 		}
 	}
@@ -457,7 +464,8 @@ func (extractor *SwaggerTypeExtractor) schemaFromParameter(param spec.Parameter)
 			extractor.outputPackage,
 			extractor.idFactory,
 			extractor.cache,
-			extractor.log)
+			extractor.log,
+		)
 	} else {
 		result = MakeOpenAPISchema(
 			nameFromRef(param.Schema.Ref),
@@ -466,7 +474,8 @@ func (extractor *SwaggerTypeExtractor) schemaFromParameter(param spec.Parameter)
 			extractor.outputPackage,
 			extractor.idFactory,
 			extractor.cache,
-			extractor.log)
+			extractor.log,
+		)
 	}
 
 	return &result
@@ -484,7 +493,8 @@ func (extractor *SwaggerTypeExtractor) doesResponseRepresentARMResource(response
 			extractor.outputPackage,
 			extractor.idFactory,
 			extractor.cache,
-			extractor.log)
+			extractor.log,
+		)
 
 		return &result, isMarkedAsARMResource(result)
 	}
@@ -505,7 +515,8 @@ func (extractor *SwaggerTypeExtractor) doesResponseRepresentARMResource(response
 			outputPackage,
 			extractor.idFactory,
 			extractor.cache,
-			extractor.log)
+			extractor.log,
+		)
 
 		return &schema, isMarkedAsARMResource(schema)
 	}
@@ -513,7 +524,8 @@ func (extractor *SwaggerTypeExtractor) doesResponseRepresentARMResource(response
 	extractor.log.V(1).Info(
 		"no schema found for response",
 		"operation", rawOperationPath,
-		"swagger", extractor.swaggerPath)
+		"swagger", extractor.swaggerPath,
+	)
 	return nil, false
 }
 
@@ -648,7 +660,8 @@ func (extractor *SwaggerTypeExtractor) expandAndCanonicalizePath(
 		extractor.log.V(1).Info(
 			"expanding enums in path",
 			"swaggerPath", extractor.swaggerPath,
-			"error", err.Error())
+			"error", err.Error(),
+		)
 		return results
 	}
 
@@ -775,7 +788,8 @@ func (extractor *SwaggerTypeExtractor) extractResourceSubpath(operationPath stri
 var hardCodedNames = set.Make(
 	"current",
 	"default",
-	"web")
+	"web",
+)
 
 // inferNameFromURLPath attempts to extract a name from a Swagger operation path
 // for example “…/Microsoft.GroupName/resourceType/{resourceId}” would result

--- a/v2/tools/generator/internal/jsonast/swagger_type_extractor_test.go
+++ b/v2/tools/generator/internal/jsonast/swagger_type_extractor_test.go
@@ -230,7 +230,8 @@ func Test_ExpandAndCanonicalizePath_DoesNotExpandSimplePath(t *testing.T) {
 		ctx,
 		"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Group/type/{typeName}",
 		scanner,
-		parameters)
+		parameters,
+	)
 
 	g.Expect(paths).To(HaveLen(1))
 	g.Expect(paths[0]).To(Equal("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Group/type/{typeName}"))
@@ -268,7 +269,8 @@ func Test_ExpandAndCanonicalizePath_ExpandsSingleValueEnumInNameLocationWithDefa
 		ctx,
 		"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Group/type/{typeName}",
 		scanner,
-		parameters)
+		parameters,
+	)
 
 	g.Expect(paths).To(HaveLen(1))
 	g.Expect(paths[0]).To(Equal("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Group/type/default"))
@@ -306,7 +308,8 @@ func Test_ExpandAndCanonicalizePath_DoesNotExpandSingleValueEnumWithoutDefault(t
 		ctx,
 		"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Group/type/{typeName}",
 		scanner,
-		parameters)
+		parameters,
+	)
 
 	g.Expect(paths).To(HaveLen(1))
 	g.Expect(paths[0]).To(Equal("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Group/type/{typeName}"))
@@ -346,7 +349,8 @@ func Test_ExpandAndCanonicalizePath_ExpandsEnumInResourceTypePath(t *testing.T) 
 		ctx,
 		"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Group/{type}/{typeName}",
 		scanner,
-		parameters)
+		parameters,
+	)
 
 	g.Expect(paths).To(HaveLen(3))
 	g.Expect(paths[0]).To(Equal("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Group/a/{typeName}"))

--- a/v2/tools/generator/internal/reporting/type_catalog_report.go
+++ b/v2/tools/generator/internal/reporting/type_catalog_report.go
@@ -283,7 +283,8 @@ func (tcr *TypeCatalogReport) writeProperty(
 	sub := rpt.Addf(
 		"%s: %s",
 		prop.PropertyName(),
-		tcr.asShortNameForType(prop.PropertyType(), currentPackage, parentTypes))
+		tcr.asShortNameForType(prop.PropertyType(), currentPackage, parentTypes),
+	)
 
 	if def, ok := tcr.asDefinitionToInline(prop.PropertyType(), parentTypes); ok && tcr.inlinedTypes.Contains(def.Name()) {
 		pt := parentTypes.Copy()
@@ -433,40 +434,48 @@ func (tcr *TypeCatalogReport) asShortNameForType(
 	case *astmodel.OptionalType:
 		return fmt.Sprintf(
 			"*%s",
-			tcr.asShortNameForType(t.Element(), currentPackage, parentTypes))
+			tcr.asShortNameForType(t.Element(), currentPackage, parentTypes),
+		)
 	case *astmodel.ArrayType:
 		return fmt.Sprintf(
 			"%s[]",
-			tcr.asShortNameForType(t.Element(), currentPackage, parentTypes))
+			tcr.asShortNameForType(t.Element(), currentPackage, parentTypes),
+		)
 	case *astmodel.MapType:
 		return fmt.Sprintf(
 			"map[%s]%s",
 			tcr.asShortNameForType(t.KeyType(), currentPackage, parentTypes),
-			tcr.asShortNameForType(t.ValueType(), currentPackage, parentTypes))
+			tcr.asShortNameForType(t.ValueType(), currentPackage, parentTypes),
+		)
 	case *astmodel.ResourceType:
 		return "Resource"
 	case *astmodel.EnumType:
 		return fmt.Sprintf(
 			"Enum (%s)",
-			tcr.formatCount(len(t.Options()), "value", "values"))
+			tcr.formatCount(len(t.Options()), "value", "values"),
+		)
 	case *astmodel.ObjectType:
 		return fmt.Sprintf(
 			"Object (%s)",
-			tcr.formatCount(t.Properties().Len(), "property", "properties"))
+			tcr.formatCount(t.Properties().Len(), "property", "properties"),
+		)
 	case *astmodel.OneOfType:
 		return fmt.Sprintf(
 			"OneOf (%s, %s)",
 			tcr.formatCount(len(t.PropertyObjects()), "object", "objects"),
-			tcr.formatCount(t.Types().Len(), "option", "options"))
+			tcr.formatCount(t.Types().Len(), "option", "options"),
+		)
 	case *astmodel.AllOfType:
 		return fmt.Sprintf(
 			"AllOf (%s)",
-			tcr.formatCount(t.Types().Len(), "choice", "choices"))
+			tcr.formatCount(t.Types().Len(), "choice", "choices"),
+		)
 	case *astmodel.ValidatedType:
 		return fmt.Sprintf(
 			"Validated<%s> (%s)",
 			tcr.asShortNameForType(t.Unwrap(), currentPackage, parentTypes),
-			tcr.formatCount(len(t.Validations().ToKubeBuilderValidations()), "rule", "rules"))
+			tcr.formatCount(len(t.Validations().ToKubeBuilderValidations()), "rule", "rules"),
+		)
 	case *astmodel.FlaggedType:
 		var flags strings.Builder
 		for i, f := range t.Flags() {
@@ -481,7 +490,8 @@ func (tcr *TypeCatalogReport) asShortNameForType(
 		return fmt.Sprintf(
 			"%s %s",
 			tcr.asShortNameForType(t.Element(), currentPackage, parentTypes),
-			flags.String())
+			flags.String(),
+		)
 	case astmodel.MetaType:
 		return tcr.asShortNameForType(t.Unwrap(), currentPackage, parentTypes)
 	default:
@@ -595,7 +605,8 @@ func (tcr *TypeCatalogReport) findPackages() []astmodel.InternalPackageReference
 		result,
 		func(left astmodel.InternalPackageReference, right astmodel.InternalPackageReference) int {
 			return astmodel.ComparePathAndVersion(left.ImportPath(), right.ImportPath())
-		})
+		},
+	)
 
 	return result
 }

--- a/v2/tools/generator/internal/reporting/type_catalog_report_test.go
+++ b/v2/tools/generator/internal/reporting/type_catalog_report_test.go
@@ -58,7 +58,8 @@ func Test_TypeCatalogReport_GivenDirectlyRecursiveType_WhenInlined_ShowsExpected
 	parentProperty := astmodel.NewPropertyDefinition(
 		"Parent",
 		"parentName",
-		astmodel.NewOptionalType(personName)).
+		astmodel.NewOptionalType(personName),
+	).
 		WithDescription("Optional reference to our parent")
 
 	personObj := astmodel.NewObjectType().
@@ -66,7 +67,8 @@ func Test_TypeCatalogReport_GivenDirectlyRecursiveType_WhenInlined_ShowsExpected
 			test.FullNameProperty,
 			test.FamilyNameProperty,
 			test.KnownAsProperty,
-			parentProperty)
+			parentProperty,
+		)
 
 	person := astmodel.MakeTypeDefinition(personName, personObj)
 
@@ -76,11 +78,14 @@ func Test_TypeCatalogReport_GivenDirectlyRecursiveType_WhenInlined_ShowsExpected
 		astmodel.NewPropertyDefinition(
 			"FirstParty",
 			"firstparty",
-			astmodel.NewOptionalType(personName)),
+			astmodel.NewOptionalType(personName),
+		),
 		astmodel.NewPropertyDefinition(
 			"SecondParty",
 			"secondparty",
-			astmodel.NewOptionalType(personName)))
+			astmodel.NewOptionalType(personName),
+		),
+	)
 
 	defs := make(astmodel.TypeDefinitionSet)
 	defs.Add(person)
@@ -103,24 +108,28 @@ func Test_TypeCatalogReport_GivenMapsAndArrays_ShowsExpectedDetails(t *testing.T
 
 	name := astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(test.Pkg2020, "Name"),
-		astmodel.StringType)
+		astmodel.StringType,
+	)
 
 	aliasesProperty := astmodel.NewPropertyDefinition(
 		"Aliases",
 		"aliases",
-		astmodel.NewArrayType(astmodel.StringType)).
+		astmodel.NewArrayType(astmodel.StringType),
+	).
 		WithDescription("Array of aliases")
 
 	friendsProperty := astmodel.NewPropertyDefinition(
 		"Friends",
 		"friends",
-		astmodel.NewArrayType(name.Name())).
+		astmodel.NewArrayType(name.Name()),
+	).
 		WithDescription("Array of friends")
 
 	cohortProperty := astmodel.NewPropertyDefinition(
 		"Cohort",
 		"cohort",
-		astmodel.NewMapType(astmodel.StringType, name.Name())).
+		astmodel.NewMapType(astmodel.StringType, name.Name()),
+	).
 		WithDescription("Map of nickname to actual name")
 
 	person := astmodel.MakeTypeDefinition(
@@ -129,7 +138,9 @@ func Test_TypeCatalogReport_GivenMapsAndArrays_ShowsExpectedDetails(t *testing.T
 			WithProperties(
 				aliasesProperty,
 				friendsProperty,
-				cohortProperty))
+				cohortProperty,
+			),
+	)
 
 	defs := make(astmodel.TypeDefinitionSet)
 	defs.Add(person)
@@ -159,24 +170,29 @@ func Test_TypeCatalogReport_GivenValidatedAndOptionalTypes_ShowsExpectedDetails(
 			astmodel.StringValidations{
 				MaxLength: &maxLength,
 				MinLength: &minLength,
-			}))
+			},
+		),
+	)
 
 	knownAsProperty := astmodel.NewPropertyDefinition(
 		"KnownAs",
 		"knownAs",
-		astmodel.StringType).
+		astmodel.StringType,
+	).
 		WithDescription("Required string property")
 
 	familyNameProperty := astmodel.NewPropertyDefinition(
 		"FamilyName",
 		"familyName",
-		astmodel.OptionalStringType).
+		astmodel.OptionalStringType,
+	).
 		WithDescription("Optional string property")
 
 	fullNameProperty := astmodel.NewPropertyDefinition(
 		"FullName",
 		"fullName",
-		name.Type()).
+		name.Type(),
+	).
 		WithDescription("Validated required string")
 
 	legalNameProperty := astmodel.NewPropertyDefinition(
@@ -187,7 +203,9 @@ func Test_TypeCatalogReport_GivenValidatedAndOptionalTypes_ShowsExpectedDetails(
 			astmodel.StringValidations{
 				MaxLength: &maxLength,
 				MinLength: &minLength,
-			})).
+			},
+		),
+	).
 		WithDescription("Validated optional string")
 
 	nicknameProperty := astmodel.NewPropertyDefinition(
@@ -199,19 +217,24 @@ func Test_TypeCatalogReport_GivenValidatedAndOptionalTypes_ShowsExpectedDetails(
 				astmodel.StringValidations{
 					MaxLength: &maxLength,
 					MinLength: &minLength,
-				}))).
+				},
+			),
+		),
+	).
 		WithDescription("Optional validated string")
 
 	akaProperty := astmodel.NewPropertyDefinition(
 		"AKA",
 		"aka",
-		name.Name()).
+		name.Name(),
+	).
 		WithDescription("Mandatory via type name")
 
 	neeProperty := astmodel.NewPropertyDefinition(
 		"Nee",
 		"nee",
-		astmodel.NewOptionalType(name.Name())).
+		astmodel.NewOptionalType(name.Name()),
+	).
 		WithDescription("Optional via type name")
 
 	person := astmodel.MakeTypeDefinition(
@@ -224,7 +247,9 @@ func Test_TypeCatalogReport_GivenValidatedAndOptionalTypes_ShowsExpectedDetails(
 				legalNameProperty,
 				nicknameProperty,
 				akaProperty,
-				neeProperty))
+				neeProperty,
+			),
+	)
 
 	defs := make(astmodel.TypeDefinitionSet)
 	defs.Add(person)
@@ -254,7 +279,8 @@ func Test_TypeCatalogReport_GivenInterface_ShowsExpectedDetails(t *testing.T) {
 
 	person := astmodel.MakeTypeDefinition(
 		personName,
-		astmodel.NewInterfaceType(f1, f2))
+		astmodel.NewInterfaceType(f1, f2),
+	)
 
 	defs := make(astmodel.TypeDefinitionSet)
 	defs.Add(person)
@@ -279,7 +305,8 @@ func Test_TypeCatalogReport_GivenObject_ShowsExpectedDetails(t *testing.T) {
 		WithProperties(
 			test.FullNameProperty,
 			test.FamilyNameProperty,
-			test.KnownAsProperty)
+			test.KnownAsProperty,
+		)
 
 	functionNames := []string{"Hello", "Goodbye"}
 	for _, name := range functionNames {
@@ -305,17 +332,20 @@ func createDefinitionSet() astmodel.TypeDefinitionSet {
 		"TestResource",
 		test.FullNameProperty,
 		test.FamilyNameProperty,
-		test.KnownAsProperty)
+		test.KnownAsProperty,
+	)
 
 	testStatus := test.CreateStatus(
 		test.Pkg2020,
-		"TestResource")
+		"TestResource",
+	)
 
 	testResource := test.CreateResource(
 		test.Pkg2020,
 		"TestResource",
 		testSpec,
-		testStatus)
+		testStatus,
+	)
 
 	defs := make(astmodel.TypeDefinitionSet)
 	defs.Add(testResource)

--- a/v2/tools/generator/internal/test/asserts.go
+++ b/v2/tools/generator/internal/test/asserts.go
@@ -163,7 +163,8 @@ func AssertPropertyExistsWithType(
 			"Expected property %q to have type %q, but was %q",
 			expectedName,
 			astmodel.DebugDescription(expectedType),
-			astmodel.DebugDescription(property.PropertyType()))
+			astmodel.DebugDescription(property.PropertyType()),
+		)
 	}
 
 	return property

--- a/v2/tools/generator/internal/test/resource.go
+++ b/v2/tools/generator/internal/test/resource.go
@@ -69,7 +69,8 @@ func CreateSpec(
 	specName := MakeSpecName(pkg, name)
 	return astmodel.MakeTypeDefinition(
 		specName,
-		astmodel.NewObjectType().WithProperties(properties...))
+		astmodel.NewObjectType().WithProperties(properties...),
+	)
 }
 
 func MakeStatusName(
@@ -88,7 +89,8 @@ func CreateStatus(
 	statusName := MakeStatusName(pkg, name)
 	return astmodel.MakeTypeDefinition(
 		statusName,
-		astmodel.NewObjectType().WithProperties(StatusProperty).WithProperties(properties...))
+		astmodel.NewObjectType().WithProperties(StatusProperty).WithProperties(properties...),
+	)
 }
 
 // CreateObjectDefinition makes a type definition with an object for testing
@@ -100,7 +102,8 @@ func CreateObjectDefinition(
 	typeName := astmodel.MakeInternalTypeName(pkg, name)
 	return astmodel.MakeTypeDefinition(
 		typeName,
-		CreateObjectType(properties...))
+		CreateObjectType(properties...),
+	)
 }
 
 // CreateObjectDefinitionWithFunction makes an object with function for testing
@@ -113,7 +116,8 @@ func CreateObjectDefinitionWithFunction(
 	typeName := astmodel.MakeInternalTypeName(pkg, name)
 	return astmodel.MakeTypeDefinition(
 		typeName,
-		CreateObjectType(properties...).WithFunction(function))
+		CreateObjectType(properties...).WithFunction(function),
+	)
 }
 
 func CreateObjectType(properties ...*astmodel.PropertyDefinition) *astmodel.ObjectType {

--- a/v2/tools/generator/internal/test/shared.go
+++ b/v2/tools/generator/internal/test/shared.go
@@ -83,7 +83,8 @@ var (
 	// Objects in Pkg2020
 	Pkg2020APIVersion = astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(Pkg2020, "APIVersion"),
-		astmodel.NewEnumType(astmodel.StringType, astmodel.MakeEnumValue("v2020", `"v2020"`)))
+		astmodel.NewEnumType(astmodel.StringType, astmodel.MakeEnumValue("v2020", `"v2020"`)),
+	)
 
 	// Objects in Pkg2021
 

--- a/v2/tools/generator/internal/testcases/json_serialization_test_case.go
+++ b/v2/tools/generator/internal/testcases/json_serialization_test_case.go
@@ -135,7 +135,8 @@ func (o *JSONSerializationTestCase) RequiredImports() *astmodel.PackageImportSet
 
 	// Standard Go Packages
 	result.AddImportsOfReferences(
-		astmodel.JSONReference, astmodel.OSReference, astmodel.ReflectReference, astmodel.TestingReference)
+		astmodel.JSONReference, astmodel.OSReference, astmodel.ReflectReference, astmodel.TestingReference,
+	)
 
 	// Cmp
 	result.AddImportsOfReferences(astmodel.CmpReference, astmodel.CmpOptsReference)
@@ -199,26 +200,30 @@ func (o *JSONSerializationTestCase) createTestRunner(codegenContext *astmodel.Co
 	// parameters := gopter.DefaultTestParameters()
 	defineParameters := astbuilder.ShortDeclaration(
 		parametersLocal,
-		astbuilder.CallQualifiedFunc(gopterPackage, "DefaultTestParameters"))
+		astbuilder.CallQualifiedFunc(gopterPackage, "DefaultTestParameters"),
+	)
 
 	// parameters.MaxSize = 10
 	configureMaxSize := astbuilder.QualifiedAssignment(
 		dst.NewIdent(parametersLocal),
 		"MaxSize",
 		token.ASSIGN,
-		astbuilder.IntLiteral(3))
+		astbuilder.IntLiteral(3),
+	)
 
 	// parameters.MinSuccessfulTests := n
 	configureMinSuccessfulTests := astbuilder.QualifiedAssignment(
 		dst.NewIdent(parametersLocal),
 		"MinSuccessfulTests",
 		token.ASSIGN,
-		astbuilder.IntLiteral(o.minSuccessfulTests))
+		astbuilder.IntLiteral(o.minSuccessfulTests),
+	)
 
 	// properties := gopter.NewProperties(parameters)
 	defineProperties := astbuilder.ShortDeclaration(
 		propertiesLocal,
-		astbuilder.CallQualifiedFunc(gopterPackage, "NewProperties", dst.NewIdent(parametersLocal)))
+		astbuilder.CallQualifiedFunc(gopterPackage, "NewProperties", dst.NewIdent(parametersLocal)),
+	)
 
 	// partial expression: description of the test
 	testName := astbuilder.StringLiteralf("Round trip of %s via JSON returns original", o.Subject())
@@ -229,7 +234,8 @@ func (o *JSONSerializationTestCase) createTestRunner(codegenContext *astmodel.Co
 		propPackage,
 		"ForAll",
 		dst.NewIdent(o.idOfTestMethod()),
-		astbuilder.CallFunc(idOfGeneratorMethod(o.subject, o.idFactory)))
+		astbuilder.CallFunc(idOfGeneratorMethod(o.subject, o.idFactory)),
+	)
 	propForAll.Decs.Before = dst.NewLine
 
 	// properties.Property("...", prop.ForAll(RunTestForX, XGenerator())
@@ -237,7 +243,8 @@ func (o *JSONSerializationTestCase) createTestRunner(codegenContext *astmodel.Co
 		propertiesLocal,
 		propertyMethod,
 		testName,
-		propForAll)
+		propForAll,
+	)
 
 	// properties.TestingRun(t, gopter.NewFormatedReporter(true, 160, os.Stdout))
 	createReporter := astbuilder.CallQualifiedFunc(
@@ -245,7 +252,8 @@ func (o *JSONSerializationTestCase) createTestRunner(codegenContext *astmodel.Co
 		"NewFormatedReporter",
 		dst.NewIdent("true"),
 		astbuilder.IntLiteral(240),
-		astbuilder.Selector(dst.NewIdent(osPackage), "Stdout"))
+		astbuilder.Selector(dst.NewIdent(osPackage), "Stdout"),
+	)
 	runTests := astbuilder.CallQualifiedFuncAsStmt(propertiesLocal, testingRunMethod, t, createReporter)
 
 	// Define our function
@@ -258,7 +266,8 @@ func (o *JSONSerializationTestCase) createTestRunner(codegenContext *astmodel.Co
 		configureMaxSize,
 		defineProperties,
 		defineTestCase,
-		runTests)
+		runTests,
+	)
 
 	return fn.DefineFunc()
 }
@@ -286,14 +295,16 @@ func (o *JSONSerializationTestCase) createTestMethod(codegenContext *astmodel.Co
 	serialize := astbuilder.SimpleAssignmentWithErr(
 		dst.NewIdent(binID),
 		token.DEFINE,
-		astbuilder.CallQualifiedFunc(jsonPackage, "Marshal", dst.NewIdent(subjectID)))
+		astbuilder.CallQualifiedFunc(jsonPackage, "Marshal", dst.NewIdent(subjectID)),
+	)
 	astbuilder.AddComment(&serialize.Decs.Start, "// Serialize to JSON")
 	serialize.Decorations().Before = dst.NewLine
 
 	// if err != nil { return err.Error() }
 	serializeFailed := astbuilder.ReturnIfNotNil(
 		dst.NewIdent(errID),
-		astbuilder.CallQualifiedFunc("err", "Error"))
+		astbuilder.CallQualifiedFunc("err", "Error"),
+	)
 
 	// var actual X
 	declare := astbuilder.NewVariable(actualID, o.subject.Name())
@@ -305,12 +316,14 @@ func (o *JSONSerializationTestCase) createTestMethod(codegenContext *astmodel.Co
 		dst.NewIdent("err"),
 		astbuilder.CallQualifiedFunc(jsonPackage, "Unmarshal",
 			dst.NewIdent(binID),
-			astbuilder.AddrOf(dst.NewIdent(actualID))))
+			astbuilder.AddrOf(dst.NewIdent(actualID))),
+	)
 
 	// if err != nil { return err.Error() }
 	deserializeFailed := astbuilder.ReturnIfNotNil(
 		dst.NewIdent(errID),
-		astbuilder.CallQualifiedFunc("err", "Error"))
+		astbuilder.CallQualifiedFunc("err", "Error"),
+	)
 
 	// match := cmp.Equal(subject, actual, cmpopts.EquateEmpty())
 	// We include cmpopts.EquateEmpty() to allow empty slices and maps to match nil values
@@ -320,24 +333,28 @@ func (o *JSONSerializationTestCase) createTestMethod(codegenContext *astmodel.Co
 		astbuilder.CallQualifiedFunc(cmpPackage, "Equal",
 			dst.NewIdent(subjectID),
 			dst.NewIdent(actualID),
-			equateEmpty))
+			equateEmpty),
+	)
 	compare.Decorations().Before = dst.EmptyLine
 	astbuilder.AddComment(&compare.Decorations().Start, "// Check for outcome")
 
 	// actualFmt := pretty.Sprint(actual)
 	declareActual := astbuilder.ShortDeclaration(
 		actualFmtID,
-		astbuilder.CallQualifiedFunc(prettyPackage, "Sprint", dst.NewIdent(actualID)))
+		astbuilder.CallQualifiedFunc(prettyPackage, "Sprint", dst.NewIdent(actualID)),
+	)
 
 	// subjectFmt := pretty.Sprint(subject)
 	declareSubject := astbuilder.ShortDeclaration(
 		subjectFmtID,
-		astbuilder.CallQualifiedFunc(prettyPackage, "Sprint", dst.NewIdent(subjectID)))
+		astbuilder.CallQualifiedFunc(prettyPackage, "Sprint", dst.NewIdent(subjectID)),
+	)
 
 	// diff := diff.Diff(subjectFmt, actualFmt)
 	declareDiff := astbuilder.ShortDeclaration(
 		resultID,
-		astbuilder.CallQualifiedFunc(diffPackage, "Diff", dst.NewIdent(subjectFmtID), dst.NewIdent(actualFmtID)))
+		astbuilder.CallQualifiedFunc(diffPackage, "Diff", dst.NewIdent(subjectFmtID), dst.NewIdent(actualFmtID)),
+	)
 
 	// return diff
 	returnDiff := astbuilder.Returns(dst.NewIdent(resultID))
@@ -351,7 +368,8 @@ func (o *JSONSerializationTestCase) createTestMethod(codegenContext *astmodel.Co
 		declareActual,
 		declareSubject,
 		declareDiff,
-		returnDiff)
+		returnDiff,
+	)
 
 	// return ""
 	ret := astbuilder.Returns(astbuilder.StringLiteral(""))
@@ -368,13 +386,15 @@ func (o *JSONSerializationTestCase) createTestMethod(codegenContext *astmodel.Co
 			deserializeFailed,
 			compare,
 			prettyPrint,
-			ret),
+			ret,
+		),
 	}
 
 	fn.AddParameter("subject", o.Subject())
 	fn.AddComments(fmt.Sprintf(
 		"runs a test to see if a specific instance of %s round trips to JSON and back losslessly",
-		o.Subject()))
+		o.Subject(),
+	))
 	fn.AddReturns("string")
 
 	return fn.DefineFunc()
@@ -384,14 +404,16 @@ func (o *JSONSerializationTestCase) createGeneratorDeclaration(genContext *astmo
 	comment := fmt.Sprintf(
 		"// Generator of %s instances for property testing - lazily instantiated by %s()",
 		o.Subject(),
-		idOfGeneratorMethod(o.subject, o.idFactory))
+		idOfGeneratorMethod(o.subject, o.idFactory),
+	)
 
 	gopterPackage := genContext.MustGetImportedPackageName(astmodel.GopterReference)
 
 	decl := astbuilder.VariableDeclaration(
 		o.idOfSubjectGeneratorGlobal(),
 		astbuilder.QualifiedTypeName(gopterPackage, "Gen"),
-		comment)
+		comment,
+	)
 
 	return decl
 }
@@ -454,7 +476,8 @@ func (o *JSONSerializationTestCase) createGeneratorMethodForObject(
 		genPkg,
 		"Struct",
 		astbuilder.CallQualifiedFunc(reflectPkg, "TypeOf", &dst.CompositeLit{Type: o.Subject()}),
-		dst.NewIdent(mapID))
+		dst.NewIdent(mapID),
+	)
 	finalCreateGenerator := initialCreateGenerator
 
 	// If we have already cached our builder, return it immediately
@@ -465,7 +488,8 @@ func (o *JSONSerializationTestCase) createGeneratorMethodForObject(
 	//
 	earlyReturn := astbuilder.ReturnIfNotNil(
 		dst.NewIdent(generatorGlobalID),
-		dst.NewIdent(generatorGlobalID))
+		dst.NewIdent(generatorGlobalID),
+	)
 
 	// Declare a map for the generators we need to construct our instance
 	//
@@ -494,7 +518,8 @@ func (o *JSONSerializationTestCase) createGeneratorMethodForObject(
 		fn.AddComments(
 			fmt.Sprintf("// We first initialize %s with a simplified generator based on the ", generatorGlobalID),
 			"// fields with primitive types then replacing it with a more complex one that also handles complex fields",
-			"// to ensure any cycles in the object graph properly terminate.")
+			"// to ensure any cycles in the object graph properly terminate.",
+		)
 
 		// Create a generator and assign it to our variable
 		//
@@ -600,7 +625,8 @@ func (o *JSONSerializationTestCase) createGeneratorMethodForOneOf(
 		&dst.MapType{
 			Key:   dst.NewIdent("string"),
 			Value: gopterGen(),
-		}).
+		},
+	).
 		AddField("propName", dst.NewIdent("propGen"))
 	props := astbuilder.ShortDeclaration(
 		propsID,
@@ -657,7 +683,8 @@ func (o *JSONSerializationTestCase) createGeneratorMethodForOneOf(
 
 	oneOfStmts = astbuilder.Statements(
 		possibleGenerators,
-		initGopters)
+		initGopters,
+	)
 
 	// If we have already cached our builder, return it immediately
 	//
@@ -667,7 +694,8 @@ func (o *JSONSerializationTestCase) createGeneratorMethodForOneOf(
 	//
 	earlyReturn := astbuilder.ReturnIfNotNil(
 		dst.NewIdent(generatorGlobalID),
-		dst.NewIdent(generatorGlobalID))
+		dst.NewIdent(generatorGlobalID),
+	)
 
 	// Declare a map for the generators we need to construct our instance
 	//
@@ -823,7 +851,8 @@ func (o *JSONSerializationTestCase) createIndependentGenerator(
 						Results: &dst.FieldList{List: []*dst.Field{{Type: dst.NewIdent(t.Name())}}},
 					},
 					Body: astbuilder.StatementBlock(astbuilder.Returns(astbuilder.CallFunc(t.Name(), dst.NewIdent("it")))),
-				})
+				},
+			)
 
 			return genMap
 		}
@@ -912,7 +941,8 @@ func (o *JSONSerializationTestCase) createRelatedGenerator(
 							Results: &dst.FieldList{List: []*dst.Field{{Type: astbuilder.Dereference(dst.NewIdent(typeName.Name()))}}},
 						},
 						Body: astbuilder.StatementBlock(astbuilder.Returns(astbuilder.AddrOf(dst.NewIdent("it")))),
-					})
+					},
+				)
 
 				genMap.Decs.End = []string{"// generate one case for OneOf type"}
 
@@ -975,19 +1005,22 @@ func (o *JSONSerializationTestCase) idOfSubjectGeneratorGlobal() string {
 func (o *JSONSerializationTestCase) idOfTestMethod() string {
 	return o.idFactory.CreateIdentifier(
 		fmt.Sprintf("RunJSONSerializationTestFor%s", o.Subject()),
-		astmodel.Exported)
+		astmodel.Exported,
+	)
 }
 
 func (o *JSONSerializationTestCase) idOfGeneratorGlobal(name astmodel.TypeName) string {
 	return o.idFactory.CreateIdentifier(
 		fmt.Sprintf("%sGenerator", name.Name()),
-		astmodel.NotExported)
+		astmodel.NotExported,
+	)
 }
 
 func (o *JSONSerializationTestCase) idOfIndependentGeneratorsFactoryMethod() string {
 	return o.idFactory.CreateIdentifier(
 		fmt.Sprintf("AddIndependentPropertyGeneratorsFor%s", o.Subject()),
-		astmodel.Exported)
+		astmodel.Exported,
+	)
 }
 
 // idOfRelatedTypesGeneratorsFactoryMethod creates the identifier for the method that creates generators referencing
@@ -995,7 +1028,8 @@ func (o *JSONSerializationTestCase) idOfIndependentGeneratorsFactoryMethod() str
 func (o *JSONSerializationTestCase) idOfRelatedGeneratorsFactoryMethod() string {
 	return o.idFactory.CreateIdentifier(
 		fmt.Sprintf("AddRelatedPropertyGeneratorsFor%s", o.Subject()),
-		astmodel.Exported)
+		astmodel.Exported,
+	)
 }
 
 func (o *JSONSerializationTestCase) Subject() *dst.Ident {

--- a/v2/tools/generator/internal/testcases/json_serialization_test_case_test.go
+++ b/v2/tools/generator/internal/testcases/json_serialization_test_case_test.go
@@ -27,7 +27,8 @@ func TestGolden_JSONSerializationTestCase_AsFunc(t *testing.T) {
 		"Person",
 		test.FullNameProperty,
 		test.KnownAsProperty,
-		test.FamilyNameProperty)
+		test.FamilyNameProperty,
+	)
 
 	container, ok := astmodel.AsPropertyContainer(currentSpec.Type())
 	g.Expect(ok).To(BeTrue())

--- a/v2/tools/generator/internal/testcases/property_assignment_test_case.go
+++ b/v2/tools/generator/internal/testcases/property_assignment_test_case.go
@@ -73,7 +73,8 @@ func NewPropertyAssignmentTestCase(
 
 	result.testName = fmt.Sprintf(
 		"%s_WhenPropertiesConverted_RoundTripsWithoutLoss",
-		name.Name())
+		name.Name(),
+	)
 
 	return result
 }
@@ -87,7 +88,8 @@ func (p *PropertyAssignmentTestCase) Name() string {
 func (p *PropertyAssignmentTestCase) References() astmodel.TypeNameSet {
 	return astmodel.NewTypeNameSet(
 		p.subject,
-		p.toFn.ParameterType())
+		p.toFn.ParameterType(),
+	)
 }
 
 // RequiredImports returns a set of the package imports required by this test case
@@ -168,19 +170,22 @@ func (p *PropertyAssignmentTestCase) createTestRunner(codegenContext *astmodel.C
 	// parameters := gopter.DefaultTestParameters()
 	defineParameters := astbuilder.ShortDeclaration(
 		parametersLocal,
-		astbuilder.CallQualifiedFunc(gopterPackage, "DefaultTestParameters"))
+		astbuilder.CallQualifiedFunc(gopterPackage, "DefaultTestParameters"),
+	)
 
 	// parameters.MaxSize = 10
 	configureMaxSize := astbuilder.QualifiedAssignment(
 		parametersLocalID,
 		"MaxSize",
 		token.ASSIGN,
-		astbuilder.IntLiteral(10))
+		astbuilder.IntLiteral(10),
+	)
 
 	// properties := gopter.NewProperties(parameters)
 	defineProperties := astbuilder.ShortDeclaration(
 		propertiesLocal,
-		astbuilder.CallQualifiedFunc(gopterPackage, "NewProperties", parametersLocalID))
+		astbuilder.CallQualifiedFunc(gopterPackage, "NewProperties", parametersLocalID),
+	)
 
 	// partial expression: description of the test
 	testName := astbuilder.StringLiteralf("Round trip from %s to %s via %s & %s returns original",
@@ -195,7 +200,8 @@ func (p *PropertyAssignmentTestCase) createTestRunner(codegenContext *astmodel.C
 		propPackage,
 		"ForAll",
 		dst.NewIdent(p.idOfTestMethod()),
-		astbuilder.CallFunc(idOfGeneratorMethod(p.subject, p.idFactory)))
+		astbuilder.CallFunc(idOfGeneratorMethod(p.subject, p.idFactory)),
+	)
 	propForAll.Decs.Before = dst.NewLine
 
 	// properties.Property("...", prop.ForAll(RunTestForX, XGenerator())
@@ -203,7 +209,8 @@ func (p *PropertyAssignmentTestCase) createTestRunner(codegenContext *astmodel.C
 		propertiesLocal,
 		propertyMethod,
 		testName,
-		propForAll)
+		propForAll,
+	)
 
 	// properties.TestingRun(t, gopter.NewFormatedReporter(true, 240, os.Stdout))
 	createReporter := astbuilder.CallQualifiedFunc(
@@ -211,7 +218,8 @@ func (p *PropertyAssignmentTestCase) createTestRunner(codegenContext *astmodel.C
 		"NewFormatedReporter",
 		dst.NewIdent("false"),
 		astbuilder.IntLiteral(240),
-		astbuilder.Selector(dst.NewIdent(osPackage), "Stdout"))
+		astbuilder.Selector(dst.NewIdent(osPackage), "Stdout"),
+	)
 	runTests := astbuilder.CallQualifiedFuncAsStmt(propertiesLocal, testingRunMethod, t, createReporter)
 
 	// Define our function
@@ -223,7 +231,8 @@ func (p *PropertyAssignmentTestCase) createTestRunner(codegenContext *astmodel.C
 		configureMaxSize,
 		defineProperties,
 		defineTestCase,
-		runTests)
+		runTests,
+	)
 
 	return fn.DefineFunc()
 }
@@ -253,7 +262,8 @@ func (p *PropertyAssignmentTestCase) createTestMethod(
 	// copied := subject.DeepCopy()
 	assignCopied := astbuilder.ShortDeclaration(
 		copiedID,
-		astbuilder.CallQualifiedFunc(subjectID, "DeepCopy"))
+		astbuilder.CallQualifiedFunc(subjectID, "DeepCopy"),
+	)
 	assignCopied.Decorations().Before = dst.NewLine
 	astbuilder.AddComment(&assignCopied.Decorations().Start, "// Copy subject to make sure assignment doesn't modify it")
 
@@ -266,7 +276,8 @@ func (p *PropertyAssignmentTestCase) createTestMethod(
 	declareOther := astbuilder.LocalVariableDeclaration(
 		otherID,
 		parameterTypeExpr,
-		"// Use AssignPropertiesTo() for the first stage of conversion")
+		"// Use AssignPropertiesTo() for the first stage of conversion",
+	)
 	declareOther.Decorations().Before = dst.EmptyLine
 
 	// err := subject.AssignPropertiesTo(other)
@@ -275,12 +286,15 @@ func (p *PropertyAssignmentTestCase) createTestMethod(
 		astbuilder.CallQualifiedFunc(
 			copiedID,
 			p.toFn.Name(),
-			astbuilder.AddrOf(dst.NewIdent(otherID))))
+			astbuilder.AddrOf(dst.NewIdent(otherID)),
+		),
+	)
 
 	// if err != nil { return err.Error() }
 	assignToFailed := astbuilder.ReturnIfNotNil(
 		dst.NewIdent(errID),
-		astbuilder.CallQualifiedFunc("err", "Error"))
+		astbuilder.CallQualifiedFunc("err", "Error"),
+	)
 
 	// var result OurType
 	subjectExpr, err := subject.AsTypeExpr(codegenContext)
@@ -291,7 +305,8 @@ func (p *PropertyAssignmentTestCase) createTestMethod(
 	declareResult := astbuilder.LocalVariableDeclaration(
 		actualID,
 		subjectExpr,
-		"// Use AssignPropertiesFrom() to convert back to our original type")
+		"// Use AssignPropertiesFrom() to convert back to our original type",
+	)
 	declareResult.Decorations().Before = dst.EmptyLine
 
 	// err = result.AssignPropertiesFrom(other)
@@ -300,12 +315,15 @@ func (p *PropertyAssignmentTestCase) createTestMethod(
 		astbuilder.CallQualifiedFunc(
 			actualID,
 			p.fromFn.Name(),
-			astbuilder.AddrOf(dst.NewIdent(otherID))))
+			astbuilder.AddrOf(dst.NewIdent(otherID)),
+		),
+	)
 
 	// if err != nil { return err.Error() }
 	assignFromFailed := astbuilder.ReturnIfNotNil(
 		dst.NewIdent(errID),
-		astbuilder.CallQualifiedFunc("err", "Error"))
+		astbuilder.CallQualifiedFunc("err", "Error"),
+	)
 
 	// match := cmp.Equal(subject, actual, cmpopts.EquateEmpty())
 	// We include cmpopts.EquateEmpty() to allow empty slices and maps to match nil values
@@ -315,24 +333,28 @@ func (p *PropertyAssignmentTestCase) createTestMethod(
 		astbuilder.CallQualifiedFunc(cmpPackage, "Equal",
 			dst.NewIdent(subjectID),
 			dst.NewIdent(actualID),
-			equateEmpty))
+			equateEmpty),
+	)
 	compare.Decorations().Before = dst.EmptyLine
 	astbuilder.AddComment(&compare.Decorations().Start, "Check for a match")
 
 	// actualFmt := pretty.Sprint(actual)
 	declareActual := astbuilder.ShortDeclaration(
 		actualFmtID,
-		astbuilder.CallQualifiedFunc(prettyPackage, "Sprint", dst.NewIdent(actualID)))
+		astbuilder.CallQualifiedFunc(prettyPackage, "Sprint", dst.NewIdent(actualID)),
+	)
 
 	// subjectFmt := pretty.Sprint(subject)
 	declareSubject := astbuilder.ShortDeclaration(
 		subjectFmtID,
-		astbuilder.CallQualifiedFunc(prettyPackage, "Sprint", dst.NewIdent(subjectID)))
+		astbuilder.CallQualifiedFunc(prettyPackage, "Sprint", dst.NewIdent(subjectID)),
+	)
 
 	// result := diff.Diff(subject, actual)
 	declareDiff := astbuilder.ShortDeclaration(
 		resultID,
-		astbuilder.CallQualifiedFunc(diffPackage, "Diff", dst.NewIdent(subjectFmtID), dst.NewIdent(actualFmtID)))
+		astbuilder.CallQualifiedFunc(diffPackage, "Diff", dst.NewIdent(subjectFmtID), dst.NewIdent(actualFmtID)),
+	)
 
 	// return result
 	returnDiff := astbuilder.Returns(dst.NewIdent(resultID))
@@ -346,7 +368,8 @@ func (p *PropertyAssignmentTestCase) createTestMethod(
 		declareActual,
 		declareSubject,
 		declareDiff,
-		returnDiff)
+		returnDiff,
+	)
 
 	// return ""
 	ret := astbuilder.Returns(astbuilder.StringLiteral(""))
@@ -365,7 +388,8 @@ func (p *PropertyAssignmentTestCase) createTestMethod(
 			assignFromFailed,
 			compare,
 			prettyPrint,
-			ret),
+			ret,
+		),
 	}
 
 	subjectExpr, err = p.subject.AsTypeExpr(codegenContext)
@@ -377,7 +401,8 @@ func (p *PropertyAssignmentTestCase) createTestMethod(
 	fn.AddComments(fmt.Sprintf(
 		"tests if a specific instance of %s can be assigned to %s and back losslessly",
 		p.subject.Name(),
-		p.fromFn.ParameterType().PackageReference().PackageName()))
+		p.fromFn.ParameterType().PackageReference().PackageName(),
+	))
 	fn.AddReturns("string")
 
 	return fn.DefineFunc(), nil
@@ -386,5 +411,6 @@ func (p *PropertyAssignmentTestCase) createTestMethod(
 func (p *PropertyAssignmentTestCase) idOfTestMethod() string {
 	return p.idFactory.CreateIdentifier(
 		fmt.Sprintf("RunPropertyAssignmentTestFor%s", p.subject.Name()),
-		astmodel.Exported)
+		astmodel.Exported,
+	)
 }

--- a/v2/tools/generator/internal/testcases/property_assignment_test_case_test.go
+++ b/v2/tools/generator/internal/testcases/property_assignment_test_case_test.go
@@ -31,14 +31,16 @@ func TestGolden_PropertyAssignmentTestCase_AsFunc(t *testing.T) {
 		"Person",
 		test.FullNameProperty,
 		test.KnownAsProperty,
-		test.FamilyNameProperty)
+		test.FamilyNameProperty,
+	)
 
 	otherSpec := test.CreateSpec(
 		test.Pkg2021,
 		"Person",
 		test.FullNameProperty,
 		test.KnownAsProperty,
-		test.FamilyNameProperty)
+		test.FamilyNameProperty,
+	)
 
 	defs := make(astmodel.TypeDefinitionSet)
 	cfg := config.NewObjectModelConfiguration()

--- a/v2/tools/generator/internal/testcases/resource_conversion_test_case.go
+++ b/v2/tools/generator/internal/testcases/resource_conversion_test_case.go
@@ -72,12 +72,14 @@ func NewResourceConversionTestCase(
 			"expected ConvertFrom(%s) and ConvertTo(%s) on %s to have the same parameter type",
 			result.fromFn.Hub(),
 			result.toFn.Hub(),
-			name)
+			name,
+		)
 	}
 
 	result.testName = fmt.Sprintf(
 		"%s_WhenConvertedToHub_RoundTripsWithoutLoss",
-		name.Name())
+		name.Name(),
+	)
 
 	return result, nil
 }
@@ -91,7 +93,8 @@ func (tc *ResourceConversionTestCase) Name() string {
 func (tc *ResourceConversionTestCase) References() astmodel.TypeNameSet {
 	return astmodel.NewTypeNameSet(
 		tc.subject,
-		tc.toFn.Hub())
+		tc.toFn.Hub(),
+	)
 }
 
 // RequiredImports returns a set of the package imports required by this test case
@@ -177,26 +180,30 @@ func (tc *ResourceConversionTestCase) createTestRunner(codegenContext *astmodel.
 	// parameters := gopter.DefaultTestParameters()
 	defineParameters := astbuilder.ShortDeclaration(
 		parametersLocal,
-		astbuilder.CallQualifiedFunc(gopterPackage, "DefaultTestParameters"))
+		astbuilder.CallQualifiedFunc(gopterPackage, "DefaultTestParameters"),
+	)
 
 	// parameters.MaxSize = 10
 	configureMaxSize := astbuilder.QualifiedAssignment(
 		dst.NewIdent(parametersLocal),
 		"MaxSize",
 		token.ASSIGN,
-		astbuilder.IntLiteral(10))
+		astbuilder.IntLiteral(10),
+	)
 
 	// parameters.MinSuccessfulTests = 10
 	configureMinSuccessfulTests := astbuilder.QualifiedAssignment(
 		dst.NewIdent(parametersLocal),
 		"MinSuccessfulTests",
 		token.ASSIGN,
-		astbuilder.IntLiteral(10))
+		astbuilder.IntLiteral(10),
+	)
 
 	// properties := gopter.NewProperties(parameters)
 	defineProperties := astbuilder.ShortDeclaration(
 		propertiesLocal,
-		astbuilder.CallQualifiedFunc(gopterPackage, "NewProperties", dst.NewIdent(parametersLocal)))
+		astbuilder.CallQualifiedFunc(gopterPackage, "NewProperties", dst.NewIdent(parametersLocal)),
+	)
 
 	// partial expression: description of the test
 	testName := astbuilder.StringLiteralf("Round trip from %s to hub returns original", tc.subject.Name())
@@ -207,7 +214,8 @@ func (tc *ResourceConversionTestCase) createTestRunner(codegenContext *astmodel.
 		propPackage,
 		"ForAll",
 		dst.NewIdent(tc.idOfTestMethod()),
-		astbuilder.CallFunc(idOfGeneratorMethod(tc.subject, tc.idFactory)))
+		astbuilder.CallFunc(idOfGeneratorMethod(tc.subject, tc.idFactory)),
+	)
 	propForAll.Decs.Before = dst.NewLine
 
 	// properties.Property("...", prop.ForAll(RunTestForX, XGenerator())
@@ -215,7 +223,8 @@ func (tc *ResourceConversionTestCase) createTestRunner(codegenContext *astmodel.
 		propertiesLocal,
 		propertyMethod,
 		testName,
-		propForAll)
+		propForAll,
+	)
 
 	// properties.TestingRun(t, gopter.NewFormatedReporter(true, 240, os.Stdout))
 	createReporter := astbuilder.CallQualifiedFunc(
@@ -223,7 +232,8 @@ func (tc *ResourceConversionTestCase) createTestRunner(codegenContext *astmodel.
 		"NewFormatedReporter",
 		dst.NewIdent("false"),
 		astbuilder.IntLiteral(240),
-		astbuilder.Selector(dst.NewIdent(osPackage), "Stdout"))
+		astbuilder.Selector(dst.NewIdent(osPackage), "Stdout"),
+	)
 	runTests := astbuilder.CallQualifiedFuncAsStmt(propertiesLocal, testingRunMethod, t, createReporter)
 
 	// Define our function
@@ -236,7 +246,8 @@ func (tc *ResourceConversionTestCase) createTestRunner(codegenContext *astmodel.
 		configureMinSuccessfulTests,
 		defineProperties,
 		defineTestCase,
-		runTests)
+		runTests,
+	)
 
 	return fn.DefineFunc()
 }
@@ -289,7 +300,8 @@ func (tc *ResourceConversionTestCase) createTestMethod(
 	// copied := subject.DeepCopy()
 	assignCopied := astbuilder.ShortDeclaration(
 		copiedID,
-		astbuilder.CallQualifiedFunc(subjectID, "DeepCopy"))
+		astbuilder.CallQualifiedFunc(subjectID, "DeepCopy"),
+	)
 	assignCopied.Decorations().Before = dst.NewLine
 	astbuilder.AddComment(&assignCopied.Decorations().Start, "// Copy subject to make sure conversion doesn't modify it")
 
@@ -302,7 +314,8 @@ func (tc *ResourceConversionTestCase) createTestMethod(
 	declareOther := astbuilder.LocalVariableDeclaration(
 		hubID,
 		hubExpr,
-		"// Convert to our hub version")
+		"// Convert to our hub version",
+	)
 	declareOther.Decorations().Before = dst.EmptyLine
 
 	// err := subject.ConvertTo(&hub)
@@ -311,12 +324,15 @@ func (tc *ResourceConversionTestCase) createTestMethod(
 		astbuilder.CallQualifiedFunc(
 			copiedID,
 			tc.toFn.Name(),
-			astbuilder.AddrOf(dst.NewIdent(hubID))))
+			astbuilder.AddrOf(dst.NewIdent(hubID)),
+		),
+	)
 
 	// if err != nil { return err.Error() }
 	assignToFailed := astbuilder.ReturnIfNotNil(
 		dst.NewIdent(errID),
-		astbuilder.CallQualifiedFunc("err", "Error"))
+		astbuilder.CallQualifiedFunc("err", "Error"),
+	)
 
 	// var result OurType
 	subjectExpr, err := subject.AsTypeExpr(codegenContext)
@@ -327,7 +343,8 @@ func (tc *ResourceConversionTestCase) createTestMethod(
 	declareResult := astbuilder.LocalVariableDeclaration(
 		actualID,
 		subjectExpr,
-		"// Convert from our hub version")
+		"// Convert from our hub version",
+	)
 	declareResult.Decorations().Before = dst.EmptyLine
 
 	// err = result.ConvertFrom(&hub)
@@ -336,12 +353,15 @@ func (tc *ResourceConversionTestCase) createTestMethod(
 		astbuilder.CallQualifiedFunc(
 			actualID,
 			tc.fromFn.Name(),
-			astbuilder.AddrOf(dst.NewIdent(hubID))))
+			astbuilder.AddrOf(dst.NewIdent(hubID)),
+		),
+	)
 
 	// if err != nil { return err.Error() }
 	assignFromFailed := astbuilder.ReturnIfNotNil(
 		dst.NewIdent(errID),
-		astbuilder.CallQualifiedFunc("err", "Error"))
+		astbuilder.CallQualifiedFunc("err", "Error"),
+	)
 
 	// match := cmp.Equal(subject, actual, cmpopts.EquateEmpty())
 	equateEmpty := astbuilder.CallQualifiedFunc(cmpoptsPackage, "EquateEmpty")
@@ -350,24 +370,28 @@ func (tc *ResourceConversionTestCase) createTestMethod(
 		astbuilder.CallQualifiedFunc(cmpPackage, "Equal",
 			dst.NewIdent(subjectID),
 			dst.NewIdent(actualID),
-			equateEmpty))
+			equateEmpty),
+	)
 	compare.Decorations().Before = dst.EmptyLine
 	astbuilder.AddComment(&compare.Decorations().Start, "// Compare actual with what we started with")
 
 	// actualFmt := pretty.Sprint(actual)
 	declareActual := astbuilder.ShortDeclaration(
 		actualFmtID,
-		astbuilder.CallQualifiedFunc(prettyPackage, "Sprint", dst.NewIdent(actualID)))
+		astbuilder.CallQualifiedFunc(prettyPackage, "Sprint", dst.NewIdent(actualID)),
+	)
 
 	// subjectFmt := pretty.Sprint(subject)
 	declareSubject := astbuilder.ShortDeclaration(
 		subjectFmtID,
-		astbuilder.CallQualifiedFunc(prettyPackage, "Sprint", dst.NewIdent(subjectID)))
+		astbuilder.CallQualifiedFunc(prettyPackage, "Sprint", dst.NewIdent(subjectID)),
+	)
 
 	// result := diff.Diff(subject, actual)
 	declareDiff := astbuilder.ShortDeclaration(
 		resultID,
-		astbuilder.CallQualifiedFunc(diffPackage, "Diff", dst.NewIdent(subjectFmtID), dst.NewIdent(actualFmtID)))
+		astbuilder.CallQualifiedFunc(diffPackage, "Diff", dst.NewIdent(subjectFmtID), dst.NewIdent(actualFmtID)),
+	)
 
 	// return result
 	returnDiff := astbuilder.Returns(dst.NewIdent(resultID))
@@ -381,7 +405,8 @@ func (tc *ResourceConversionTestCase) createTestMethod(
 		declareActual,
 		declareSubject,
 		declareDiff,
-		returnDiff)
+		returnDiff,
+	)
 
 	// return ""
 	ret := astbuilder.Returns(astbuilder.StringLiteral(""))
@@ -400,7 +425,8 @@ func (tc *ResourceConversionTestCase) createTestMethod(
 			assignFromFailed,
 			compare,
 			prettyPrint,
-			ret),
+			ret,
+		),
 	}
 
 	subjectExpr, err = tc.subject.AsTypeExpr(codegenContext)
@@ -411,7 +437,8 @@ func (tc *ResourceConversionTestCase) createTestMethod(
 	fn.AddParameter("subject", subjectExpr)
 	fn.AddComments(fmt.Sprintf(
 		"tests if a specific instance of %s round trips to the hub storage version and back losslessly",
-		tc.subject.Name()))
+		tc.subject.Name(),
+	))
 	fn.AddReturns("string")
 
 	return fn.DefineFunc(), nil
@@ -420,5 +447,6 @@ func (tc *ResourceConversionTestCase) createTestMethod(
 func (tc *ResourceConversionTestCase) idOfTestMethod() string {
 	return tc.idFactory.CreateIdentifier(
 		fmt.Sprintf("RunResourceConversionTestFor%s", tc.subject.Name()),
-		astmodel.Exported)
+		astmodel.Exported,
+	)
 }

--- a/v2/tools/generator/internal/testcases/resource_conversion_test_case_test.go
+++ b/v2/tools/generator/internal/testcases/resource_conversion_test_case_test.go
@@ -32,7 +32,8 @@ func TestGolden_ResourceConversionTestCase_AsFunc(t *testing.T) {
 		"Person",
 		test.FullNameProperty,
 		test.KnownAsProperty,
-		test.FamilyNameProperty)
+		test.FamilyNameProperty,
+	)
 
 	personStatus2020 := test.CreateStatus(test.Pkg2020, "Person")
 
@@ -44,7 +45,8 @@ func TestGolden_ResourceConversionTestCase_AsFunc(t *testing.T) {
 		test.FullNameProperty,
 		test.KnownAsProperty,
 		test.FamilyNameProperty,
-		test.FullAddressProperty)
+		test.FullAddressProperty,
+	)
 
 	personStatus2021 := test.CreateStatus(test.Pkg2021, "Person")
 
@@ -88,5 +90,6 @@ func TestGolden_ResourceConversionTestCase_AsFunc(t *testing.T) {
 		person2020modified,
 		test.DiffWith(person2020),
 		test.IncludeTestFiles(),
-		test.ExcludeCodeFiles())
+		test.ExcludeCodeFiles(),
+	)
 }

--- a/v2/tools/generator/internal/testcases/shared.go
+++ b/v2/tools/generator/internal/testcases/shared.go
@@ -15,6 +15,7 @@ import (
 func idOfGeneratorMethod(typeName astmodel.TypeName, idFactory astmodel.IdentifierFactory) string {
 	name := idFactory.CreateIdentifier(
 		fmt.Sprintf("%sGenerator", typeName.Name()),
-		astmodel.Exported)
+		astmodel.Exported,
+	)
 	return name
 }

--- a/v2/tools/mangle-test-json/main.go
+++ b/v2/tools/mangle-test-json/main.go
@@ -37,7 +37,8 @@ func main() {
 	for _, testOutputFile := range os.Args[1:] {
 		log.Info(
 			"Parsing",
-			"file", testOutputFile)
+			"file", testOutputFile,
+		)
 		fmt.Printf("# `%s`\n\n", testOutputFile)
 
 		byPackage := loadJSON(testOutputFile, log)
@@ -70,7 +71,8 @@ func loadJSON(
 	if err != nil {
 		log.Error(
 			err,
-			"Unable to get current working directory")
+			"Unable to get current working directory",
+		)
 		return make(map[string][]TestRun)
 	}
 
@@ -81,7 +83,8 @@ func loadJSON(
 		log.Error(
 			err,
 			"Unable to set root directory",
-			"directory", cwd)
+			"directory", cwd,
+		)
 		return make(map[string][]TestRun)
 	}
 	defer root.Close()
@@ -92,7 +95,8 @@ func loadJSON(
 		log.Error(
 			err,
 			"Unable to open file",
-			"file", testOutputFile)
+			"file", testOutputFile,
+		)
 		return make(map[string][]TestRun)
 	}
 	defer file.Close()
@@ -115,7 +119,8 @@ func loadJSON(
 			text := string(line)
 			log.Info(
 				"Unable to parse",
-				"line", text)
+				"line", text,
+			)
 
 			if text != "" && !strings.HasPrefix(text, "FAIL") {
 				// It's a parse failure we care about, write details
@@ -134,13 +139,15 @@ func loadJSON(
 		log.Error(
 			err,
 			"Error reading file",
-			"file", testOutputFile)
+			"file", testOutputFile,
+		)
 	}
 
 	if errCount > 0 {
 		log.Info(
 			"Errors parsing JSON",
-			"count", errCount)
+			"count", errCount,
+		)
 	}
 
 	// package → list of tests

--- a/v2/tools/mangle-test-json/test_run.go
+++ b/v2/tools/mangle-test-json/test_run.go
@@ -52,7 +52,8 @@ func (tr *TestRun) pause(stopped time.Time) {
 		msg := fmt.Sprintf(
 			"Test %s in package %s was paused when it was not running",
 			tr.Test.Value(),
-			tr.Package.Value())
+			tr.Package.Value(),
+		)
 		panic(msg)
 	}
 


### PR DESCRIPTION
## What this PR does

Release v0.10.0 of gofumpt adds some new rules that require some updates for our code to comply:

> A new rule is introduced to require multi-line function calls to match the opening and closing parenthesis in terms of the use of newlines. See https://github.com/mvdan/gofumpt/issues/74.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZHZqd2dtNTk4YnA2YjdlMjUzMXd5emp3ajh1cWo2M3c0aTRma3B3eSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/G4GPgzIlcNlr8glbhb/giphy.gif)

