### PR TITLE
feat: Enable smart deletion precheck for containerservice

### DIFF
--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -1036,7 +1036,6 @@ func ConvertToARMResourceImpl(
 var skipDeletionPrecheck = sets.NewString(
 	"compute.azure.com",
 	"containerinstance.azure.com",
-	"containerservice.azure.com",
 	"datafactory.azure.com",
 	"dbforpostgresql.azure.com",
 	"devices.azure.com",


### PR DESCRIPTION
Removes `containerservice.azure.com` from the `skipDeletionPrecheck` deny list in the ARM reconciler. Both sample tests (`Test_Containerservice_*`) and controller tests (`Test_AKS_*`) pass with this group enabled.

Part of #5108