### PR TITLE
[asoctl] Fix import failure due to problems looking for Quota resources

### DIFF
--- a/v2/cmd/asoctl/pkg/importresources/importable_arm_resource.go
+++ b/v2/cmd/asoctl/pkg/importresources/importable_arm_resource.go
@@ -379,11 +379,13 @@ func (i *importableARMResource) importChildResources(
 // These error codes represent cases where the request we've made doesn't make sense,
 // so there's no point in alerting the user to the details.
 var skipCodes = set.Make(
-	"RequestUrlInvalid",
-	"ValidationFailed",
+	"BadRequest",
 	"NoRegisteredProviderFound",
+	"RequestUrlInvalid",
 	"ResourceTypeNotSupported",
 	"UnsupportedResourceType",
+	"UnsupportedFeature",
+	"ValidationFailed",
 )
 
 func (*importableARMResource) classifyError(err error) (string, bool) {

--- a/v2/cmd/asoctl/pkg/importresources/importable_arm_resource.go
+++ b/v2/cmd/asoctl/pkg/importresources/importable_arm_resource.go
@@ -346,6 +346,14 @@ func (i *importableARMResource) importChildResources(
 		imp.GetAPIVersion(),
 	)
 	if err != nil {
+		// If this is an extension resource, errors will mean it's not supported in this location,
+		// we can safely skip it without alarming the user
+		if kr, ok := obj.(genruntime.KubernetesResource); ok {
+			if kr.GetResourceScope() == genruntime.ResourceScopeExtension {
+				return nil, nil
+			}
+		}
+
 		if _, nonfatal := i.classifyError(err); nonfatal {
 			// Non-fatal error, we'll just skip this child resource type
 			return nil, nil


### PR DESCRIPTION
## What this PR does

Fix for failure of `ascoctl` to handle errors returned when attempting to GET Quota resources.

### Special notes

Instead of just adding the new error codes to the silence list, I've also added a specific check to silence all errors encountered when trying to load extension resources, which should preclude this bug from happening again.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPWVjZjA1ZTQ3dXc4MzM3aG1tNmhmZTNrOXFnY3prOXR5Yjc0aHo5dmMwbDVhdmk5YyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/A04BWC6cktqlG/giphy.gif)
