### PR TITLE
use correct certificate for secure metrics endpoint

### DIFF
--- a/v2/charts/azure-service-operator/templates/apps_v1_deployment_azureserviceoperator-controller-manager.yaml
+++ b/v2/charts/azure-service-operator/templates/apps_v1_deployment_azureserviceoperator-controller-manager.yaml
@@ -55,6 +55,9 @@ spec:
         - --metrics-addr={{ tpl .Values.metrics.address . }}
         - --secure-metrics={{ .Values.metrics.secure }}
         - --profiling-metrics={{ .Values.metrics.profiling }}
+        {{- if .Values.metrics.secure }}
+        - --metrics-cert-dir=/tmp/k8s-metrics-server/serving-certs
+        {{- end }}
         {{- end }}
         - --health-addr=:8081
         - --enable-leader-election
@@ -256,6 +259,11 @@ spec:
           name: cert
           readOnly: true
         {{- end }}
+        {{- if and .Values.metrics.enable .Values.metrics.secure }}
+        - mountPath: /tmp/k8s-metrics-server/serving-certs
+          name: metrics-cert
+          readOnly: true
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
       {{- toYaml . | nindent 8 }}
@@ -275,6 +283,12 @@ spec:
         secret:
           defaultMode: 420
           secretName: webhook-server-cert
+      {{- end }}
+      {{- if and .Values.metrics.enable .Values.metrics.secure }}
+      - name: metrics-cert
+        secret:
+          defaultMode: 420
+          secretName: metrics-server-cert
       {{- end }}
       - name: azure-identity
         projected:

--- a/v2/charts/azure-service-operator/templates/cert-manager.io_v1_certificate_azureserviceoperator-metrics-server-cert.yaml
+++ b/v2/charts/azure-service-operator/templates/cert-manager.io_v1_certificate_azureserviceoperator-metrics-server-cert.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.metrics.enable .Values.metrics.secure }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: azureserviceoperator-metrics-server-cert
+  namespace: {{ .Release.Namespace }}
+spec:
+  dnsNames:
+  - azureserviceoperator-controller-manager-metrics-service.{{ .Release.Namespace }}.svc
+  - azureserviceoperator-controller-manager-metrics-service.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: azureserviceoperator-selfsigned-issuer
+  secretName: metrics-server-cert
+  subject:
+    organizations:
+    - azure
+{{- end }}

