### PR TITLE
Enable smart deletion precheck for signalrservice

### DIFF
--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -987,7 +987,6 @@ var skipDeletionPrecheck = sets.NewString(
 	"resources.azure.com",
 	"search.azure.com",
 	"servicebus.azure.com",
-	"signalrservice.azure.com",
 	"sql.azure.com",
 	"storage.azure.com",
 	"subscription.azure.com",


### PR DESCRIPTION
Removes `signalrservice.azure.com` from the `skipDeletionPrecheck` deny list, enabling the pre-deletion existence check for this group.

Both sample tests (2 versions) and controller tests (2 tests) pass with this change.

Part of #5108