### PR TITLE
perf(config): speed up ObjectModelConfiguration lookups

### DIFF
--- a/v2/internal/util/typo/typo_advisor.go
+++ b/v2/internal/util/typo/typo_advisor.go
@@ -29,11 +29,11 @@ func NewAdvisor() *Advisor {
 }
 
 // AddTerm records that we saw the specified item.
-// The advisor is consulted on every lookup made against the ObjectModelConfiguration, so the
-// same terms are added many times over. We take a read lock first and only escalate to the
-// exclusive write lock when the term is genuinely new; this keeps the hot lookup path free of
-// serialization once each unique term has been observed at least once.
 func (advisor *Advisor) AddTerm(item string) {
+	// The advisor is consulted on every lookup made against the ObjectModelConfiguration, so the
+	// same terms are added many times over. We take a read lock first and only escalate to the
+	// exclusive write lock when the term is genuinely new; this keeps the hot lookup path free of
+	// serialization once each unique term has been observed at least once.
 	advisor.lock.RLock()
 	if advisor.terms.Contains(item) {
 		advisor.lock.RUnlock()

--- a/v2/internal/util/typo/typo_advisor.go
+++ b/v2/internal/util/typo/typo_advisor.go
@@ -28,8 +28,19 @@ func NewAdvisor() *Advisor {
 	}
 }
 
-// AddTerm records that we saw the specified item
+// AddTerm records that we saw the specified item.
+// The advisor is consulted on every lookup made against the ObjectModelConfiguration, so the
+// same terms are added many times over. We take a read lock first and only escalate to the
+// exclusive write lock when the term is genuinely new; this keeps the hot lookup path free of
+// serialization once each unique term has been observed at least once.
 func (advisor *Advisor) AddTerm(item string) {
+	advisor.lock.RLock()
+	if advisor.terms.Contains(item) {
+		advisor.lock.RUnlock()
+		return
+	}
+	advisor.lock.RUnlock()
+
 	advisor.lock.Lock()
 	defer advisor.lock.Unlock()
 	advisor.terms.Add(item)

--- a/v2/tools/generator/internal/config/object_model_configuration.go
+++ b/v2/tools/generator/internal/config/object_model_configuration.go
@@ -326,34 +326,46 @@ func (omc *ObjectModelConfiguration) visitGroups(visitor *configurationVisitor) 
 }
 
 // findGroup uses the provided TypeName to work out which nested GroupConfiguration should be used
-func (omc *ObjectModelConfiguration) findGroup(ref astmodel.InternalPackageReference) *GroupConfiguration {
-	group := ref.Group()
-
+func (omc *ObjectModelConfiguration) findGroup(
+	ref astmodel.InternalPackageReference,
+) *GroupConfiguration {
 	if omc == nil || omc.groups == nil {
 		return nil
 	}
 
 	// Fast path: consult the resolution cache under a read lock. Cached entries may be nil to
 	// record a known-absent group so that repeated defensive lookups do not re-do the work.
-	omc.groupCacheLock.RLock()
-	if cached, ok := omc.groupCache[group]; ok {
-		omc.groupCacheLock.RUnlock()
-		omc.typoAdvisor.AddTerm(group)
+	if cached, ok := omc.findGroupFromCache(ref); ok {
 		return cached
 	}
-	omc.groupCacheLock.RUnlock()
 
+	group := ref.Group()
 	omc.typoAdvisor.AddTerm(group)
 	g := omc.groups[group]
 
 	omc.groupCacheLock.Lock()
+	defer omc.groupCacheLock.Unlock()
+
 	if omc.groupCache == nil {
 		omc.groupCache = make(map[string]*GroupConfiguration)
 	}
+
 	omc.groupCache[group] = g
-	omc.groupCacheLock.Unlock()
 
 	return g
+}
+
+// findGroupFromCache uses the provided TypeName to look up a cached GroupConfiguration, if present.
+func (omc *ObjectModelConfiguration) findGroupFromCache(
+	ref astmodel.InternalPackageReference,
+) (*GroupConfiguration, bool) {
+	group := ref.Group()
+
+	omc.groupCacheLock.RLock()
+	defer omc.groupCacheLock.RUnlock()
+
+	gc, ok := omc.groupCache[group]
+	return gc, ok
 }
 
 // UnmarshalYAML populates our instance from the YAML.

--- a/v2/tools/generator/internal/config/object_model_configuration.go
+++ b/v2/tools/generator/internal/config/object_model_configuration.go
@@ -8,6 +8,7 @@ package config
 import (
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/rotisserie/eris"
 	"gopkg.in/yaml.v3"
@@ -28,6 +29,13 @@ import (
 type ObjectModelConfiguration struct {
 	groups      map[string]*GroupConfiguration // nested configuration for individual groups
 	typoAdvisor *typo.Advisor
+
+	// groupCache memoises findGroup results so that repeated lookups against the same group
+	// name (which is the norm during code generation) skip the small amount of work involved.
+	// The key is the raw name from ref.Group(); a nil value means "known absent". Cache
+	// entries are cleared by addGroup so that late additions from tests remain observable.
+	groupCacheLock sync.RWMutex
+	groupCache     map[string]*GroupConfiguration
 
 	// Group access fields here (alphabetical, please)
 	PayloadType propertyAccess[PayloadType]
@@ -274,7 +282,20 @@ func (omc *ObjectModelConfiguration) addGroup(name string, group *GroupConfigura
 	}
 
 	omc.groups[key] = group
+
+	// Any previously cached "known absent" answer for this key must be discarded so that
+	// subsequent lookups see the newly added group.
+	omc.invalidateGroupCache()
+
 	return nil
+}
+
+// invalidateGroupCache clears the group-resolution cache. Called whenever the set of configured
+// groups changes.
+func (omc *ObjectModelConfiguration) invalidateGroupCache() {
+	omc.groupCacheLock.Lock()
+	omc.groupCache = nil
+	omc.groupCacheLock.Unlock()
 }
 
 // visitGroup invokes the provided visitor on the specified group if present.
@@ -312,12 +333,27 @@ func (omc *ObjectModelConfiguration) findGroup(ref astmodel.InternalPackageRefer
 		return nil
 	}
 
-	omc.typoAdvisor.AddTerm(group)
-	if g, ok := omc.groups[group]; ok {
-		return g
+	// Fast path: consult the resolution cache under a read lock. Cached entries may be nil to
+	// record a known-absent group so that repeated defensive lookups do not re-do the work.
+	omc.groupCacheLock.RLock()
+	if cached, ok := omc.groupCache[group]; ok {
+		omc.groupCacheLock.RUnlock()
+		omc.typoAdvisor.AddTerm(group)
+		return cached
 	}
+	omc.groupCacheLock.RUnlock()
 
-	return nil
+	omc.typoAdvisor.AddTerm(group)
+	g := omc.groups[group]
+
+	omc.groupCacheLock.Lock()
+	if omc.groupCache == nil {
+		omc.groupCache = make(map[string]*GroupConfiguration)
+	}
+	omc.groupCache[group] = g
+	omc.groupCacheLock.Unlock()
+
+	return g
 }
 
 // UnmarshalYAML populates our instance from the YAML.

--- a/v2/tools/generator/internal/config/object_model_configuration_bench_test.go
+++ b/v2/tools/generator/internal/config/object_model_configuration_bench_test.go
@@ -17,6 +17,29 @@ import (
 // generator hits on every reconciliation of every type. Use `go test -run=^$ -bench=. -benchmem`
 // from this package to run them.
 
+// Sample Results
+//
+// Without caching
+//
+// cpu: 13th Gen Intel(R) Core(TM) i9-13900H
+// BenchmarkTypeAccess_Lookup_Hit-12                        6197558               191.5 ns/op            48 B/op          3 allocs/op
+// BenchmarkTypeAccess_Lookup_Miss-12                       5943925               199.0 ns/op            64 B/op          3 allocs/op
+// BenchmarkPropertyAccess_Lookup_Hit-12                    3886447               311.5 ns/op            80 B/op          5 allocs/op
+// BenchmarkPropertyAccess_Lookup_Miss-12                   4048657               300.0 ns/op            88 B/op          5 allocs/op
+// BenchmarkIsTypeConfigured-12                             6973417               172.6 ns/op            32 B/op          3 allocs/op
+// BenchmarkTypeAccess_Lookup_RepeatedSameName-12           6623281               181.2 ns/op            48 B/op          3 allocs/op
+//
+// With caching
+//
+// cpu: 13th Gen Intel(R) Core(TM) i9-13900H
+// BenchmarkTypeAccess_Lookup_Hit-12                        9089062               132.0 ns/op            40 B/op          2 allocs/op
+// BenchmarkTypeAccess_Lookup_Miss-12                       8999131               127.7 ns/op            40 B/op          2 allocs/op
+// BenchmarkPropertyAccess_Lookup_Hit-12                    4717492               249.2 ns/op            72 B/op          4 allocs/op
+// BenchmarkPropertyAccess_Lookup_Miss-12                   5039460               234.9 ns/op            80 B/op          4 allocs/op
+// BenchmarkIsTypeConfigured-12                             9827052               118.9 ns/op            17 B/op          2 allocs/op
+// BenchmarkTypeAccess_Lookup_RepeatedSameName-12          10079797               124.9 ns/op            40 B/op          2 allocs/op
+//
+
 // buildBenchmarkModel returns an ObjectModelConfiguration populated with a representative shape
 // of configuration - a handful of groups, each with a handful of versions, each with a moderate
 // number of types and per-type properties. The specific numbers are chosen to be at least as

--- a/v2/tools/generator/internal/config/object_model_configuration_bench_test.go
+++ b/v2/tools/generator/internal/config/object_model_configuration_bench_test.go
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package config
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/test"
+)
+
+// The benchmarks in this file exercise the ObjectModelConfiguration lookup hot paths that the
+// generator hits on every reconciliation of every type. Use `go test -run=^$ -bench=. -benchmem`
+// from this package to run them.
+
+// buildBenchmarkModel returns an ObjectModelConfiguration populated with a representative shape
+// of configuration - a handful of groups, each with a handful of versions, each with a moderate
+// number of types and per-type properties. The specific numbers are chosen to be at least as
+// large as the largest groups in production so that the benchmarks reflect worst-case walks.
+func buildBenchmarkModel(tb testing.TB) (*ObjectModelConfiguration, []astmodel.InternalTypeName, []astmodel.PropertyName) {
+	tb.Helper()
+
+	const (
+		groupCount      = 8
+		versionsPerGrp  = 4
+		typesPerVersion = 32
+		propsPerType    = 12
+	)
+
+	model := NewObjectModelConfiguration()
+
+	typeNames := make([]astmodel.InternalTypeName, 0, groupCount*versionsPerGrp*typesPerVersion)
+	propNames := make([]astmodel.PropertyName, 0, propsPerType)
+
+	for p := 0; p < propsPerType; p++ {
+		propNames = append(propNames, astmodel.PropertyName(fmt.Sprintf("Property%02d", p)))
+	}
+
+	for g := 0; g < groupCount; g++ {
+		groupName := fmt.Sprintf("group%02d", g)
+		for v := 0; v < versionsPerGrp; v++ {
+			// Use a realistic API-version style so lookup keys are non-trivial
+			versionName := fmt.Sprintf("v2020010%d", v+1)
+			pkg := test.MakeLocalPackageReference(groupName, versionName)
+			for t := 0; t < typesPerVersion; t++ {
+				typeName := astmodel.MakeInternalTypeName(pkg, fmt.Sprintf("Type%03d", t))
+				typeNames = append(typeNames, typeName)
+
+				err := model.ModifyType(typeName, func(tc *TypeConfiguration) error {
+					tc.SupportedFrom.Set("v2.0.0")
+					tc.ExportAs.Set(typeName.Name())
+					return nil
+				})
+				if err != nil {
+					tb.Fatalf("populating type: %s", err)
+				}
+
+				for _, pn := range propNames {
+					err := model.ModifyProperty(typeName, pn, func(pc *PropertyConfiguration) error {
+						pc.ReferenceType.Set(ReferenceTypeSimple)
+						return nil
+					})
+					if err != nil {
+						tb.Fatalf("populating property: %s", err)
+					}
+				}
+			}
+		}
+	}
+
+	return model, typeNames, propNames
+}
+
+// BenchmarkTypeAccess_Lookup_Hit measures the cost of a Lookup that resolves to a configured
+// value. This is the dominant pattern in the generator - the same set of types are queried for
+// many attributes across many pipeline stages.
+func BenchmarkTypeAccess_Lookup_Hit(b *testing.B) {
+	model, typeNames, _ := buildBenchmarkModel(b)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		name := typeNames[i%len(typeNames)]
+		if _, ok := model.SupportedFrom.Lookup(name); !ok {
+			b.Fatalf("expected hit for %s", name)
+		}
+	}
+}
+
+// BenchmarkTypeAccess_Lookup_Miss measures the cost of a Lookup that does not resolve, so we walk
+// the whole hierarchy for nothing. Misses are common because pipelines defensively check for
+// configuration on many types that have none.
+func BenchmarkTypeAccess_Lookup_Miss(b *testing.B) {
+	model, typeNames, _ := buildBenchmarkModel(b)
+
+	// Use type names in a package that exists so we go all the way to the version level before
+	// missing. This exercises the deepest miss path.
+	missNames := make([]astmodel.InternalTypeName, 0, len(typeNames))
+	for _, tn := range typeNames {
+		missNames = append(missNames, astmodel.MakeInternalTypeName(tn.InternalPackageReference(), "NotConfigured"+tn.Name()))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		name := missNames[i%len(missNames)]
+		if _, ok := model.SupportedFrom.Lookup(name); ok {
+			b.Fatalf("expected miss for %s", name)
+		}
+	}
+}
+
+// BenchmarkPropertyAccess_Lookup_Hit measures the property-level lookup path, which is a deeper
+// walk than the type-level path.
+func BenchmarkPropertyAccess_Lookup_Hit(b *testing.B) {
+	model, typeNames, propNames := buildBenchmarkModel(b)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		name := typeNames[i%len(typeNames)]
+		prop := propNames[i%len(propNames)]
+		if _, ok := model.ReferenceType.Lookup(name, prop); !ok {
+			b.Fatalf("expected hit for %s.%s", name, prop)
+		}
+	}
+}
+
+// BenchmarkPropertyAccess_Lookup_Miss measures a property lookup that misses at the property
+// level (so we walk group → version → type → nothing).
+func BenchmarkPropertyAccess_Lookup_Miss(b *testing.B) {
+	model, typeNames, _ := buildBenchmarkModel(b)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		name := typeNames[i%len(typeNames)]
+		if _, ok := model.ReferenceType.Lookup(name, "NotAConfiguredProperty"); ok {
+			b.Fatalf("expected miss for %s", name)
+		}
+	}
+}
+
+// BenchmarkIsTypeConfigured measures the defensive-check that pipelines use to decide whether
+// to walk a type at all. It's called on every type in the model.
+func BenchmarkIsTypeConfigured(b *testing.B) {
+	model, typeNames, _ := buildBenchmarkModel(b)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		name := typeNames[i%len(typeNames)]
+		if !model.IsTypeConfigured(name) {
+			b.Fatalf("expected configured for %s", name)
+		}
+	}
+}
+
+// BenchmarkTypeAccess_Lookup_RepeatedSameName measures the case where the same type is looked up
+// many times in a row across different attributes (each attribute is a separate Lookup call).
+// This is the pattern where a resolution cache would show the biggest win.
+func BenchmarkTypeAccess_Lookup_RepeatedSameName(b *testing.B) {
+	model, typeNames, _ := buildBenchmarkModel(b)
+	name := typeNames[len(typeNames)/2]
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, ok := model.SupportedFrom.Lookup(name); !ok {
+			b.Fatalf("expected hit for %s", name)
+		}
+	}
+}

