### PR TITLE
Enable smart deletion precheck for dataprotection

### DIFF
--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -963,7 +963,6 @@ var skipDeletionPrecheck = sets.NewString(
 	"containerregistry.azure.com",
 	"containerservice.azure.com",
 	"datafactory.azure.com",
-	"dataprotection.azure.com",
 	"dbformariadb.azure.com",
 	"dbforpostgresql.azure.com",
 	"devices.azure.com",


### PR DESCRIPTION
Removes `dataprotection.azure.com` from the `skipDeletionPrecheck` deny list, enabling the pre-deletion existence check for dataprotection resources.

Both sample tests and controller tests pass:
- `Test_Samples_CreationAndDeletion/Test_Dataprotection_v1api20230101_CreationAndDeletion` — PASS
- `Test_Samples_CreationAndDeletion/Test_Dataprotection_v1api20231101_CreationAndDeletion` — PASS
- `Test_Dataprotection_Backuppolicy_20231101_CRUD` — PASS
- `Test_Dataprotection_Backuppolicy_20230101_CRUD` — PASS
- `Test_Dataprotection_Backupvault_20230101_CRUD` — PASS
- `Test_Dataprotection_Backupvault_20231101_CRUD` — PASS
- `Test_DataProtection_BackupInstance_20231101_CRUD` — PASS

Part of #5108