### PR TITLE
Enable smart deletion precheck for kusto

### DIFF
--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -974,7 +974,6 @@ var skipDeletionPrecheck = sets.NewString(
 	"insights.azure.com",
 	"keyvault.azure.com",
 	"kubernetesconfiguration.azure.com",
-	"kusto.azure.com",
 	"machinelearningservices.azure.com",
 	"managedidentity.azure.com",
 	"monitor.azure.com",


### PR DESCRIPTION
Removes `kusto.azure.com` from the `skipDeletionPrecheck` deny list, enabling the pre-deletion existence check for this group.

Both sample tests (2 versions) and controller tests (2 tests) pass with this change.

Part of #5108