--- a/v2/tools/generator/internal/config/version_configuration.go
+++ b/v2/tools/generator/internal/config/version_configuration.go
@@ -108,26 +108,34 @@ func (vc *VersionConfiguration) visitTypes(visitor *configurationVisitor) error 
 func (vc *VersionConfiguration) findType(name string) *TypeConfiguration {
 	// Fast path: consult the resolution cache under a read lock. The cache is keyed on the
 	// raw name (not the lowercased form) so a hit avoids allocating a lowercase copy.
-	vc.typeCacheLock.RLock()
-	if cached, ok := vc.typeCache[name]; ok {
-		vc.typeCacheLock.RUnlock()
-		vc.advisor.AddTerm(name)
+	if cached, ok := vc.findTypeFromCache(name); ok {
 		return cached
 	}
-	vc.typeCacheLock.RUnlock()
 
 	vc.advisor.AddTerm(name)
 	n := strings.ToLower(name)
 	t := vc.types[n]
 
 	vc.typeCacheLock.Lock()
+	defer vc.typeCacheLock.Unlock()
+
 	if vc.typeCache == nil {
 		vc.typeCache = make(map[string]*TypeConfiguration)
 	}
+
 	vc.typeCache[name] = t
-	vc.typeCacheLock.Unlock()
 
 	return t
+}
+
+// findTypeFromCache uses the provided name to look up in our cache
+func (vc *VersionConfiguration) findTypeFromCache(name string) (*TypeConfiguration, bool) {
+	vc.typeCacheLock.RLock()
+	defer vc.typeCacheLock.RUnlock()
+
+	tc, ok := vc.typeCache[name]
+
+	return tc, ok
 }
 
 // addTypeAlias adds an alias for the specified type, so it may be found with an alternative name

--- a/v2/tools/generator/internal/config/version_configuration.go
+++ b/v2/tools/generator/internal/config/version_configuration.go
@@ -7,6 +7,7 @@ package config
 
 import (
 	"strings"
+	"sync"
 
 	"github.com/rotisserie/eris"
 	"gopkg.in/yaml.v3"
@@ -27,6 +28,14 @@ type VersionConfiguration struct {
 	name    string
 	types   map[string]*TypeConfiguration
 	advisor *typo.Advisor
+
+	// typeCache memoises findType results so that repeated lookups for the same type name -
+	// including negative "not configured" results - skip the strings.ToLower allocation and
+	// map lookup. The cache is keyed on the raw name passed to findType (so a hit on the
+	// common case bypasses the ToLower entirely). Populated lazily on first find; cleared by
+	// addType and addTypeAlias so that late additions remain observable.
+	typeCacheLock sync.RWMutex
+	typeCache     map[string]*TypeConfiguration
 }
 
 // NewVersionConfiguration returns a new (empty) VersionConfiguration
@@ -46,7 +55,17 @@ func (vc *VersionConfiguration) addType(name string, tc *TypeConfiguration) erro
 		return eris.Errorf("duplicate type configuration: %q already exists", name)
 	}
 	vc.types[key] = tc
+	vc.invalidateTypeCache()
 	return nil
+}
+
+// invalidateTypeCache clears the type-resolution cache. Called whenever the set of configured
+// types for this version changes so that lookups previously recorded as "known absent" are
+// re-resolved against the updated map.
+func (vc *VersionConfiguration) invalidateTypeCache() {
+	vc.typeCacheLock.Lock()
+	vc.typeCache = nil
+	vc.typeCacheLock.Unlock()
 }
 
 // visitType invokes the provided visitor on the specified type if present.
