### PR TITLE
Enable test caching for local tasks

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -606,7 +606,7 @@ tasks:
       - setup
       - controller:run-kustomize-for-envtest
     cmds:
-      - go test -count=1 -timeout {{.TIMEOUT}} -run '{{default ".*" .TEST_FILTER}}' {{.VERBOSE}} ./internal/controllers | tee '{{.TEST_OUT}}/test-controllers.log'
+      - go test -timeout {{.TIMEOUT}} -run '{{default ".*" .TEST_FILTER}}' {{.VERBOSE}} ./internal/controllers | tee '{{.TEST_OUT}}/test-controllers.log'
     vars:
       VERBOSE:
         sh: if [ $TEST_FILTER ]; then echo "-v"; fi
@@ -619,7 +619,7 @@ tasks:
       - setup
       - controller:run-kustomize-for-envtest
     cmds:
-      - go test -count=1 -timeout {{.TIMEOUT}} -run '{{default ".*" .TEST_FILTER}}' {{.VERBOSE}} ./internal/testsamples | tee '{{.TEST_OUT}}/test-samples.log'
+      - go test -timeout {{.TIMEOUT}} -run '{{default ".*" .TEST_FILTER}}' {{.VERBOSE}} ./internal/testsamples | tee '{{.TEST_OUT}}/test-samples.log'
     vars:
       VERBOSE:
         sh: if [ $TEST_FILTER ]; then echo "-v"; fi


### PR DESCRIPTION
## What this PR does

The two tasks `controller:test-controllers` and `controller:test-samples` are now only used locally - there are CI specific variants in the `ci/Taskfile.yaml` file that are used for PR checks.

We can therefore remove the `-count=1` parameter from them that serves to turn off build/test caching, which should improve local performance when testing changes.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbHBlMjZ4NmcwcW1zN2hqNjljOTA2ZDlsZDBzMXpkd3MxNXdrNGhkcyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3o6Zth7pE7aPKqAEEM/giphy.gif)
