### PR TITLE
Enable smart deletion precheck for operationalinsights

### DIFF
--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -973,7 +973,6 @@ var skipDeletionPrecheck = sets.NewString(
 	"machinelearningservices.azure.com",
 	"network.azure.com",
 	"network.frontdoor.azure.com",
-	"operationalinsights.azure.com",
 	"redhatopenshift.azure.com",
 	"resources.azure.com",
 	"search.azure.com",


### PR DESCRIPTION
Removes `operationalinsights.azure.com` from the `skipDeletionPrecheck` deny list, enabling the pre-deletion existence check for Operational Insights resources.

Both sample tests and controller tests pass with the change.

Part of #5108