@@ -87,13 +106,28 @@ func (vc *VersionConfiguration) visitTypes(visitor *configurationVisitor) error 
 
 // findType uses the provided name to work out which nested TypeConfiguration should be used
 func (vc *VersionConfiguration) findType(name string) *TypeConfiguration {
+	// Fast path: consult the resolution cache under a read lock. The cache is keyed on the
+	// raw name (not the lowercased form) so a hit avoids allocating a lowercase copy.
+	vc.typeCacheLock.RLock()
+	if cached, ok := vc.typeCache[name]; ok {
+		vc.typeCacheLock.RUnlock()
+		vc.advisor.AddTerm(name)
+		return cached
+	}
+	vc.typeCacheLock.RUnlock()
+
 	vc.advisor.AddTerm(name)
 	n := strings.ToLower(name)
-	if t, ok := vc.types[n]; ok {
-		return t
-	}
+	t := vc.types[n]
 
-	return nil
+	vc.typeCacheLock.Lock()
+	if vc.typeCache == nil {
+		vc.typeCache = make(map[string]*TypeConfiguration)
+	}
+	vc.typeCache[name] = t
+	vc.typeCacheLock.Unlock()
+
+	return t
 }
 
 // addTypeAlias adds an alias for the specified type, so it may be found with an alternative name
