### PR TITLE
Restrict default GITHUB_TOKEN permissions in workflows

### DIFF
--- a/.github/workflows/create-release-experimental.yml
+++ b/.github/workflows/create-release-experimental.yml
@@ -11,6 +11,8 @@ on:
   # no content, allows manual triggering
   workflow_dispatch:
 
+permissions: {}
+
 env:
   ARTIFACT_VERSION: experimental
 

--- a/.github/workflows/create-release-official.yml
+++ b/.github/workflows/create-release-official.yml
@@ -7,6 +7,8 @@ on:
     tags:
       - v2*
 
+permissions: {}
+
 jobs:
   build-and-push:
     runs-on: [self-hosted, 1ES.Pool=aso-1es-pool, "JobId=officialrelease-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"]

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -18,6 +18,8 @@ on:
   workflow_dispatch:
   # no content, allows manual triggering
 
+permissions: {}
+
 jobs:
   test-go-get:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add top-level `permissions: {}` to `create-release-experimental.yml`, `create-release-official.yml`, and `pr-validation.yml` workflows
- Follows the [principle of least privilege](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) by defaulting the GITHUB_TOKEN to no permissions at the workflow level
- Each job already declares the specific permissions it needs (e.g., `contents: write`, `packages: read`), so this change has no functional impact — it only ensures that any newly added jobs without explicit permissions will default to none rather than inheriting the broad default scope

## Test plan
- [ ] Verify `create-release-experimental` workflow still succeeds (job-level `contents: write` is preserved)
- [ ] Verify `create-release-official` workflow still succeeds (job-level `contents: write` is preserved)
- [ ] Verify `pr-validation` workflow still succeeds (job-level `packages: read` and `checks: write` are preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)