### PR TITLE
[asoctl] Only include ManagedIdentityCredential if IMDS is available

### DIFF
--- a/v2/cmd/asoctl/cmd/import_azure_resource.go
+++ b/v2/cmd/asoctl/cmd/import_azure_resource.go
@@ -328,7 +328,8 @@ func isIMDSAvailable(ctx context.Context) bool {
 		probeCtx,
 		http.MethodGet,
 		"http://169.254.169.254/metadata/identity/oauth2/token",
-		nil)
+		nil,
+	)
 	if err != nil {
 		return false
 	}

--- a/v2/cmd/asoctl/cmd/import_azure_resource.go
+++ b/v2/cmd/asoctl/cmd/import_azure_resource.go
@@ -335,10 +335,12 @@ func isIMDSAvailable(ctx context.Context) bool {
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
 		return false
 	}
-
-	resp.Body.Close()
+	defer resp.Body.Close()
 	return true
 }
 

--- a/v2/cmd/asoctl/cmd/import_azure_resource.go
+++ b/v2/cmd/asoctl/cmd/import_azure_resource.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"sync"
 	"time"
@@ -144,7 +145,7 @@ func importAzureResource(
 	}
 
 	// Create an ARM client for requesting resources
-	client, err := createARMClient(options)
+	client, err := createARMClient(ctx, options)
 	if err != nil {
 		return eris.Wrapf(err, "failed to create ARM client")
 	}
@@ -235,10 +236,13 @@ func importAzureResource(
 }
 
 // createARMClient creates our client for talking to ARM
-func createARMClient(options *importAzureResourceOptions) (*genericarmclient.GenericClient, error) {
+func createARMClient(
+	ctx context.Context,
+	options *importAzureResourceOptions,
+) (*genericarmclient.GenericClient, error) {
 	activeCloud := options.cloud()
 
-	creds, err := newChainedCredential(activeCloud)
+	creds, err := newChainedCredential(ctx, activeCloud)
 	if err != nil {
 		return nil, eris.Wrap(err, "unable to create Azure credential")
 	}
@@ -251,7 +255,10 @@ func createARMClient(options *importAzureResourceOptions) (*genericarmclient.Gen
 }
 
 // newChainedCredential creates a ChainedTokenCredential with multiple credential types for asoctl.
-func newChainedCredential(cloud cloud.Configuration) (azcore.TokenCredential, error) {
+func newChainedCredential(
+	ctx context.Context,
+	cloud cloud.Configuration,
+) (azcore.TokenCredential, error) {
 	var creds []azcore.TokenCredential
 	var credErrors []string
 
@@ -281,17 +288,19 @@ func newChainedCredential(cloud cloud.Configuration) (azcore.TokenCredential, er
 		creds = append(creds, wiCred)
 	}
 
-	miCred, err := azidentity.NewManagedIdentityCredential(
-		&azidentity.ManagedIdentityCredentialOptions{
-			ClientOptions: azcore.ClientOptions{
-				Cloud: cloud,
+	if isIMDSAvailable(ctx) {
+		miCred, err := azidentity.NewManagedIdentityCredential(
+			&azidentity.ManagedIdentityCredentialOptions{
+				ClientOptions: azcore.ClientOptions{
+					Cloud: cloud,
+				},
 			},
-		},
-	)
-	if err != nil {
-		credErrors = append(credErrors, fmt.Sprintf("ManagedIdentityCredential: %s", err.Error()))
-	} else {
-		creds = append(creds, miCred)
+		)
+		if err != nil {
+			credErrors = append(credErrors, fmt.Sprintf("ManagedIdentityCredential: %s", err.Error()))
+		} else {
+			creds = append(creds, miCred)
+		}
 	}
 
 	cliCred, err := azidentity.NewAzureCLICredential(nil)
@@ -309,6 +318,28 @@ func newChainedCredential(cloud cloud.Configuration) (azcore.TokenCredential, er
 	}
 
 	return azidentity.NewChainedTokenCredential(creds, nil)
+}
+
+func isIMDSAvailable(ctx context.Context) bool {
+	probeCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(
+		probeCtx,
+		http.MethodGet,
+		"http://169.254.169.254/metadata/identity/oauth2/token",
+		nil)
+	if err != nil {
+		return false
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false
+	}
+
+	resp.Body.Close()
+	return true
 }
 
 // configureImportedResources applies additional configuration to imported resources


### PR DESCRIPTION
## What this PR does

Opts out of including `ManagedIdentityCredential` in the credential chain for `asoctl` if IMDS is unavailable.

### Special notes

When calling `azidentity.NewDefaultAzureCredential()`, any instance of `ManagedIdentityCredential` that's created gets an internal flag set if there are other credential types in the chain:

``` go
		o := &ManagedIdentityCredentialOptions{
			ClientOptions: options.ClientOptions,
			// enable special DefaultAzureCredential behavior (IMDS probing) only when the chain contains another credential
			dac: selected^managedIdentity != 0,
		}
```
(See [`default_azure_credential.go#171`](https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/azidentity/default_azure_credential.go#L171))

With this flag true, the `ManagedIdentityCredential` probes IMDS for availability before requesting a token, ensuring it doesn't block the chain if another credential should be used.

Unfortunately, the flag is internal, there's no API to set it - and we need to avoid calling `NewDefaultAzureCredential()`.

So, we do the probe ourselves, and only include the MI Cred in the chain if IMDS is available.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExc244M29rNndvaWs5czJ6ZDdjeWJhbTByMjhybGViczV3a24zYWV3bCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/MtIPR6C5okdt6/giphy.gif)
