### PR TITLE
Enable smart deletion precheck for notificationhubs

### DIFF
--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -980,7 +980,6 @@ var skipDeletionPrecheck = sets.NewString(
 	"monitor.azure.com",
 	"network.azure.com",
 	"network.frontdoor.azure.com",
-	"notificationhubs.azure.com",
 	"operationalinsights.azure.com",
 	"quota.azure.com",
 	"redhatopenshift.azure.com",


### PR DESCRIPTION
Removes `notificationhubs.azure.com` from the `skipDeletionPrecheck` deny list, enabling the pre-deletion existence check for this group.

Both sample tests (1 version) and controller tests (1 test with subtests) pass with this change.

Part of #5108