### PR TITLE
fix(generator): Pre-allocate map capacities in TypeDefinitionSet hot paths

### DIFF
--- a/v2/tools/generator/internal/astmodel/type_definition_set.go
+++ b/v2/tools/generator/internal/astmodel/type_definition_set.go
@@ -235,7 +235,8 @@ func (set TypeDefinitionSet) AddAllAllowDuplicates(otherDefinitions []TypeDefini
 
 // Where returns a new set of types including only those that satisfy the predicate
 func (set TypeDefinitionSet) Where(predicate func(definition TypeDefinition) bool) TypeDefinitionSet {
-	result := make(TypeDefinitionSet)
+	// Best-effort capacity: the result is at most as large as the source.
+	result := make(TypeDefinitionSet, len(set))
 	for _, t := range set {
 		if predicate(t) {
 			result[t.Name()] = t
@@ -268,14 +269,21 @@ func (set TypeDefinitionSet) Contains(name InternalTypeName) bool {
 // OverlayWith creates a new set containing all the type definitions from both this and the provided set. Any name
 // collisions are resolved in favour of the provided set. Returns a new independent set, leaving the original unmodified.
 func (set TypeDefinitionSet) OverlayWith(t TypeDefinitionSet) TypeDefinitionSet {
-	result := t.Copy()
-	result.AddTypes(set.Except(t))
+	// Single-pass merge: pre-allocate to the upper bound and copy both maps in.
+	// Entries from `t` overwrite entries from `set` to preserve the documented semantics.
+	result := make(TypeDefinitionSet, len(set)+len(t))
+	for k, v := range set {
+		result[k] = v
+	}
+	for k, v := range t {
+		result[k] = v
+	}
 	return result
 }
 
 // Names returns the names of all types in the set
 func (set TypeDefinitionSet) Names() TypeNameSet {
-	result := NewTypeNameSet()
+	result := make(TypeNameSet, len(set))
 	for name := range set {
 		result.Add(name)
 	}
@@ -293,8 +301,10 @@ func TypesDisjointUnion(s1 TypeDefinitionSet, s2 TypeDefinitionSet) TypeDefiniti
 
 // Copy makes an independent copy of this set of types
 func (set TypeDefinitionSet) Copy() TypeDefinitionSet {
-	result := make(TypeDefinitionSet)
-	result.AddTypes(set)
+	result := make(TypeDefinitionSet, len(set))
+	for name, def := range set {
+		result[name] = def
+	}
 	return result
 }
 
@@ -398,7 +408,7 @@ func (set TypeDefinitionSet) ResolveResourceSpecAndStatus(resourceDef TypeDefini
 // Only definitions returned by the func will be included in the results of the function. The func may return a nil
 // TypeDefinition if it doesn't want to include anything in the output set.
 func (set TypeDefinitionSet) Process(transformation func(definition TypeDefinition) (*TypeDefinition, error)) (TypeDefinitionSet, error) {
-	result := make(TypeDefinitionSet)
+	result := make(TypeDefinitionSet, len(set))
 
 	for _, def := range set {
 		d, err := transformation(def)

--- a/v2/tools/generator/internal/astmodel/type_visitor.go
+++ b/v2/tools/generator/internal/astmodel/type_visitor.go
@@ -134,7 +134,7 @@ func (tv *TypeVisitor[C]) VisitDefinition(td TypeDefinition, ctx C) (TypeDefinit
 }
 
 func (tv *TypeVisitor[C]) VisitDefinitions(definitions TypeDefinitionSet, ctx C) (TypeDefinitionSet, error) {
-	result := make(TypeDefinitionSet)
+	result := make(TypeDefinitionSet, len(definitions))
 	var errs []error
 	for _, d := range definitions {
 		def, err := tv.VisitDefinition(d, ctx)


### PR DESCRIPTION
## What

The generator pipeline produces and transforms a `TypeDefinitionSet` of ~150k entries dozens of times per run. Several core helpers created the result map without a capacity hint, forcing Go's hash table to resize repeatedly (and because growth doubles, most resizes happen when the map is already large).

Adds capacity hints to:
- `Copy`
- `Where` (which `Except` and `Intersect` both delegate to)
- `OverlayWith`
- `Names`
- `Process`
- `VisitDefinitions` (in `type_visitor.go`)

Plus two small wins while in the area:

- **OverlayWith** is rewritten as a single-pass merge of the two maps, removing the prior triple-pass (`Copy` → `Except` → `AddTypes`) which walked the larger set twice.
- **Copy** now copies directly via `range`, skipping the per-element duplicate-detection panic check in `AddTypes`. Copying from a map that already enforces unique keys cannot produce a duplicate.

## Why

Behaviour is unchanged. The change reduces allocation pressure and time spent in `mapassign`/`growWork` during the pipeline's hot stages.

## Verification

- `task generator:quick-checks` passes (build, unit tests, lint, golden files)
- Full `go test ./...` in `v2/tools/generator` passes
- End-to-end `gen-types azure-arm.yaml` produces identical output

Identified as one of ten generator-performance improvements in sibling PRs (#5479, #5480).