### PR TITLE
fix(generator): qualify method receivers that collide with arm/storage import aliases

### DIFF
--- a/v2/api/cognitiveservices/v1api20250601/account_types_gen.go
+++ b/v2/api/cognitiveservices/v1api20250601/account_types_gen.go
@@ -7448,21 +7448,21 @@ type UserOwnedStorage struct {
 var _ genruntime.ARMTransformer = &UserOwnedStorage{}
 
 // ConvertToARM converts from a Kubernetes CRD object to an ARM object
-func (storage *UserOwnedStorage) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (interface{}, error) {
-	if storage == nil {
+func (ownedStorage *UserOwnedStorage) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (interface{}, error) {
+	if ownedStorage == nil {
 		return nil, nil
 	}
 	result := &arm.UserOwnedStorage{}
 
 	// Set property "IdentityClientId":
-	if storage.IdentityClientId != nil {
-		identityClientId := *storage.IdentityClientId
+	if ownedStorage.IdentityClientId != nil {
+		identityClientId := *ownedStorage.IdentityClientId
 		result.IdentityClientId = &identityClientId
 	}
 
 	// Set property "ResourceId":
-	if storage.ResourceReference != nil {
-		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*storage.ResourceReference)
+	if ownedStorage.ResourceReference != nil {
+		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*ownedStorage.ResourceReference)
 		if err != nil {
 			return nil, err
 		}
@@ -7473,12 +7473,12 @@ func (storage *UserOwnedStorage) ConvertToARM(resolved genruntime.ConvertToARMRe
 }
 
 // NewEmptyARMValue returns an empty ARM value suitable for deserializing into
-func (storage *UserOwnedStorage) NewEmptyARMValue() genruntime.ARMResourceStatus {
+func (ownedStorage *UserOwnedStorage) NewEmptyARMValue() genruntime.ARMResourceStatus {
 	return &arm.UserOwnedStorage{}
 }
 
 // PopulateFromARM populates a Kubernetes CRD object from an Azure ARM object
-func (storage *UserOwnedStorage) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInput interface{}) error {
+func (ownedStorage *UserOwnedStorage) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInput interface{}) error {
 	typedInput, ok := armInput.(arm.UserOwnedStorage)
 	if !ok {
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected arm.UserOwnedStorage, got %T", armInput)
@@ -7487,7 +7487,7 @@ func (storage *UserOwnedStorage) PopulateFromARM(owner genruntime.ArbitraryOwner
 	// Set property "IdentityClientId":
 	if typedInput.IdentityClientId != nil {
 		identityClientId := *typedInput.IdentityClientId
-		storage.IdentityClientId = &identityClientId
+		ownedStorage.IdentityClientId = &identityClientId
 	}
 
 	// no assignment for property "ResourceReference"
@@ -7497,17 +7497,17 @@ func (storage *UserOwnedStorage) PopulateFromARM(owner genruntime.ArbitraryOwner
 }
 
 // AssignProperties_From_UserOwnedStorage populates our UserOwnedStorage from the provided source UserOwnedStorage
-func (storage *UserOwnedStorage) AssignProperties_From_UserOwnedStorage(source *storage.UserOwnedStorage) error {
+func (ownedStorage *UserOwnedStorage) AssignProperties_From_UserOwnedStorage(source *storage.UserOwnedStorage) error {
 
 	// IdentityClientId
-	storage.IdentityClientId = genruntime.ClonePointerToString(source.IdentityClientId)
+	ownedStorage.IdentityClientId = genruntime.ClonePointerToString(source.IdentityClientId)
 
 	// ResourceReference
 	if source.ResourceReference != nil {
 		resourceReference := source.ResourceReference.Copy()
-		storage.ResourceReference = &resourceReference
+		ownedStorage.ResourceReference = &resourceReference
 	} else {
-		storage.ResourceReference = nil
+		ownedStorage.ResourceReference = nil
 	}
 
 	// No error
@@ -7515,16 +7515,16 @@ func (storage *UserOwnedStorage) AssignProperties_From_UserOwnedStorage(source *
 }
 
 // AssignProperties_To_UserOwnedStorage populates the provided destination UserOwnedStorage from our UserOwnedStorage
-func (storage *UserOwnedStorage) AssignProperties_To_UserOwnedStorage(destination *storage.UserOwnedStorage) error {
+func (ownedStorage *UserOwnedStorage) AssignProperties_To_UserOwnedStorage(destination *storage.UserOwnedStorage) error {
 	// Create a new property bag
 	propertyBag := genruntime.NewPropertyBag()
 
 	// IdentityClientId
-	destination.IdentityClientId = genruntime.ClonePointerToString(storage.IdentityClientId)
+	destination.IdentityClientId = genruntime.ClonePointerToString(ownedStorage.IdentityClientId)
 
 	// ResourceReference
-	if storage.ResourceReference != nil {
-		resourceReference := storage.ResourceReference.Copy()
+	if ownedStorage.ResourceReference != nil {
+		resourceReference := ownedStorage.ResourceReference.Copy()
 		destination.ResourceReference = &resourceReference
 	} else {
 		destination.ResourceReference = nil
@@ -7542,17 +7542,17 @@ func (storage *UserOwnedStorage) AssignProperties_To_UserOwnedStorage(destinatio
 }
 
 // Initialize_From_UserOwnedStorage_STATUS populates our UserOwnedStorage from the provided source UserOwnedStorage_STATUS
-func (storage *UserOwnedStorage) Initialize_From_UserOwnedStorage_STATUS(source *UserOwnedStorage_STATUS) error {
+func (ownedStorage *UserOwnedStorage) Initialize_From_UserOwnedStorage_STATUS(source *UserOwnedStorage_STATUS) error {
 
 	// IdentityClientId
-	storage.IdentityClientId = genruntime.ClonePointerToString(source.IdentityClientId)
+	ownedStorage.IdentityClientId = genruntime.ClonePointerToString(source.IdentityClientId)
 
 	// ResourceReference
 	if source.ResourceId != nil {
 		resourceReference := genruntime.CreateResourceReferenceFromARMID(*source.ResourceId)
-		storage.ResourceReference = &resourceReference
+		ownedStorage.ResourceReference = &resourceReference
 	} else {
-		storage.ResourceReference = nil
+		ownedStorage.ResourceReference = nil
 	}
 
 	// No error
@@ -7570,12 +7570,12 @@ type UserOwnedStorage_STATUS struct {
 var _ genruntime.FromARMConverter = &UserOwnedStorage_STATUS{}
 
 // NewEmptyARMValue returns an empty ARM value suitable for deserializing into
-func (storage *UserOwnedStorage_STATUS) NewEmptyARMValue() genruntime.ARMResourceStatus {
+func (ownedStorage *UserOwnedStorage_STATUS) NewEmptyARMValue() genruntime.ARMResourceStatus {
 	return &arm.UserOwnedStorage_STATUS{}
 }
 
 // PopulateFromARM populates a Kubernetes CRD object from an Azure ARM object
-func (storage *UserOwnedStorage_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInput interface{}) error {
+func (ownedStorage *UserOwnedStorage_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInput interface{}) error {
 	typedInput, ok := armInput.(arm.UserOwnedStorage_STATUS)
 	if !ok {
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected arm.UserOwnedStorage_STATUS, got %T", armInput)
@@ -7584,13 +7584,13 @@ func (storage *UserOwnedStorage_STATUS) PopulateFromARM(owner genruntime.Arbitra
 	// Set property "IdentityClientId":
 	if typedInput.IdentityClientId != nil {
 		identityClientId := *typedInput.IdentityClientId
-		storage.IdentityClientId = &identityClientId
+		ownedStorage.IdentityClientId = &identityClientId
 	}
 
 	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
-		storage.ResourceId = &resourceId
+		ownedStorage.ResourceId = &resourceId
 	}
 
 	// No error
@@ -7598,28 +7598,28 @@ func (storage *UserOwnedStorage_STATUS) PopulateFromARM(owner genruntime.Arbitra
 }
 
 // AssignProperties_From_UserOwnedStorage_STATUS populates our UserOwnedStorage_STATUS from the provided source UserOwnedStorage_STATUS
-func (storage *UserOwnedStorage_STATUS) AssignProperties_From_UserOwnedStorage_STATUS(source *storage.UserOwnedStorage_STATUS) error {
+func (ownedStorage *UserOwnedStorage_STATUS) AssignProperties_From_UserOwnedStorage_STATUS(source *storage.UserOwnedStorage_STATUS) error {
 
 	// IdentityClientId
-	storage.IdentityClientId = genruntime.ClonePointerToString(source.IdentityClientId)
+	ownedStorage.IdentityClientId = genruntime.ClonePointerToString(source.IdentityClientId)
 
 	// ResourceId
-	storage.ResourceId = genruntime.ClonePointerToString(source.ResourceId)
+	ownedStorage.ResourceId = genruntime.ClonePointerToString(source.ResourceId)
 
 	// No error
 	return nil
 }
 
 // AssignProperties_To_UserOwnedStorage_STATUS populates the provided destination UserOwnedStorage_STATUS from our UserOwnedStorage_STATUS
-func (storage *UserOwnedStorage_STATUS) AssignProperties_To_UserOwnedStorage_STATUS(destination *storage.UserOwnedStorage_STATUS) error {
+func (ownedStorage *UserOwnedStorage_STATUS) AssignProperties_To_UserOwnedStorage_STATUS(destination *storage.UserOwnedStorage_STATUS) error {
 	// Create a new property bag
 	propertyBag := genruntime.NewPropertyBag()
 
 	// IdentityClientId
-	destination.IdentityClientId = genruntime.ClonePointerToString(storage.IdentityClientId)
+	destination.IdentityClientId = genruntime.ClonePointerToString(ownedStorage.IdentityClientId)
 
 	// ResourceId
-	destination.ResourceId = genruntime.ClonePointerToString(storage.ResourceId)
+	destination.ResourceId = genruntime.ClonePointerToString(ownedStorage.ResourceId)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {

--- a/v2/tools/generator/internal/astmodel/identifier_factory.go
+++ b/v2/tools/generator/internal/astmodel/identifier_factory.go
@@ -232,10 +232,13 @@ func (factory *identifierFactory) CreateReceiver(name string) string {
 
 	base := words[len(words)-1]
 
-	// Prefix with a qualifying term if one is available,
-	// AND either base is a reserved word, or it is too short (3 characters or less)
+	// Prefix with a qualifying term if one is available, AND the base is a reserved word, is too
+	// short (3 characters or less), or collides with a conversion-package alias (arm/storage) that
+	// the generated code imports - a bare receiver named after one of those would shadow the package.
 	if len(words) > 1 {
-		if _, found := factory.reservedWords[strings.ToLower(base)]; found || len(base) <= 3 {
+		lowerBase := strings.ToLower(base)
+		_, reserved := factory.reservedWords[lowerBase]
+		if reserved || len(base) <= 3 || forbiddenReceiverNames.Contains(lowerBase) {
 			base = words[len(words)-2] + base
 		}
 	}
@@ -295,6 +298,10 @@ func createForbiddenReceiverSuffixes() set.Set[string] {
 	spec := strings.TrimPrefix(SpecSuffix, "_")
 	return set.Make(status, spec)
 }
+
+// forbiddenReceiverNames are lowercase receiver names that would shadow a conversion-package import
+// (e.g. a type ending in "Storage" yields receiver "storage", clashing with the storage subpackage alias).
+var forbiddenReceiverNames = set.Make(strings.ToLower(ARMPackageName), strings.ToLower(StoragePackageName))
 
 func (factory *identifierFactory) CreateGroupName(group string) string {
 	return strings.TrimPrefix(strings.ToLower(group), "microsoft.")

--- a/v2/tools/generator/internal/astmodel/identifier_factory_test.go
+++ b/v2/tools/generator/internal/astmodel/identifier_factory_test.go
@@ -224,6 +224,9 @@ func Test_CreateReceiver_GivenTypeName_ReturnsExpectedResult(t *testing.T) {
 		{"DiskSku" + StatusSuffix, "diskSku"},
 		// Conflicts with reserved words need more detail
 		{"BlobRestoreRange" + StatusSuffix, "restoreRange"},
+		// Conflicts with conversion-package import aliases (arm/storage) need more detail
+		{"FunctionsDeployment_Storage", "deploymentStorage"},
+		{"FunctionsDeployment_Storage" + StatusSuffix, "deploymentStorage"},
 	}
 
 	factory := NewIdentifierFactory()


### PR DESCRIPTION
## Problem

`CreateReceiver()` derives a method-receiver name from the last word of a type name. For a type whose
name ends in `Storage` (e.g. `FunctionsDeployment_Storage` in the web group), the receiver becomes
`storage` — which **shadows the `storage` conversion-package import alias** used in generated
`AssignProperties_To_*` / `AssignProperties_From_*` methods. The generated code then fails to compile,
e.g. `storage.FunctionsDeployment_Storage_Authentication is not a type`.

`CreateReceiver` already qualifies Go reserved words and very short (≤3-char) identifiers — so `arm`
(len 3) was already safe, but `storage` was not. This extends the same guard to the fixed
conversion-package import aliases (`arm`, `storage`) so a type-derived receiver can never shadow them.
The receiver is renamed (e.g. `storage` → `deploymentStorage`); type names and JSON wire tags are
unchanged.

General fix: any current or future type whose name ends in `Storage` (or otherwise collides with these
aliases) benefits.

## Tests

- `go test ./internal/astmodel/...` (incl. a new case covering the receiver/alias collision) → ok
- `go test ./internal/codegen/...` (golden tests) → ok, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
