### PR TITLE
feat: Enable smart deletion precheck for network.frontdoor

### DIFF
--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -1046,7 +1046,6 @@ var skipDeletionPrecheck = sets.NewString(
 	"kubernetesconfiguration.azure.com",
 	"machinelearningservices.azure.com",
 	"network.azure.com",
-	"network.frontdoor.azure.com",
 	"redhatopenshift.azure.com",
 	"resources.azure.com",
 	"servicebus.azure.com",


### PR DESCRIPTION
Removes `network.frontdoor.azure.com` from the `skipDeletionPrecheck` deny list in the ARM reconciler. Both the sample test (`Test_NetworkFrontdoor_v1api_CreationAndDeletion`) and controller test (`Test_NetworkFrontDoorFirewallPolicy_CRUD`) pass with this group enabled.

Part of #5108