### PR TITLE
feat: Enable smart deletion precheck for kubernetesconfiguration

### DIFF
--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -1043,7 +1043,6 @@ var skipDeletionPrecheck = sets.NewString(
 	"documentdb.azure.com",
 	"insights.azure.com",
 	"keyvault.azure.com",
-	"kubernetesconfiguration.azure.com",
 	"machinelearningservices.azure.com",
 	"network.azure.com",
 	"network.frontdoor.azure.com",


### PR DESCRIPTION
Removes `kubernetesconfiguration.azure.com` from the `skipDeletionPrecheck` deny list in the ARM reconciler. Both sample tests (`Test_Kubernetesconfiguration_*`) and controller tests (`Test_KubernetesConfiguration_*`) pass with this group enabled.

Part of #5108