### PR TITLE
chore: Update `codeql-action` actions and group for future updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -73,4 +73,3 @@ updates:
       codeql-action:
         patterns:
           - "github/codeql-action/*"
-      

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,4 +69,8 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore"
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"
       

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # pinned to v4.37.0
+      uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # pinned to v4.37.1
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -77,7 +77,7 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # pinned to v4.37.0
+      uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # pinned to v4.37.1
       with:
         category: "/language:${{matrix.language}}"
       timeout-minutes: 60


### PR DESCRIPTION
## What this PR does

Groups current dependabot updates for both the `codeql-action/init` and `codeql-action/analyze` actions so that they can merge (they are a matched pair), replacing #5555 and #5557.

Also updates the dependabot configuration to group these together next time, hopefully avoiding the need for a manual PR to update them.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExY2plMzE0NmttMXhpY25vOTQ3eTU1dmthc3U1NXo1dnE3ODRvZXJqeCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/AhAysobj49aqQ/giphy.gif)
