### PR TITLE
feat: Enable smart deletion precheck for redhatopenshift

### DIFF
--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -1042,7 +1042,6 @@ var skipDeletionPrecheck = sets.NewString(
 	"keyvault.azure.com",
 	"machinelearningservices.azure.com",
 	"network.azure.com",
-	"redhatopenshift.azure.com",
 	"resources.azure.com",
 	"servicebus.azure.com",
 	"storage.azure.com",


### PR DESCRIPTION
Removes `redhatopenshift.azure.com` from the `skipDeletionPrecheck` deny list in the ARM reconciler. Both sample and controller tests pass with this group enabled.

Part of #5108