### PR TITLE
Enable smart deletion precheck for containerregistry

### DIFF
--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -959,7 +959,6 @@ func ConvertToARMResourceImpl(
 var skipDeletionPrecheck = sets.NewString(
 	"compute.azure.com",
 	"containerinstance.azure.com",
-	"containerregistry.azure.com",
 	"containerservice.azure.com",
 	"datafactory.azure.com",
 	"dbformariadb.azure.com",


### PR DESCRIPTION
Removes `containerregistry.azure.com` from the `skipDeletionPrecheck` deny list, enabling the GET-before-DELETE existence check for container registry resources.

Both sample tests and controller tests pass with this change:
- `Test_Containerregistry_v1api20210901_CreationAndDeletion` — PASS
- `Test_Containerregistry_v1api20230701_CreationAndDeletion` — PASS
- `Test_ContainerRegistry_Registry_20210901_CRUD` — PASS
- `Test_ContainerRegistry_Registry_20230701_CRUD` — PASS

Part of #5108