### PR TITLE
Enable smart deletion precheck for monitor

### DIFF
--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -974,7 +974,6 @@ var skipDeletionPrecheck = sets.NewString(
 	"keyvault.azure.com",
 	"kubernetesconfiguration.azure.com",
 	"machinelearningservices.azure.com",
-	"monitor.azure.com",
 	"network.azure.com",
 	"network.frontdoor.azure.com",
 	"operationalinsights.azure.com",


### PR DESCRIPTION
Removes `monitor.azure.com` from the `skipDeletionPrecheck` deny list, enabling the pre-deletion existence check for monitor resources.

Both sample tests and controller tests pass:
- `Test_Samples_CreationAndDeletion/Test_Monitor_v1api20230403_CreationAndDeletion` — PASS
- `Test_Monitor_Account_CRUD` — PASS

Part of #5108