@@ -120,6 +154,9 @@ func (vc *VersionConfiguration) addTypeAlias(name string, alias string) error {
 	// Add the alias as another route to the existing configuration
 	// We skip the duplicate check here since we've already verified above that it's safe
 	vc.types[strings.ToLower(alias)] = tc
+	// Any cached "known absent" entry for `alias` (populated by the findType(alias) call above)
+	// must be discarded so subsequent lookups resolve to `tc`.
+	vc.invalidateTypeCache()
 	return nil
 }
 


### PR DESCRIPTION
Improve the performance of the code generator's configuration lookups.

The generator consults `ObjectModelConfiguration` a very large number of times during code generation — every pipeline stage that walks resources or properties asks the same handful of type/property attributes for each item. All of those lookups fan out through the visitor hierarchy, and each one paid a cost for work that was already known.

Two focused changes here, both preserving existing semantics; a benchmark added first captures the baseline and makes the improvement measurable.

## Changes

**1. `test(config): add lookup benchmarks for ObjectModelConfiguration`**

Adds `go test -bench` coverage for the hot paths: `TypeAccess.Lookup` hit/miss, `PropertyAccess.Lookup` hit/miss, `IsTypeConfigured`, and a "repeated same name" variant that highlights redundant work.

**2. `perf(typo): fast-path AddTerm when the term is already known`**

