### PR TITLE
fix: restrict GITHUB_TOKEN permissions in workflows

### DIFF
--- a/.github/workflows/add-needs-triage-label.yml
+++ b/.github/workflows/add-needs-triage-label.yml
@@ -6,6 +6,8 @@ on:
       - reopened
       - opened
 
+permissions: {}
+
 jobs:
   label_issues:
     runs-on: ubuntu-latest

--- a/.github/workflows/api-docs-repo.yaml
+++ b/.github/workflows/api-docs-repo.yaml
@@ -8,6 +8,8 @@ on:
     # to ensure the docs are never too stale
     - cron: "35 17 * * 0"
 
+permissions: {}
+
 jobs:
   gen-crd-docs:
 

--- a/.github/workflows/build-devcontainer-image.yml
+++ b/.github/workflows/build-devcontainer-image.yml
@@ -15,6 +15,8 @@ on:
     paths:
     - .devcontainer/**
 
+permissions: {}
+
 jobs:
   # Based on: https://docs.github.com/en/actions/guides/publishing-docker-images#publishing-images-to-github-packages
   build-devcontainer-image:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,8 @@ on:
   schedule:
     - cron: '31 1 * * 3'
 
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -13,7 +13,9 @@ on:
     # 5:35 pm every Sunday (UTC)
     # to ensure the site is rebuilt weekly to publish scheduled blog posts
     - cron: "35 17 * * 0"
-  
+
+permissions: {}
+
 jobs:
   deploy-site:
 

--- a/.github/workflows/helm-chart-repo.yaml
+++ b/.github/workflows/helm-chart-repo.yaml
@@ -12,6 +12,8 @@ on:
     tags:
       - v2*
 
+permissions: {}
+
 env:
   ref: "${{ github.event.inputs.ref || github.ref_name }}"
 

--- a/.github/workflows/live-validation.yml
+++ b/.github/workflows/live-validation.yml
@@ -6,6 +6,8 @@ on:
     - cron: "35 17 * * 0"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   test-generator:
     concurrency: live-resources # only permit one run at a time

--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -6,6 +6,8 @@ on:
   issue_comment:
     types: [created]
 
+permissions: {}
+
 jobs:
   ok-to-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-validation-docs.yml
+++ b/.github/workflows/pr-validation-docs.yml
@@ -13,6 +13,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   validate-site-links:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-validation-fork.yml
+++ b/.github/workflows/pr-validation-fork.yml
@@ -4,6 +4,8 @@ on:
   repository_dispatch:
     types: [ok-to-test-command]
 
+permissions: {}
+
 jobs:
   integration-tests-fork:
     runs-on: [self-hosted, 1ES.Pool=aso-1es-pool, "JobId=integrationfork-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"]

--- a/.github/workflows/pre-release-tests.yaml
+++ b/.github/workflows/pre-release-tests.yaml
@@ -7,6 +7,8 @@ on:
     # 5:30 pm every Sunday (UTC)
     - cron: '30 17 * * 0'
 
+permissions: {}
+
 jobs:
   generate:
     runs-on: [self-hosted, 1ES.Pool=aso-1es-pool, "JobId=testprerelease-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"]

--- a/.github/workflows/scan-controller-image.yaml
+++ b/.github/workflows/scan-controller-image.yaml
@@ -15,6 +15,8 @@ on:
     paths:
       - ./v2/go.mod
 
+permissions: {}
+
 jobs:
   scan-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/visualize-repo.yml
+++ b/.github/workflows/visualize-repo.yml
@@ -7,6 +7,9 @@ on:
     # 5:35 pm every Sunday (UTC)
     # to ensure the images are never too stale
     - cron: "35 17 * * 0"
+
+permissions: {}
+
 jobs:
   render:
     


### PR DESCRIPTION
## Summary

- Add top-level `permissions: {}` to 13 workflow files that were missing it
- This ensures `GITHUB_TOKEN` defaults to no permissions at the workflow level
- Individual jobs already declare their required permissions at the job level — no behavior change
- Resolves OSSF Scorecard `Token-Permissions` findings

### Affected workflows

| Workflow | Job-level permissions already set |
|----------|----------------------------------|
| `add-needs-triage-label.yml` | `issues: write` |
| `api-docs-repo.yaml` | `contents: read`, `packages: read` |
| `build-devcontainer-image.yml` | `packages: write`, `contents: read` |
| `codeql.yml` | `security-events: write`, `packages: read` |
| `deploy-site.yml` | `packages: read`, `contents: write` |
| `helm-chart-repo.yaml` | `contents: read`, `packages: read` |
| `live-validation.yml` | `contents: read` |
| `ok-to-test.yml` | `pull-requests: write` |
| `pr-validation-docs.yml` | `packages: read` |
| `pr-validation-fork.yml` | `checks: write`, `packages: read` |
| `pre-release-tests.yaml` | `contents: read` |
| `scan-controller-image.yaml` | `packages: read` |
| `visualize-repo.yml` | `contents: read` |

## Test plan

- [ ] Verify YAML is valid (validated locally with Ruby YAML parser)
- [ ] Confirm workflows still trigger and run correctly (job-level permissions unchanged)
- [ ] Verify OSSF Scorecard Token-Permissions findings are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)