### PR TITLE
feat: Enable smart deletion precheck for documentdb

### DIFF
--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -1040,7 +1040,6 @@ var skipDeletionPrecheck = sets.NewString(
 	"datafactory.azure.com",
 	"dbforpostgresql.azure.com",
 	"devices.azure.com",
-	"documentdb.azure.com",
 	"insights.azure.com",
 	"keyvault.azure.com",
 	"kubernetesconfiguration.azure.com",


### PR DESCRIPTION
Removes `documentdb.azure.com` from the `skipDeletionPrecheck` deny list in the ARM reconciler. Both sample tests (`Test_(Cassandra|Mongodb|Sqldatabase)_*`) and controller tests (`Test_(CosmosDB|DocumentDB)_*`) pass with this group enabled.

Part of #5108