### PR TITLE
Enable smart deletion precheck for synapse

### DIFF
--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -981,7 +981,6 @@ var skipDeletionPrecheck = sets.NewString(
 	"sql.azure.com",
 	"storage.azure.com",
 	"subscription.azure.com",
-	"synapse.azure.com",
 )
 
 // deleteResource deletes a resource in ARM. This function is used as the default deletion handler and can


### PR DESCRIPTION
Removes `synapse.azure.com` from the `skipDeletionPrecheck` deny list, enabling the pre-deletion existence check for Synapse resources.

Both sample tests and controller tests pass with the change.

Part of #5108