`typo.Advisor.AddTerm` was called on every `findGroup`/`findVersion`/`findType`/`findProperty` and always took the exclusive lock, even though the same terms are added many thousands of times over during a run. Take the read lock and check for membership first; only escalate to the write lock the first time each unique term is seen.

**3. `perf(config): cache findGroup and findType resolutions`**

Add per-level resolution caches (`ObjectModelConfiguration.groupCache`, `VersionConfiguration.typeCache`), keyed on the raw name from the caller so that a hit also skips the `strings.ToLower` allocation. Nil values record known-absent lookups. Populated lazily, protected by an `sync.RWMutex`, and invalidated by `addGroup`/`addType`/`addTypeAlias` so that late additions from tests remain observable. The visitor hierarchy is unchanged, so `MetaType` wrapping semantics are preserved.

## Benchmark results

Measured on this machine (Intel i9-13900H, Go 1.26); all numbers are ns/op, B/op, allocs/op.

| Benchmark | Baseline | After (both changes) | Δ |
| --- | --- | --- | --- |
| `TypeAccess_Lookup_Hit` | 255.8 ns · 48 B · 3 allocs | 147.6 ns · 40 B · 2 allocs | **-42%** |
| `TypeAccess_Lookup_Miss` | 244.6 ns · 64 B · 3 allocs | 147.8 ns · 40 B · 2 allocs | **-40%** |
| `PropertyAccess_Lookup_Hit` | 540.5 ns · 80 B · 5 allocs | 285.0 ns · 72 B · 4 allocs | **-47%** |
| `PropertyAccess_Lookup_Miss` | 386.7 ns · 88 B · 5 allocs | 283.4 ns · 80 B · 4 allocs | **-27%** |
| `IsTypeConfigured` | 223.3 ns · 32 B · 3 allocs | 137.3 ns · 17 B · 2 allocs | **-38%** |
| `TypeAccess_Lookup_RepeatedSameName` | 235.6 ns · 48 B · 3 allocs | 136.8 ns · 40 B · 2 allocs | **-42%** |

## Testing

* `task generator:quick-checks` passes (unit tests, header check, specifier check, and lint all green).
* `typo` package tests pass.

## Notes

* No behavioural change is intended — the typo advisor still records the same set of terms and still generates the same suggestions; the cache always returns the same `*Configuration` pointers that the un-cached walk would have.
* Bypassing the visitor pattern for single-target lookups was considered but not pursued in this PR, per feedback that it would interact badly with `MetaType` wrappers (`ValidatedType`, `FlaggedType`) around `ObjectType`.
