### PR TITLE
Enable smart deletion precheck for cognitiveservices

### DIFF
--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -958,7 +958,6 @@ func ConvertToARMResourceImpl(
 // This is to bypass the need to re-record every test in one go - we enable the extra check group by group.
 var skipDeletionPrecheck = sets.NewString(
 	"cache.azure.com",
-	"cognitiveservices.azure.com",
 	"compute.azure.com",
 	"containerinstance.azure.com",
 	"containerregistry.azure.com",


### PR DESCRIPTION
Removes `cognitiveservices.azure.com` from the `skipDeletionPrecheck` deny list, enabling the pre-deletion existence check for this group.

Both sample tests and controller tests pass with this change.

Part of #5108