### PR TITLE
Enable deletion precheck for batch 1 groups

### DIFF
--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -957,11 +957,6 @@ func ConvertToARMResourceImpl(
 // skipDeletionPrecheck is a set of resource groups for which we skip the pre-deletion existence check.
 // This is to bypass the need to re-record every test in one go - we enable the extra check group by group.
 var skipDeletionPrecheck = sets.NewString(
-	"alertsmanagement.azure.com",
-	"apimanagement.azure.com",
-	"app.azure.com",
-	"appconfiguration.azure.com",
-	"cache.azure.com",
 	"cdn.azure.com",
 	"cognitiveservices.azure.com",
 	"compute.azure.com",


### PR DESCRIPTION
## Summary

Remove the following groups from the `skipDeletionPrecheck` deny list, enabling the pre-deletion existence check for these resource groups:

- `alertsmanagement.azure.com`
- `apimanagement.azure.com`
- `app.azure.com`
- `appconfiguration.azure.com`
- `cache.azure.com`

## Testing

Each group was individually verified to pass `task controller:test-samples` with the appropriate `TEST_FILTER` before inclusion in this PR.

Progresses #5108