### PR TITLE
feat: Entra specific redaction

### DIFF
--- a/v2/internal/testcommon/creds/creds.go
+++ b/v2/internal/testcommon/creds/creds.go
@@ -82,17 +82,19 @@ func GetCreds() (azcore.TokenCredential, AzureIDs, error) {
 		return nil, AzureIDs{}, eris.Wrapf(err, "creating credentials")
 	}
 
+	// Read AZURE_SUBSCRIPTION_ID
 	subscriptionID := os.Getenv(config.AzureSubscriptionID)
 	if subscriptionID == "" {
 		return nil, AzureIDs{}, eris.Errorf("required environment variable %q was not supplied", config.AzureSubscriptionID)
 	}
 
+	// Read AZURE_TENANT_ID
 	tenantID := os.Getenv(config.AzureTenantID)
 	if tenantID == "" {
 		return nil, AzureIDs{}, eris.Errorf("required environment variable %q was not supplied", config.AzureTenantID)
 	}
 
-	// EntraID is optional - it's only needed if using Entra resources
+	// Read AZURE_ENTRA_APP_ID (optional; only used if Entra resources are used)
 	entraID := os.Getenv(config.EntraAppID)
 
 	// This is test specific and doesn't have a corresponding config entry. It's also optional as it's only required for

--- a/v2/internal/testcommon/creds/creds.go
+++ b/v2/internal/testcommon/creds/creds.go
@@ -32,6 +32,7 @@ type AzureIDs struct {
 	SubscriptionID   string
 	TenantID         string
 	BillingInvoiceID string
+	EntraAppID       string
 }
 
 // getCredentials returns the token credential authentication modes supported by
@@ -91,6 +92,9 @@ func GetCreds() (azcore.TokenCredential, AzureIDs, error) {
 		return nil, AzureIDs{}, eris.Errorf("required environment variable %q was not supplied", config.AzureTenantID)
 	}
 
+	// EntraID is optional - it's only needed if using Entra resources
+	entraID := os.Getenv(config.EntraAppID)
+
 	// This is test specific and doesn't have a corresponding config entry. It's also optional as it's only required for
 	// a small number of tests. Those tests will check for it explicitly
 	billingInvoiceID := os.Getenv(TestBillingIDVar)
@@ -99,6 +103,7 @@ func GetCreds() (azcore.TokenCredential, AzureIDs, error) {
 		SubscriptionID:   subscriptionID,
 		TenantID:         tenantID,
 		BillingInvoiceID: billingInvoiceID,
+		EntraAppID:       entraID,
 	}
 
 	cachedCreds = creds

--- a/v2/internal/testcommon/vcr/redact.go
+++ b/v2/internal/testcommon/vcr/redact.go
@@ -43,6 +43,10 @@ func NewRedactor(azureIDs creds.AzureIDs) *Redactor {
 		redactor.AddLiteralRedaction(azureIDs.BillingInvoiceID, creds.DummyBillingID)
 	}
 
+	if azureIDs.EntraAppID != "" {
+		redactor.AddLiteralRedaction(azureIDs.EntraAppID, nilGUID)
+	}
+
 	// OpenAI keys
 	redactor.AddRegexRedaction(
 		`"(?<key>key\d)":"[A-Za-z0-9]*"`,
@@ -67,6 +71,12 @@ func NewRedactor(azureIDs creds.AzureIDs) *Redactor {
 	redactor.AddRegexRedaction(
 		`-----BEGIN CERTIFICATE-----[A-Za-z0-9\\+/=]+-----END CERTIFICATE-----`,
 		`-----BEGIN CERTIFICATE-----REDACTED-----END CERTIFICATE-----`,
+	)
+
+	// Entra Publisher Domain
+	redactor.AddRegexRedaction(
+		`[A-Za-z0-9-]+\.onmicrosoft\.com`,
+		`redactedtenant.onmicrosoft.com`,
 	)
 
 	return redactor

--- a/v2/pkg/common/config/config.go
+++ b/v2/pkg/common/config/config.go
@@ -107,4 +107,7 @@ const (
 	// When disabled, any attempt to specify these settings in a credential will cause reconciliation to fail.
 	// This defaults to false for security reasons.
 	AllowMultiEnvManagement = "ALLOW_MULTI_ENV_MANAGEMENT"
+	// EntraAppID is the client ID of the Entra application used to authenticate with Entra.
+	// NOTE: This is required when using Entra authentication, but optional otherwise.
+	EntraAppID = "ENTRA_APP_ID"
 )


### PR DESCRIPTION
## What this PR does

Adds Entra specific redaction.

As Copilot noted in PR #5232, our recordings included some details that should have been redacted, though fortunately nothing security related.

This PR adds redaction of the ENTRA_APP_ID value, and of the custom subdomains used with `.onmicrosoft.com`.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZzN4aG83czhldTkxMTdnMGM3Nm4xbzU2bHlsYWV0cjU5c2ZkZ3NqNSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/otYYkRFODhvrCEQfRa/giphy.gif)

