### PR TITLE
Enable smart deletion precheck for managedidentity

### DIFF
--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -976,7 +976,6 @@ var skipDeletionPrecheck = sets.NewString(
 	"kubernetesconfiguration.azure.com",
 	"kusto.azure.com",
 	"machinelearningservices.azure.com",
-	"managedidentity.azure.com",
 	"monitor.azure.com",
 	"network.azure.com",
 	"network.frontdoor.azure.com",


### PR DESCRIPTION
Removes `managedidentity.azure.com` from the `skipDeletionPrecheck` deny list, enabling the pre-deletion existence check for this group.

Both sample tests (3 versions) and controller tests (5 tests) pass with this change.

Part of #5108