### PR TITLE
Enable deletion precheck for batch 8 groups

### DIFF
--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -993,11 +993,8 @@ var skipDeletionPrecheck = sets.NewString(
 	"search.azure.com",
 	"servicebus.azure.com",
 	"signalrservice.azure.com",
-	"sql.azure.com",
 	"storage.azure.com",
 	"subscription.azure.com",
-	"synapse.azure.com",
-	"web.azure.com",
 )
 
 // deleteResource deletes a resource in ARM. This function is used as the default deletion handler and can


### PR DESCRIPTION
## Summary

Remove the following groups from the `skipDeletionPrecheck` deny list, enabling the pre-deletion existence check for these resource groups:

- `sql.azure.com`
- `synapse.azure.com`
- `web.azure.com`

## Testing

Each group was individually verified to pass `task controller:test-samples` with the appropriate `TEST_FILTER` before inclusion in this PR.

Progresses #5108