### PR TITLE
Enable smart deletion precheck for web

### DIFF
--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -987,7 +987,6 @@ var skipDeletionPrecheck = sets.NewString(
 	"storage.azure.com",
 	"subscription.azure.com",
 	"synapse.azure.com",
-	"web.azure.com",
 )
 
 // deleteResource deletes a resource in ARM. This function is used as the default deletion handler and can


### PR DESCRIPTION
Removes `web.azure.com` from the `skipDeletionPrecheck` deny list, enabling the pre-deletion existence check for web resources.

Both sample tests and controller tests pass:
- `Test_Samples_CreationAndDeletion/Test_Web_v20220301_CreationAndDeletion` — PASS
- `Test_Samples_CreationAndDeletion/Test_Web_v1api20220301_CreationAndDeletion` — PASS
- `Test_Web_ServerFarm_v20220301_CRUD` — PASS
- `Test_Web_Site_v20220301_CRUD` — PASS
- `Test_Web_SitesSourcecontrol_v20220301_CRUD` — PASS

Part of #5108