### PR TITLE
fix: avoid rebuilding generator on commit changes

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -322,7 +322,9 @@ tasks:
     desc: Generate the {{.GENERATOR_APP}} binary.
     dir: '{{.GENERATOR_ROOT}}'
     cmds:
-      - go build {{.LDFLAGS}} -o ../../bin/{{.GENERATOR_APP}} .
+      # Not passing LDFLAGS here as embedding the version in the generator causes frequent rebuilds during local development
+      # that are unnecessary
+      - go build -o ../../bin/{{.GENERATOR_APP}} .
 
   # Stub retained until migration of workflows complete
   generator:diagrams:

--- a/v2/tools/generator/internal/codegen/code_generator.go
+++ b/v2/tools/generator/internal/codegen/code_generator.go
@@ -15,7 +15,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/rotisserie/eris"
 
-	"github.com/Azure/azure-service-operator/v2/internal/version"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/codegen/pipeline"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/config"
@@ -272,7 +271,7 @@ func createAllPipelineStages(
 	}
 }
 
-// Generate produces the Go code corresponding to the configured JSON schema in the given output folder
+// Generate produces the Go code for the configured resources in the given output folder
 // ctx is used to cancel the generation process.
 // log is used to log progress.
 func (generator *CodeGenerator) Generate(
@@ -280,8 +279,7 @@ func (generator *CodeGenerator) Generate(
 	log logr.Logger,
 ) error {
 	log.V(1).Info(
-		"ASO Code Generator",
-		"version", version.BuildVersion,
+		"ASO Code Generator, running...",
 	)
 
 	if generator.debugSettings != nil {

--- a/v2/tools/generator/root.go
+++ b/v2/tools/generator/root.go
@@ -14,7 +14,6 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 
-	"github.com/Azure/azure-service-operator/v2/internal/version"
 	"github.com/Azure/azure-service-operator/v2/pkg/xcontext"
 )
 
@@ -55,7 +54,6 @@ func newRootCommand() (*cobra.Command, error) {
 	cmdFuncs := []func() (*cobra.Command, error){
 		NewGenTypesCommand,
 		NewGenKustomizeCommand,
-		version.NewCommand,
 	}
 
 	for _, f := range cmdFuncs {


### PR DESCRIPTION
We were not really using the version command of the generator, nor does the version really do much good in the generator, as it is not a tool we ship externally.

This change avoids the situation where when recording tests or performing other tasks we:

1. Run the generator initially to get in-sync with the branch. This runs task controller:generate-types because azure-arm.yaml and friends have changed (we changed to this branch).
2. Run some tests, possibly to record something.
3. Run some more tests, except at this point the generator is rebuilt because the git repo is now "dirty", which changes the version and results in a changed generator executable. This triggers an unncessary re-run of the costly controller:generate-types step.

By not embedding the version in the generator we avoid the second controller:generate-types and make local iteration faster.

## Checklist

<!--
_Delete any that don't apply. For completed items, change [ ] to [x]._
-->

- [ ] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
