### PR TITLE
Enable smart deletion precheck for dbformariadb

### DIFF
--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -962,7 +962,6 @@ var skipDeletionPrecheck = sets.NewString(
 	"containerregistry.azure.com",
 	"containerservice.azure.com",
 	"datafactory.azure.com",
-	"dbformariadb.azure.com",
 	"dbforpostgresql.azure.com",
 	"devices.azure.com",
 	"documentdb.azure.com",


### PR DESCRIPTION
Removes `dbformariadb.azure.com` from the `skipDeletionPrecheck` deny list, enabling the pre-deletion existence check for MariaDB resources.

Both sample tests and controller tests pass with the change.

Part of #5108