--- a/v2/cmd/controller/app/flags.go
+++ b/v2/cmd/controller/app/flags.go
@@ -14,6 +14,7 @@ type Flags struct {
 	MetricsAddr          string
 	ProfilingMetrics     bool
 	SecureMetrics        bool
+	MetricsCertDir       string
 	HealthAddr           string
 	WebhookPort          int
 	WebhookCertDir       string
@@ -24,10 +25,11 @@ type Flags struct {
 
 func (f Flags) String() string {
 	return fmt.Sprintf(
-		"MetricsAddr: %s, SecureMetrics: %t, ProfilingMetrics: %t, HealthAddr: %s, WebhookPort: %d, WebhookCertDir: %s, EnableLeaderElection: %t, CRDManagementMode: %s, CRDPatterns: %s",
+		"MetricsAddr: %s, SecureMetrics: %t, ProfilingMetrics: %t, MetricsCertDir: %s, HealthAddr: %s, WebhookPort: %d, WebhookCertDir: %s, EnableLeaderElection: %t, CRDManagementMode: %s, CRDPatterns: %s",
 		f.MetricsAddr,
 		f.SecureMetrics,
 		f.ProfilingMetrics,
+		f.MetricsCertDir,
 		f.HealthAddr,
 		f.WebhookPort,
 		f.WebhookCertDir,
@@ -44,6 +46,7 @@ func InitFlags(flagSet *flag.FlagSet) *Flags {
 	flagSet.StringVar(&result.MetricsAddr, "metrics-addr", "0", "The address the metric endpoint binds to.")
 	flagSet.BoolVar(&result.SecureMetrics, "secure-metrics", true, "Enable secure metrics. This secures the pprof and metrics endpoints via Kubernetes RBAC and HTTPS")
 	flagSet.BoolVar(&result.ProfilingMetrics, "profiling-metrics", false, "Enable pprof metrics, only enabled in conjunction with secure-metrics. This will enable serving pprof metrics endpoints")
+	flagSet.StringVar(&result.MetricsCertDir, "metrics-cert-dir", "", "The directory the metrics server's certs are stored.")
 	flagSet.StringVar(&result.HealthAddr, "health-addr", "", "The address the healthz endpoint binds to.")
 	flagSet.IntVar(&result.WebhookPort, "webhook-port", 9443, "The port the webhook endpoint binds to.")
 	flagSet.StringVar(&result.WebhookCertDir, "webhook-cert-dir", "", "The directory the webhook server's certs are stored.")

--- a/v2/cmd/controller/app/setup.go
+++ b/v2/cmd/controller/app/setup.go
@@ -259,6 +259,7 @@ func getMetricsOpts(flags *Flags) server.Options {
 			BindAddress:    flags.MetricsAddr,
 			SecureServing:  true,
 			FilterProvider: filters.WithAuthenticationAndAuthorization,
+			CertDir:        flags.MetricsCertDir,
 		}
 		// Note that pprof endpoints are meant to be sensitive and shouldn't be exposed publicly.
 		if flags.ProfilingMetrics {

--- a/v2/config/certmanager/certificate.yaml
+++ b/v2/config/certmanager/certificate.yaml
@@ -1,4 +1,4 @@
-# The following manifests contain a self-signed issuer CR and a certificate CR.
+# The following manifests contain a self-signed issuer CR and certificate CRs.
 # More document can be found at https://docs.cert-manager.io
 # WARNING: Targets CertManager 1.1 check https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html for
 # breaking changes
@@ -27,3 +27,21 @@ spec:
     kind: Issuer
     name: selfsigned-issuer
   secretName: webhook-server-cert # this secret will not be prefixed, since it's not managed by kustomize
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: metrics-server-cert
+  namespace: system
+spec:
+  subject:
+    organizations:
+      - azure
+  # $(METRICS_SERVICE_NAME) and $(METRICS_SERVICE_NAMESPACE) will be substituted by kustomize
+  dnsNames:
+  - $(METRICS_SERVICE_NAME).$(METRICS_SERVICE_NAMESPACE).svc
+  - $(METRICS_SERVICE_NAME).$(METRICS_SERVICE_NAMESPACE).svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: metrics-server-cert # this secret will not be prefixed, since it's not managed by kustomize

--- a/v2/config/default/kustomization.yaml
+++ b/v2/config/default/kustomization.yaml
@@ -25,17 +25,10 @@ bases:
 #- ../prometheus
 
 patchesStrategicMerge:
-  # If you want your controller-manager to expose the /metrics
-  # endpoint w/o any authn/z, uncomment the following line and
-  # comment manager_auth_proxy_patch.yaml.
-  # Only one of manager_auth_proxy_patch.yaml and
-  # manager_prometheus_metrics_patch.yaml should be enabled.
-#- manager_prometheus_metrics_patch.yaml
-
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in crd/kustomization.yaml
 - manager_webhook_patch.yaml
-
-# - manager_credentials_patch.yaml
+# [METRICS] Expose the controller manager metrics service + cert
+- manager_metrics_cert_patch.yaml
 
 patches:
 # [CERTMANAGER] Inject CA from cert-manager into all webhook configurations.
@@ -49,6 +42,7 @@ patches:
     group: admissionregistration.k8s.io
     version: v1
     kind: ValidatingWebhookConfiguration
+# [WEBHOOK] Patch in the webhook cert volume and mount to the deployment
 - patch: |-
     - op: add
       path: /spec/template/spec/containers/0/args/-
@@ -56,6 +50,13 @@ patches:
     - op: add
       path: /spec/template/spec/containers/0/args/-
       value: --webhook-cert-dir=/tmp/k8s-webhook-server/serving-certs
+  target:
+    kind: Deployment
+# [METRICS] Patch in the metrics cert volume and mount to the deployment
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --metrics-cert-dir=/tmp/k8s-metrics-server/serving-certs
   target:
     kind: Deployment
 
@@ -88,3 +89,16 @@ vars:
     kind: Service
     version: v1
     name: webhook-service
+# [METRICS] vars
+- name: METRICS_SERVICE_NAMESPACE # namespace of the metrics service
+  objref:
+    kind: Service
+    version: v1
+    name: controller-manager-metrics-service
+  fieldref:
+    fieldpath: metadata.namespace
+- name: METRICS_SERVICE_NAME
+  objref:
+    kind: Service
+    version: v1
+    name: controller-manager-metrics-service

--- a/v2/config/default/manager_metrics_cert_patch.yaml
+++ b/v2/config/default/manager_metrics_cert_patch.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        volumeMounts:
+        - mountPath: /tmp/k8s-metrics-server/serving-certs
+          name: metrics-cert
+          readOnly: true
+      volumes:
+      - name: metrics-cert
+        secret:
+          defaultMode: 420
+          secretName: metrics-server-cert


### PR DESCRIPTION
Fixes #5091

## Testing

### ✅ **Fix Confirmed Working**

We successfully verified that the cert-manager certificate fix resolves the metrics server certificate issue:

| Scenario | Certificate Subject | SANs | Result |
|----------|-------------------|------|--------|
| **WITHOUT cert-manager cert** | `CN=localhost@1778534518` | None (localhost only) | ❌ **FAILED**: `subjectAltName does not match hostname` |
| **WITH cert-manager cert** | `O=azure` | Service DNS names | ✅ **SUCCESS**: `subjectAltName matches` |

### Test Results

1. **Before Fix (auto-generated cert)**:
   - Certificate: `CN=localhost@1778534518`
   - Error: `SSL: no alternative certificate subject name matches target hostname 'azureserviceoperator-controller-manager-metrics-service.azureserviceoperator-system.svc'`
   - Prometheus cannot scrape metrics ❌

2. **After Fix (cert-manager cert)**:
   - Certificate: `O=azure`
   - SANs include: 
     - `azureserviceoperator-controller-manager-metrics-service.azureserviceoperator-system.svc`
     - `azureserviceoperator-controller-manager-metrics-service.azureserviceoperator-system.svc.cluster.local`
   - Hostname validation: `subjectAltName matches cert's DNS name` ✅
   - Prometheus can scrape metrics successfully ✅

### Changes Made

All changes are in place for both kustomize and Helm deployments:
- ✅ Added `--metrics-cert-dir` flag
- ✅ Created cert-manager Certificate resource
- ✅ Mounted certificate secret into pods
- ✅ Kustomize configuration updated
- ✅ Helm chart templates updated

## Checklist

<!--
_Delete any that don't apply. For completed items, change [ ] to [x]._
-->

- [ ] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
