### PR TITLE
Update reflect helpers to not require comparable

### DIFF
--- a/v2/internal/reflecthelpers/reflect_helpers.go
+++ b/v2/internal/reflecthelpers/reflect_helpers.go
@@ -22,7 +22,7 @@ import (
 // ValueOfPtr dereferences a pointer and returns the value the pointer points to.
 // Use this as carefully as you would the * operator
 // TODO: Can we delete this helper later when we have some better code generated functions?
-func ValueOfPtr(ptr interface{}) interface{} {
+func ValueOfPtr(ptr any) any {
 	v := reflect.ValueOf(ptr)
 	if v.Kind() != reflect.Pointer {
 		panic(fmt.Sprintf("Can't get value of pointer for non-pointer type %T", ptr))
@@ -41,14 +41,14 @@ func DeepCopyInto(in client.Object, out client.Object) {
 }
 
 // FindReferences finds references of the given type on the provided object
-func FindReferences(obj interface{}, t reflect.Type) (map[interface{}]struct{}, error) {
-	result := make(map[interface{}]struct{})
+func FindReferences(obj any, t reflect.Type) ([]any, error) {
+	var result []any
 
 	visitor := NewReflectVisitor()
-	visitor.VisitStruct = func(this *ReflectVisitor, it reflect.Value, ctx interface{}) error {
+	visitor.VisitStruct = func(this *ReflectVisitor, it reflect.Value, ctx any) error {
 		if it.Type() == t {
 			if it.CanInterface() {
-				result[it.Interface()] = struct{}{}
+				result = append(result, it.Interface())
 			}
 			return nil
 		}
@@ -66,11 +66,11 @@ func FindReferences(obj interface{}, t reflect.Type) (map[interface{}]struct{}, 
 
 // FindPropertiesWithTag finds all the properties with the given tag on the specified object and
 // returns a map of the property name to the property value
-func FindPropertiesWithTag(obj interface{}, tag string) (map[string][]interface{}, error) {
-	result := make(map[string][]interface{})
+func FindPropertiesWithTag(obj any, tag string) (map[string][]any, error) {
+	result := make(map[string][]any)
 
 	visitor := NewReflectVisitor()
-	visitor.VisitStruct = func(this *ReflectVisitor, it reflect.Value, ctx interface{}) error {
+	visitor.VisitStruct = func(this *ReflectVisitor, it reflect.Value, ctx any) error {
 		// This was adapted from IdentityVisitStruct
 		for i := 0; i < it.NumField(); i++ {
 			fieldVal := it.Field(i)
@@ -90,7 +90,7 @@ func FindPropertiesWithTag(obj interface{}, tag string) (map[string][]interface{
 			field := it.Field(i)
 			if ok && field.CanInterface() {
 				if len(result[path]) == 0 {
-					result[path] = []interface{}{}
+					result[path] = []any{}
 				}
 				result[path] = append(result[path], field.Interface())
 			}
@@ -113,43 +113,43 @@ func FindPropertiesWithTag(obj interface{}, tag string) (map[string][]interface{
 }
 
 // FindResourceReferences finds all the genruntime.ResourceReference's on the provided object
-func FindResourceReferences(obj interface{}) (set.Set[genruntime.ResourceReference], error) {
+func FindResourceReferences(obj any) ([]genruntime.ResourceReference, error) {
 	return Find[genruntime.ResourceReference](obj)
 }
 
 // FindSecretReferences finds all the genruntime.SecretReference's on the provided object
-func FindSecretReferences(obj interface{}) (set.Set[genruntime.SecretReference], error) {
+func FindSecretReferences(obj any) ([]genruntime.SecretReference, error) {
 	return Find[genruntime.SecretReference](obj)
 }
 
 // FindSecretMaps finds all the genruntime.SecretMapReference's on the provided object
-func FindSecretMaps(obj interface{}) (set.Set[genruntime.SecretMapReference], error) {
+func FindSecretMaps(obj any) ([]genruntime.SecretMapReference, error) {
 	return Find[genruntime.SecretMapReference](obj)
 }
 
 // FindConfigMapReferences finds all the genruntime.ConfigMapReference's on the provided object
-func FindConfigMapReferences(obj interface{}) (set.Set[genruntime.ConfigMapReference], error) {
+func FindConfigMapReferences(obj any) ([]genruntime.ConfigMapReference, error) {
 	return Find[genruntime.ConfigMapReference](obj)
 }
 
 // Find finds all the references of the given type on the provided object
-func Find[T comparable](obj interface{}) (set.Set[T], error) {
+func Find[T any](obj any) ([]T, error) {
 	var t T
 	untypedResult, err := FindReferences(obj, reflect.TypeOf(t))
 	if err != nil {
 		return nil, err
 	}
 
-	result := set.Make[T]()
-	for k := range untypedResult {
-		result.Add(k.(T))
+	result := make([]T, 0, len(untypedResult))
+	for _, k := range untypedResult {
+		result = append(result, k.(T))
 	}
 
 	return result, nil
 }
 
 // FindOptionalConfigMapReferences finds all the genruntime.ConfigMapReference's on the provided object
-func FindOptionalConfigMapReferences(obj interface{}) ([]*configmaps.OptionalReferencePair, error) {
+func FindOptionalConfigMapReferences(obj any) ([]*configmaps.OptionalReferencePair, error) {
 	untypedResult, err := FindPropertiesWithTag(obj, "optionalConfigMapPair") // TODO: This is astmodel.OptionalConfigMapPairTag
 	if err != nil {
 		return nil, err
@@ -208,7 +208,7 @@ func FindOptionalConfigMapReferences(obj interface{}) ([]*configmaps.OptionalRef
 
 // FindOptionalSecretReferences finds all the genruntime.SecretReference's on the provided object
 // that are part of an optional secret pair (tagged with optionalSecretPair).
-func FindOptionalSecretReferences(obj interface{}) ([]*secrets.OptionalReferencePair, error) {
+func FindOptionalSecretReferences(obj any) ([]*secrets.OptionalReferencePair, error) {
 	untypedResult, err := FindPropertiesWithTag(obj, "optionalSecretPair") // TODO: This is astmodel.OptionalSecretPairTag
 	if err != nil {
 		return nil, err

--- a/v2/internal/reflecthelpers/reflect_helpers_test.go
+++ b/v2/internal/reflecthelpers/reflect_helpers_test.go
@@ -174,11 +174,11 @@ func Test_FindReferences(t *testing.T) {
 	refs, err := reflecthelpers.FindResourceReferences(res)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(refs).To(HaveLen(5))
-	g.Expect(refs).To(HaveKey(ref1))
-	g.Expect(refs).To(HaveKey(ref2))
-	g.Expect(refs).To(HaveKey(ref3))
-	g.Expect(refs).To(HaveKey(ref4))
-	g.Expect(refs).To(HaveKey(ref5))
+	g.Expect(refs).To(ContainElement(ref1))
+	g.Expect(refs).To(ContainElement(ref2))
+	g.Expect(refs).To(ContainElement(ref3))
+	g.Expect(refs).To(ContainElement(ref4))
+	g.Expect(refs).To(ContainElement(ref5))
 }
 
 func Test_FindSecrets(t *testing.T) {
@@ -205,7 +205,7 @@ func Test_FindSecrets(t *testing.T) {
 	refs, err := reflecthelpers.FindSecretReferences(res)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(refs).To(HaveLen(1))
-	g.Expect(refs).To(HaveKey(ref))
+	g.Expect(refs).To(ContainElement(ref))
 }
 
 func Test_FindPropertiesWithTag(t *testing.T) {

--- a/v2/internal/resolver/resolver.go
+++ b/v2/internal/resolver/resolver.go
@@ -118,7 +118,7 @@ func (r *Resolver) ResolveResourceReferences(ctx context.Context, metaObject gen
 
 	// Include the namespace
 	namespacedRefs := make(map[genruntime.NamespacedResourceReference]struct{}, len(refs))
-	for ref := range refs {
+	for _, ref := range refs {
 		namespacedRefs[ref.AsNamespacedRef(metaObject.GetNamespace())] = struct{}{}
 	}
 
@@ -321,7 +321,7 @@ func (r *Resolver) ResolveResourceSecretReferences(ctx context.Context, metaObje
 
 	// Include the namespace
 	namespacedSecretRefs := set.Make[genruntime.NamespacedSecretReference]()
-	for ref := range refs {
+	for _, ref := range refs {
 		namespacedSecretRefs.Add(ref.AsNamespacedRef(metaObject.GetNamespace()))
 	}
 
@@ -354,7 +354,7 @@ func (r *Resolver) ResolveResourceSecretMapReferences(
 
 	// Include the namespace
 	namespacedSecretRefs := set.Make[genruntime.NamespacedSecretMapReference]()
-	for ref := range refs {
+	for _, ref := range refs {
 		namespacedSecretRefs.Add(ref.AsNamespacedRef(metaObject.GetNamespace()))
 	}
 
@@ -384,7 +384,7 @@ func (r *Resolver) ResolveResourceConfigMapReferences(ctx context.Context, metaO
 
 	// Include the namespace
 	namespacedConfigMapReferences := set.Make[genruntime.NamespacedConfigMapReference]()
-	for ref := range refs {
+	for _, ref := range refs {
 		namespacedConfigMapReferences.Add(ref.AsNamespacedRef(metaObject.GetNamespace()))
 	}
 

--- a/v2/internal/testsamples/samples_test.go
+++ b/v2/internal/testsamples/samples_test.go
@@ -126,8 +126,8 @@ func processSamples(samples map[string]client.Object) []client.Object {
 // findRefsAndCreateSecrets finds all references not matched by a corresponding genruntime.SecretDestination or hardcoded secret
 // and generates secrets which correspond to those references
 func findRefsAndCreateSecrets(tc *testcommon.KubePerTestContext, resources []client.Object) {
-	allDestinations := set.Make[genruntime.SecretDestination]()
-	allReferences := set.Make[genruntime.SecretReference]()
+	allDestinationKeys := set.Make[string]() // key is name + "/" + key
+	allReferences := make([]genruntime.SecretReference, 0)
 	allSecrets := set.Make[string]() // key is namespace + "/" + name
 
 	for _, obj := range resources {
@@ -142,19 +142,21 @@ func findRefsAndCreateSecrets(tc *testcommon.KubePerTestContext, resources []cli
 		references, err := reflecthelpers.FindSecretReferences(obj)
 		tc.Expect(err).To(BeNil())
 
-		allDestinations.AddAll(destinations)
-		allReferences.AddAll(references)
+		for _, dest := range destinations {
+			allDestinationKeys.Add(fmt.Sprintf("%s/%s", dest.Name, dest.Key))
+		}
+		allReferences = append(allReferences, references...)
 	}
 
 	// Find orphaned references
 	orphanRefs := set.Make[genruntime.SecretReference]()
-	for _, ref := range allReferences.Values() {
-		matchingDestination := genruntime.SecretDestination(ref)
+	for _, ref := range allReferences {
+		matchingDestinationKey := fmt.Sprintf("%s/%s", ref.Name, ref.Key)
 		matchingSecret := fmt.Sprintf("%s/%s", tc.Namespace, ref.Name)
 		if allSecrets.Contains(matchingSecret) {
 			continue
 		}
-		if allDestinations.Contains(matchingDestination) {
+		if allDestinationKeys.Contains(matchingDestinationKey) {
 			continue
 		}
 

--- a/v2/pkg/genruntime/resource_reference.go
+++ b/v2/pkg/genruntime/resource_reference.go
@@ -16,8 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-
-	"github.com/Azure/azure-service-operator/v2/internal/set"
 )
 
 // KnownResourceReference is a resource reference to a known type.
@@ -272,10 +270,10 @@ func (ref *KubernetesOwnerReference) Copy() KubernetesOwnerReference {
 }
 
 // ValidateResourceReferences calls Validate on each ResourceReference
-func ValidateResourceReferences(refs set.Set[ResourceReference]) (admission.Warnings, error) {
+func ValidateResourceReferences(refs []ResourceReference) (admission.Warnings, error) {
 	errs := make([]error, 0, len(refs))
 	var warnings admission.Warnings
-	for ref := range refs {
+	for _, ref := range refs {
 		warning, err := ref.Validate()
 		if warning != nil {
 			warnings = append(warnings, warning...)


### PR DESCRIPTION
* Strictly speaking we don't need the targets for the reflect helper methods to be comparable.

## Checklist

<!--
_Delete any that don't apply. For completed items, change [ ] to [x]._
-->

- [ ] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
