### PR TITLE
Enable smart deletion precheck for search

### DIFF
--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -976,7 +976,6 @@ var skipDeletionPrecheck = sets.NewString(
 	"operationalinsights.azure.com",
 	"redhatopenshift.azure.com",
 	"resources.azure.com",
-	"search.azure.com",
 	"servicebus.azure.com",
 	"sql.azure.com",
 	"storage.azure.com",


### PR DESCRIPTION
Removes `search.azure.com` from the `skipDeletionPrecheck` deny list, enabling the GET-before-DELETE existence check for search resources.

**Sample tests** pass with this change:
- `Test_Search_v1api20220901_CreationAndDeletion` — PASS
- `Test_Search_v1api20231101_CreationAndDeletion` — PASS

**Controller tests** (`Test_Search_SearchService_CRUD`) failed 3 times with envtest infrastructure timeout (`unable to install CRDs onto control plane: context deadline exceeded`) — the test never reached the VCR replay stage. The sample tests prove the recordings include the precheck GET (visible in the logs as `"Replaying request" method="GET"` during deletion).

Part of #5108