### PR TITLE
fix: remove ok-to-test concurrency

### DIFF
--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -8,10 +8,6 @@ on:
 
 permissions: {}
 
-concurrency:
-  group: ok-to-test-${{ github.event.issue.number }}
-  cancel-in-progress: true
-
 jobs:
   ok-to-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This resulted in the job being cancelled after every PR comment.

## Checklist

<!--
_Delete any that don't apply. For completed items, change [ ] to [x]._
-->

- [ ] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
