### PR TITLE
Classify ScopeLocked ARM errors as fatal rather than retryable

### DIFF
--- a/v2/internal/reconcilers/arm/error_classifier.go
+++ b/v2/internal/reconcilers/arm/error_classifier.go
@@ -66,6 +66,7 @@ func classifyCloudError(err *genericarmclient.CloudError) core.ErrorClassificati
 		return core.ErrorRetryable
 	case "BadRequestFormat",
 		"Conflict",
+		"ScopeLocked", // Returned when a CanNotDelete/ReadOnly management lock blocks the operation. Needs a human to remove the lock; won't resolve by itself, so this belongs with Conflict rather than the retryable bucket. See issue #3756.
 		"BadRequest",
 		"PublicIpForGatewayIsRequired", // TODO: There's not a great way to look at an arbitrary error returned by this API and determine if it's a 4xx or 5xx level... ugh
 		"InvalidParameter",

--- a/v2/internal/reconcilers/arm/error_classifier_test.go
+++ b/v2/internal/reconcilers/arm/error_classifier_test.go
@@ -26,6 +26,10 @@ var http400Error = genericarmclient.NewCloudError(&azcore.ResponseError{StatusCo
 
 var unknownError = genericarmclient.NewTestCloudError("ThisCodeIsNotACodeUnderstoodByTheClassifier", "No idea what went wrong")
 
+// scopeLockedError mirrors the error ARM actually returns when a CanNotDelete management lock blocks an
+// operation, confirmed against a live subscription: HTTP 409, code ScopeLocked.
+var scopeLockedError = genericarmclient.NewTestCloudError("ScopeLocked", "The scope '/subscriptions/.../resourceGroups/example' cannot perform delete operation because following scope(s) are locked: '/subscriptions/.../resourceGroups/example'. Please remove the lock and try again.")
+
 func Test_NilError_IsRetryable(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
@@ -84,6 +88,18 @@ func Test_UnknownError_IsRetryable(t *testing.T) {
 		Message:        unknownError.Message(),
 	}
 	g.Expect(arm.ClassifyCloudError(unknownError)).To(Equal(expected))
+}
+
+func Test_ScopeLocked_IsFatal(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	expected := core.CloudErrorDetails{
+		Classification: core.ErrorFatal,
+		Code:           scopeLockedError.Code(),
+		Message:        scopeLockedError.Message(),
+	}
+	g.Expect(arm.ClassifyCloudError(scopeLockedError)).To(Equal(expected))
 }
 
 func Test_HTTP400_IsFatal(t *testing.T) {


### PR DESCRIPTION
## What this PR does

When a `CanNotDelete` or `ReadOnly` management lock blocks an operation, ARM returns HTTP `409` with the code `ScopeLocked`. Right now that code isn't in the classifier's `switch` in `error_classifier.go`, so it falls through to `classifyHTTPError`; since 409 isn't 400, it ends up classified as retryable. The effect is that ASO keeps retrying an operation that can't succeed until someone removes the lock, and the Ready condition shows up as a `Warning` rather than an `Error`.

This moves `ScopeLocked` into the fatal bucket next to `Conflict`, so the Ready condition is surfaced with `Error` severity, which is more accurate for a state that won't resolve on its own. The ARM error message (which already names the lock) is still shown either way.

I confirmed against a live subscription that the code returned is `ScopeLocked` with HTTP 409, and added a unit test that mirrors the existing classifier tests.

refs #3756

## How does this PR make you feel?

![gif](https://media.giphy.com/media/3o7abKhOpu0NwenH3O/giphy.gif)

## Checklist

- [x] Added unit test(s)
- [x] `gofmt`, `go vet`, and `golangci-lint` clean on the changed package
- [x] Full `./internal/reconcilers/arm/...` test suite passes
