### PR TITLE
fix(generator): Avoid allocating diff sets just to log added/removed counts per stage

### DIFF
--- a/v2/tools/generator/internal/codegen/code_generator.go
+++ b/v2/tools/generator/internal/codegen/code_generator.go
@@ -8,6 +8,7 @@ package codegen
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"runtime/debug"
 	"time"
 
@@ -327,16 +328,39 @@ func (generator *CodeGenerator) logStateChanges(
 ) {
 	duration := time.Since(start).Round(time.Millisecond)
 
-	defsAdded := newState.Definitions().Except(state.Definitions())
-	defsRemoved := state.Definitions().Except(newState.Definitions())
+	// Count added/removed definitions without allocating intermediate sets. Map identity
+	// short-circuit handles the very common case where the stage did not touch the
+	// definitions map at all.
+	added, removed := countDefinitionChanges(newState.Definitions(), state.Definitions())
 
 	log.Info(
 		stageDescription,
 		"elapsed", duration,
-		"added", len(defsAdded),
-		"removed", len(defsRemoved),
+		"added", added,
+		"removed", removed,
 		"totalDefs", len(newState.Definitions()),
 	)
+}
+
+// countDefinitionChanges returns the number of definitions added and removed when going
+// from the "before" set to the "after" set, without allocating any intermediate sets.
+// If both sets share the same underlying map (the common no-change case), the work is O(1).
+func countDefinitionChanges(after, before astmodel.TypeDefinitionSet) (added, removed int) {
+	if reflect.ValueOf(after).Pointer() == reflect.ValueOf(before).Pointer() {
+		return 0, 0
+	}
+
+	for name := range after {
+		if _, ok := before[name]; !ok {
+			added++
+		}
+	}
+	for name := range before {
+		if _, ok := after[name]; !ok {
+			removed++
+		}
+	}
+	return added, removed
 }
 
 // executeStage runs the given stage against the given state, returning the new state.


### PR DESCRIPTION
## What

`logStateChanges` previously called `TypeDefinitionSet.Except` twice on every pipeline stage to build two diff `TypeDefinitionSet` maps that were used only for their `len()`. Replace with `countDefinitionChanges`, a small helper that counts adds/removes by iterating both maps with key-only lookups (no allocations). When the two maps share the same underlying pointer — the common case when a stage doesn't touch the definitions set — the work is O(1).

## Why

With ~85 stages and 100k+ definitions in flight, the old implementation allocated several million map entries per generator run purely for logging. This delivered no information beyond the two integers we end up logging.

## Verification

- `task generator:quick-checks` passes
- Full `go test ./...` in `v2/tools/generator` passes
- Log output is byte-identical for the `added`/`removed`/`totalDefs` fields on representative pipelines

Identified as one of ten generator-performance improvements in sibling PRs (#5479, #5481).