### PR TITLE
Enable smart deletion precheck for sql

### DIFF
--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -978,7 +978,6 @@ var skipDeletionPrecheck = sets.NewString(
 	"resources.azure.com",
 	"search.azure.com",
 	"servicebus.azure.com",
-	"sql.azure.com",
 	"storage.azure.com",
 	"subscription.azure.com",
 	"synapse.azure.com",


### PR DESCRIPTION
Removes `sql.azure.com` from the `skipDeletionPrecheck` deny list, enabling the pre-deletion existence check for Azure SQL resources.

Both sample tests and controller tests pass with the change.

Part of #5108