### PR TITLE
Enable smart deletion precheck for eventhub

### DIFF
--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -969,7 +969,6 @@ var skipDeletionPrecheck = sets.NewString(
 	"devices.azure.com",
 	"documentdb.azure.com",
 	"eventgrid.azure.com",
-	"eventhub.azure.com",
 	"insights.azure.com",
 	"keyvault.azure.com",
 	"kubernetesconfiguration.azure.com",


### PR DESCRIPTION
Removes `eventhub.azure.com` from the `skipDeletionPrecheck` deny list, enabling the pre-deletion existence check for eventhub resources.

Both sample tests and controller tests pass:
- `Test_Samples_CreationAndDeletion/Test_Eventhub_v1api20240101_CreationAndDeletion` — PASS
- `Test_Samples_CreationAndDeletion/Test_Eventhub_v1api20211101_CreationAndDeletion` — PASS
- `Test_EventHub_Namespace_v20211101_CRUD` — PASS
- `Test_EventHub_Namespace_v20240101_CRUD` — PASS

Part of #5108