### PR TITLE
Improve diagnostics for $resourceEmbeddedInParent

### DIFF
--- a/v2/tools/generator/internal/codegen/embeddedresources/remover.go
+++ b/v2/tools/generator/internal/codegen/embeddedresources/remover.go
@@ -396,7 +396,8 @@ func findResourcesEmbeddedInParent(
 				"in package %s cannot find %s parent %s",
 				name.InternalPackageReference(),
 				name.Name(),
-				parentTypeName.Name())
+				parentTypeName.Name(),
+			)
 			errs = append(errs, err)
 			continue
 		}

--- a/v2/tools/generator/internal/codegen/embeddedresources/remover.go
+++ b/v2/tools/generator/internal/codegen/embeddedresources/remover.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
+	"github.com/Azure/azure-service-operator/v2/internal/util/typo"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/config"
 )
@@ -372,7 +373,30 @@ func findResourcesEmbeddedInParent(
 
 		parentTypeName := name.WithName(parentResource)
 		if !defs.Contains(parentTypeName) {
-			err := eris.Errorf("in package %s cannot find %s parent %s", name.InternalPackageReference(), name.Name(), parentTypeName.Name())
+			// Create a typoAdvisor with all the available resources in this package to help the user find the correct parent type name
+			// Note that we only use the type names in this package, as the parent resource must be in the same package as the child resource
+			typoAdvisor := typo.NewAdvisor()
+			for typeName, typeDef := range defs {
+				if !typeName.InternalPackageReference().Equals(name.InternalPackageReference()) {
+					continue
+				}
+
+				if objectDef, ok := astmodel.AsObjectType(typeDef.Type()); ok && objectDef.IsResource() {
+					typoAdvisor.AddTerm(typeName.Name())
+					continue
+				}
+
+				if _, ok := astmodel.AsResourceType(typeDef.Type()); ok {
+					typoAdvisor.AddTerm(typeName.Name())
+				}
+			}
+
+			err := typoAdvisor.Errorf(
+				parentTypeName.Name(),
+				"in package %s cannot find %s parent %s",
+				name.InternalPackageReference(),
+				name.Name(),
+				parentTypeName.Name())
 			errs = append(errs, err)
 			continue
 		}

--- a/v2/tools/generator/internal/codegen/embeddedresources/remover_test.go
+++ b/v2/tools/generator/internal/codegen/embeddedresources/remover_test.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package embeddedresources
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/config"
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/test"
+)
+
+func TestFindResourcesEmbeddedInParent_WhenParentTypeMissing_ReturnsTypoSuggestion(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	pkg := test.MakeLocalPackageReference("network", "2020-01-01")
+	childName := astmodel.MakeInternalTypeName(pkg, "Subnet")
+	parentName := astmodel.MakeInternalTypeName(pkg, "VirtualNetwork")
+
+	defs := make(astmodel.TypeDefinitionSet)
+	defs.Add(astmodel.MakeTypeDefinition(childName, astmodel.NewObjectType().WithIsResource(true)))
+	defs.Add(astmodel.MakeTypeDefinition(parentName, astmodel.NewObjectType().WithIsResource(true)))
+
+	cfg := config.NewConfiguration()
+	err := cfg.ObjectModelConfiguration.ModifyType(
+		childName,
+		func(tc *config.TypeConfiguration) error {
+			tc.ResourceEmbeddedInParent.Set("VirtalNetwork")
+			return nil
+		},
+	)
+	g.Expect(err).To(Succeed())
+
+	_, err = findResourcesEmbeddedInParent(cfg, defs)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("did you mean VirtualNetwork"))
+}


### PR DESCRIPTION
## What this PR does

Adds a typo-suggestion when the code generator fails to find a parent requested by `$resourceEmbededInParent`.

Resource embedding happens before applying export rules, so the name specified for `$resourceEmbededInParent` has to be the "raw" one generated by our initial import stage. 

Sometimes the name here isn't obvious, so I've applied our existing typoAdvisor to make a suggestion (new text bolded):

> error generating code: 
> failed to execute stage 19: 
> Remove properties that point to embedded resources: 
> couldn't find all resources embedded in parent: 
> in package github.com/Azure/azure-service-operator/v2/api/network/v1api20220401 cannot find Endpoint_STATUS parent TrafficManagerProfile **(did you mean Trafficmanagerprofile?)**

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZGg2ZWNpb2piNW4wa2wxNjVwM3JqcnQwbGRrY2VtYjR0NXMxbjlrNCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/453QsWPQj5bsQaqp8M/giphy.gif)

