### PR TITLE
feat: support additional labels on managed CRDs

### DIFF
--- a/v2/charts/azure-service-operator/templates/apps_v1_deployment_azureserviceoperator-controller-manager.yaml
+++ b/v2/charts/azure-service-operator/templates/apps_v1_deployment_azureserviceoperator-controller-manager.yaml
@@ -64,6 +64,7 @@ spec:
         - --v=2
         {{- if and (eq .Values.installCRDs true) (or (eq .Values.multitenant.enable false) (eq .Values.azureOperatorMode "webhooks")) }}
         - --crd-pattern={{ if kindIs "slice" .Values.crdPattern }}{{ join ";" .Values.crdPattern }}{{ else }}{{ .Values.crdPattern }}{{ end }}
+        - --crd-labels={{ if kindIs "slice" .Values.crdLabels }}{{ join "," .Values.crdLabels }}{{ else }}{{ .Values.crdLabels }}{{ end }}
         {{- end }}
         - --webhook-port={{ .Values.webhook.port }}
         {{- if or (eq .Values.multitenant.enable false) (eq .Values.azureOperatorMode "webhooks") }}

--- a/v2/charts/azure-service-operator/values.yaml
+++ b/v2/charts/azure-service-operator/values.yaml
@@ -149,6 +149,23 @@ installCRDs: true
 # See https://azure.github.io/azure-service-operator/guide/crd-management for more details.
 crdPattern: ""
 
+# crdLabels is a comma-delimited (or semicolon-delimited) string, or a list of key=value strings, containing
+# additional labels to apply to all CRDs managed by ASO.
+# Setting this has no effect if installCRDs is false.
+# Existing labels not managed by ASO are preserved when CRDs are upgraded. Note that removing a label from this
+# list does not remove it from CRDs already in the cluster.
+# Labels reserved by ASO itself (app.kubernetes.io/name, app.kubernetes.io/version and any label prefixed with
+# serviceoperator.azure.com/) cannot be set here and will be rejected at startup.
+# Example: "cluster.x-k8s.io/provider=infrastructure-azure"
+# Example: "cluster.x-k8s.io/provider=infrastructure-azure,environment=production" would apply both labels.
+# Example: "cluster.x-k8s.io/provider=infrastructure-azure;environment=production" is equivalent, using the
+# semicolon delimiter also accepted by crdPattern.
+# Example as a list:
+#   crdLabels:
+#     - cluster.x-k8s.io/provider=infrastructure-azure
+#     - environment=production
+crdLabels: ""
+
 useJSONLogging: false
 
 # deploymentAnnotations contain the deployment annotations for Azure Service Operator

--- a/v2/cmd/asoctl/internal/crd/cleaner.go
+++ b/v2/cmd/asoctl/internal/crd/cleaner.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/Azure/azure-service-operator/v2/internal/crdmanagement"
+	asolabels "github.com/Azure/azure-service-operator/v2/pkg/common/labels"
 )
 
 type Cleaner struct {
@@ -64,7 +65,11 @@ func (c *Cleaner) Run(ctx context.Context) error {
 		c.log.Info("Starting update")
 	}
 
-	appLabelRequirement, err := labels.NewRequirement(crdmanagement.ServiceOperatorAppLabel, selection.Equals, []string{crdmanagement.ServiceOperatorAppValue})
+	appLabelRequirement, err := labels.NewRequirement(
+		asolabels.ServiceOperatorAppLabel,
+		selection.Equals,
+		[]string{asolabels.ServiceOperatorAppValue},
+	)
 	if err != nil {
 		return err
 	}
@@ -75,7 +80,11 @@ func (c *Cleaner) Run(ctx context.Context) error {
 		return eris.Wrap(err, "failed to list CRDs")
 	}
 
-	versionLabelRequirement, err := labels.NewRequirement(crdmanagement.ServiceOperatorVersionLabelOld, selection.Exists, []string{})
+	versionLabelRequirement, err := labels.NewRequirement(
+		asolabels.ServiceOperatorVersionLabelOld,
+		selection.Exists,
+		[]string{},
+	)
 	if err != nil {
 		return err
 	}

--- a/v2/cmd/controller/app/flags.go
+++ b/v2/cmd/controller/app/flags.go
@@ -8,6 +8,11 @@ package app
 import (
 	"flag"
 	"fmt"
+
+	"github.com/rotisserie/eris"
+
+	"github.com/Azure/azure-service-operator/v2/internal/crdmanagement"
+	"github.com/Azure/azure-service-operator/v2/internal/labels"
 )
 
 type Flags struct {
@@ -21,11 +26,29 @@ type Flags struct {
 	EnableLeaderElection bool
 	CRDManagementMode    string
 	CRDPatterns          string // This is a ';' delimited string containing a collection of patterns
+	CRDLabels            string // This is a ',' or ';' delimited string containing labels to apply to managed CRDs
+}
+
+// parseCRDLabels parses the --crd-labels flag, rejecting any label reserved for ASO's own use.
+func parseCRDLabels(value string) (map[string]string, error) {
+	result, err := labels.ParseMap(value)
+	if err != nil {
+		return nil, err
+	}
+
+	// Done as a separate pass so that the general purpose label parsing stays free of CRD specific rules.
+	for key := range result {
+		if crdmanagement.IsReservedLabel(key) {
+			return nil, eris.Errorf("label %q is reserved for use by Azure Service Operator and cannot be overridden", key)
+		}
+	}
+
+	return result, nil
 }
 
 func (f Flags) String() string {
 	return fmt.Sprintf(
-		"MetricsAddr: %s, SecureMetrics: %t, ProfilingMetrics: %t, MetricsCertDir: %s, HealthAddr: %s, WebhookPort: %d, WebhookCertDir: %s, EnableLeaderElection: %t, CRDManagementMode: %s, CRDPatterns: %s",
+		"MetricsAddr: %s, SecureMetrics: %t, ProfilingMetrics: %t, MetricsCertDir: %s, HealthAddr: %s, WebhookPort: %d, WebhookCertDir: %s, EnableLeaderElection: %t, CRDManagementMode: %s, CRDPatterns: %s, CRDLabels: %s",
 		f.MetricsAddr,
 		f.SecureMetrics,
 		f.ProfilingMetrics,
@@ -36,6 +59,7 @@ func (f Flags) String() string {
 		f.EnableLeaderElection,
 		f.CRDManagementMode,
 		f.CRDPatterns,
+		f.CRDLabels,
 	)
 }
 
@@ -55,6 +79,7 @@ func InitFlags(flagSet *flag.FlagSet) *Flags {
 	flagSet.StringVar(&result.CRDManagementMode, "crd-management", "auto",
 		"Instructs the operator on how it should manage the Custom Resource Definitions. One of 'auto', 'none'")
 	flagSet.StringVar(&result.CRDPatterns, "crd-pattern", "", "Install these CRDs. CRDs already in the cluster will also always be upgraded.")
+	flagSet.StringVar(&result.CRDLabels, "crd-labels", "", "Comma-separated (or semicolon-separated) labels to apply to all managed CRDs (for example, example.com/owner=aso,environment=production). Labels reserved by the operator (app.kubernetes.io/name, app.kubernetes.io/version and the serviceoperator.azure.com/ prefix) cannot be set.")
 
 	return result
 }

--- a/v2/cmd/controller/app/flags_test.go
+++ b/v2/cmd/controller/app/flags_test.go
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package app
+
+import (
+	"flag"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestCRDLabelsFlag(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	flags := InitFlags(flagSet)
+
+	g.Expect(flagSet.Parse([]string{"--crd-labels=cluster.x-k8s.io/provider=infrastructure-azure,example.com/owner=aso"})).To(Succeed())
+	g.Expect(flags.CRDLabels).To(Equal("cluster.x-k8s.io/provider=infrastructure-azure,example.com/owner=aso"))
+
+	parsed, err := parseCRDLabels(flags.CRDLabels)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(parsed).To(HaveLen(2))
+	g.Expect(parsed).To(HaveKeyWithValue("cluster.x-k8s.io/provider", "infrastructure-azure"))
+	g.Expect(parsed).To(HaveKeyWithValue("example.com/owner", "aso"))
+}
+
+// TestParseCRDLabels covers the CRD specific behaviour layered on top of labels.ParseMap.
+// General label parsing and validation is covered by TestParseMap in the labels package.
+func TestParseCRDLabels(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		value         string
+		expected      map[string]string
+		expectedError string
+	}{
+		"empty": {
+			value:    "",
+			expected: map[string]string{},
+		},
+		"reserved app label": {
+			value:         "app.kubernetes.io/name=mine",
+			expectedError: `label "app.kubernetes.io/name" is reserved`,
+		},
+		"reserved version label": {
+			value:         "app.kubernetes.io/version=v1.0.0",
+			expectedError: `label "app.kubernetes.io/version" is reserved`,
+		},
+		"reserved old version label": {
+			value:         "serviceoperator.azure.com/version=v1.0.0",
+			expectedError: `label "serviceoperator.azure.com/version" is reserved`,
+		},
+		"reserved prefix": {
+			value:         "serviceoperator.azure.com/anything=value",
+			expectedError: `label "serviceoperator.azure.com/anything" is reserved`,
+		},
+		"reserved label alongside a valid one": {
+			value:         "example.com/owner=aso,app.kubernetes.io/name=mine",
+			expectedError: `label "app.kubernetes.io/name" is reserved`,
+		},
+		"reserved label with surrounding whitespace": {
+			value:         " app.kubernetes.io/version = v1.0.0 ",
+			expectedError: `label "app.kubernetes.io/version" is reserved`,
+		},
+		"unreserved app.kubernetes.io label": {
+			value:    "app.kubernetes.io/part-of=platform",
+			expected: map[string]string{"app.kubernetes.io/part-of": "platform"},
+		},
+		"valid labels are passed through": {
+			value:    "environment=production;example.com/owner=aso",
+			expected: map[string]string{"environment": "production", "example.com/owner": "aso"},
+		},
+		"parse errors are propagated": {
+			value:         "not a label=value",
+			expectedError: `invalid label key "not a label"`,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			actual, err := parseCRDLabels(c.value)
+
+			if c.expectedError != "" {
+				g.Expect(err).To(MatchError(ContainSubstring(c.expectedError)))
+				return
+			}
+
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(actual).To(HaveLen(len(c.expected)))
+			for key, value := range c.expected {
+				g.Expect(actual).To(HaveKeyWithValue(key, value))
+			}
+		})
+	}
+}

--- a/v2/cmd/controller/app/setup.go
+++ b/v2/cmd/controller/app/setup.go
@@ -158,6 +158,14 @@ func SetupControllerManager(ctx context.Context, setupLog logr.Logger, flgs *Fla
 		os.Exit(1)
 	}
 
+	// Parse the configured CRD labels regardless of CRD management mode, so that a misconfiguration
+	// fails fast rather than only when this pod is later switched into webhooks mode.
+	crdLabels, err := parseCRDLabels(flgs.CRDLabels)
+	if err != nil {
+		setupLog.Error(err, "failed to parse CRD labels")
+		os.Exit(1)
+	}
+
 	switch flgs.CRDManagementMode {
 	case "auto":
 		// We only apply CRDs if we're in webhooks mode. No other mode will have CRD CRUD permissions
@@ -165,6 +173,7 @@ func SetupControllerManager(ctx context.Context, setupLog logr.Logger, flgs *Fla
 			// Note that this step will restart the pod when it succeeds
 			err = crdManager.Install(ctx, crdmanagement.Options{
 				CRDPatterns:  flgs.CRDPatterns,
+				CRDLabels:    crdLabels,
 				ExistingCRDs: &existingCRDs,
 				Path:         crdmanagement.CRDLocation,
 				Namespace:    cfg.PodNamespace,

--- a/v2/config/manager/manager.yaml
+++ b/v2/config/manager/manager.yaml
@@ -47,6 +47,7 @@ spec:
         - --enable-leader-election
         - --v=2
         - --crd-pattern=
+        - --crd-labels=
         ports:
           - containerPort: 8081
             name: health-port

--- a/v2/internal/crdmanagement/crd_installation_instruction.go
+++ b/v2/internal/crdmanagement/crd_installation_instruction.go
@@ -14,9 +14,10 @@ import (
 type DiffResult string
 
 const (
-	NoDifference     = DiffResult("NoDifference")
-	SpecDifferent    = DiffResult("SpecDifferent")
-	VersionDifferent = DiffResult("VersionDifferent")
+	NoDifference      = DiffResult("NoDifference")
+	SpecDifferent     = DiffResult("SpecDifferent")
+	VersionDifferent  = DiffResult("VersionDifferent")
+	MetadataDifferent = DiffResult("MetadataDifferent")
 )
 
 func (i DiffResult) DiffReason(crd apiextensions.CustomResourceDefinition) string {
@@ -27,6 +28,8 @@ func (i DiffResult) DiffReason(crd apiextensions.CustomResourceDefinition) strin
 		return fmt.Sprintf("The spec was different between existing and goal CRD %q", makeMatchString(crd))
 	case VersionDifferent:
 		return fmt.Sprintf("The version was different between existing and goal CRD %q", makeMatchString(crd))
+	case MetadataDifferent:
+		return fmt.Sprintf("The metadata was different between existing and goal CRD %q", makeMatchString(crd))
 	default:
 		return fmt.Sprintf("Unknown DiffResult %q", i)
 	}

--- a/v2/internal/crdmanagement/manager.go
+++ b/v2/internal/crdmanagement/manager.go
@@ -30,16 +30,23 @@ import (
 
 	"github.com/Azure/azure-service-operator/v2/internal/util/kubeclient"
 	"github.com/Azure/azure-service-operator/v2/internal/util/match"
+	asolabels "github.com/Azure/azure-service-operator/v2/pkg/common/labels"
 )
 
-// ServiceOperatorVersionLabelOld is the label the CRDs have on them containing the ASO version. This value must match the value
-// injected by config/crd/labels.yaml
-const (
-	ServiceOperatorVersionLabelOld = "serviceoperator.azure.com/version"
-	ServiceOperatorVersionLabel    = "app.kubernetes.io/version"
-	ServiceOperatorAppLabel        = "app.kubernetes.io/name"
-	ServiceOperatorAppValue        = "azure-service-operator"
-)
+// IsReservedLabel returns true if the given label key is reserved for ASO's own use and so may not be
+// set by the user. Overwriting these labels would break CRD discovery (ListCRDs matches on
+// ServiceOperatorAppLabel) or CRD upgrade detection (VersionEqual compares ServiceOperatorVersionLabel).
+// Surrounding whitespace is ignored so that the result doesn't depend on the caller having trimmed the key.
+func IsReservedLabel(key string) bool {
+	key = strings.TrimSpace(key)
+
+	switch key {
+	case asolabels.ServiceOperatorAppLabel, asolabels.ServiceOperatorVersionLabel, asolabels.ServiceOperatorVersionLabelOld:
+		return true
+	}
+
+	return strings.HasPrefix(key, asolabels.ServiceOperatorLabelPrefix)
+}
 
 const CRDLocation = "crds"
 
@@ -163,7 +170,11 @@ func (m *Manager) ListCRDs(ctx context.Context, list *apiextensions.CustomResour
 	list.ResourceVersion = ""
 
 	selector := labels.NewSelector()
-	requirement, err := labels.NewRequirement(ServiceOperatorAppLabel, selection.Equals, []string{ServiceOperatorAppValue})
+	requirement, err := labels.NewRequirement(
+		asolabels.ServiceOperatorAppLabel,
+		selection.Equals,
+		[]string{asolabels.ServiceOperatorAppValue},
+	)
 	if err != nil {
 		return err
 	}
@@ -323,6 +334,18 @@ func (m *Manager) DetermineCRDsToInstallOrUpgrade(
 		result.DiffResult = VersionDifferent
 	}
 
+	goalCRDsWithDifferentMetadata := m.FindNonMatchingCRDs(existingCRDs, filteredGoalCRDs, DesiredMetadataEqual)
+	for name := range goalCRDsWithDifferentMetadata {
+		result, ok := resultMap[name]
+		if !ok {
+			return nil, eris.Errorf("Couldn't find goal CRD %q. This is unexpected!", name)
+		}
+
+		if result.DiffResult == NoDifference {
+			result.DiffResult = MetadataDifferent
+		}
+	}
+
 	// Collapse result to a slice
 	results := maps.Values(resultMap)
 	return results, nil
@@ -392,8 +415,10 @@ func (m *Manager) applyCRDs(
 
 		result, err := controllerutil.CreateOrUpdate(ctx, m.kubeClient, toApply, func() error {
 			resourceVersion := toApply.ResourceVersion
+			existingMetadata := toApply.ObjectMeta
 			*toApply = instruction.CRD
 			toApply.ResourceVersion = resourceVersion
+			mergeCRDMetadata(existingMetadata, toApply)
 
 			return nil
 		})
@@ -427,6 +452,7 @@ type Options struct {
 	Path         string
 	Namespace    string
 	CRDPatterns  string
+	CRDLabels    map[string]string
 	ExistingCRDs *apiextensions.CustomResourceDefinitionList
 }
 
@@ -436,6 +462,7 @@ func (m *Manager) Install(ctx context.Context, options Options) error {
 	if err != nil {
 		return eris.Wrap(err, "failed to load CRDs from disk")
 	}
+	applyCRDLabels(goalCRDs, options.CRDLabels)
 
 	installationInstructions, err := m.DetermineCRDsToInstallOrUpgrade(goalCRDs, options.ExistingCRDs.Items, options.CRDPatterns)
 	if err != nil {
@@ -702,8 +729,8 @@ func VersionEqual(a apiextensions.CustomResourceDefinition, b apiextensions.Cust
 		return false
 	}
 
-	aVersion, aOk := a.Labels[ServiceOperatorVersionLabel]
-	bVersion, bOk := b.Labels[ServiceOperatorVersionLabel]
+	aVersion, aOk := a.Labels[asolabels.ServiceOperatorVersionLabel]
+	bVersion, bOk := b.Labels[asolabels.ServiceOperatorVersionLabel]
 
 	if !aOk && !bOk {
 		return true

--- a/v2/internal/crdmanagement/manager_test.go
+++ b/v2/internal/crdmanagement/manager_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/testcommon"
 	"github.com/Azure/azure-service-operator/v2/internal/util/kubeclient"
 	"github.com/Azure/azure-service-operator/v2/internal/util/to"
+	asolabels "github.com/Azure/azure-service-operator/v2/pkg/common/labels"
 )
 
 /*
@@ -254,6 +255,95 @@ func Test_DetermineCRDsToInstallOrUpgrade(t *testing.T) {
 			},
 		},
 		{
+			name: "Applies CRD when a desired label is missing",
+			goal: func() []apiextensions.CustomResourceDefinition {
+				crd := makeBasicCRDWithVersion("test", "v1.0.0")
+				crd.Labels["cluster.x-k8s.io/provider"] = "infrastructure-azure"
+				return []apiextensions.CustomResourceDefinition{crd}
+			}(),
+			existing: []apiextensions.CustomResourceDefinition{makeBasicCRDWithVersion("test", "v1.0.0")},
+			patterns: "testrp.azure.com/*",
+			validate: func(g *WithT, instructions []*crdmanagement.CRDInstallationInstruction) {
+				g.Expect(instructions).To(HaveLen(1))
+				g.Expect(instructions[0].DiffResult).To(Equal(crdmanagement.MetadataDifferent))
+				apply, _ := instructions[0].ShouldApply()
+				g.Expect(apply).To(BeTrue())
+			},
+		},
+		{
+			name: "Applies CRD when the cert-manager annotation namespace has drifted",
+			goal: []apiextensions.CustomResourceDefinition{makeBasicCRDWithVersion("test", "v1.0.0")},
+			existing: func() []apiextensions.CustomResourceDefinition {
+				crd := makeBasicCRDWithVersion("test", "v1.0.0")
+				// Simulates the operator having previously been deployed into a different namespace.
+				crd.Annotations["cert-manager.io/inject-ca-from"] = "old-namespace/azureserviceoperator-serving-cert"
+				return []apiextensions.CustomResourceDefinition{crd}
+			}(),
+			patterns: "testrp.azure.com/*",
+			validate: func(g *WithT, instructions []*crdmanagement.CRDInstallationInstruction) {
+				g.Expect(instructions).To(HaveLen(1))
+				g.Expect(instructions[0].DiffResult).To(Equal(crdmanagement.MetadataDifferent))
+				apply, _ := instructions[0].ShouldApply()
+				g.Expect(apply).To(BeTrue())
+			},
+		},
+		{
+			name: "Applies CRD when a desired label has a different value",
+			goal: func() []apiextensions.CustomResourceDefinition {
+				crd := makeBasicCRDWithVersion("test", "v1.0.0")
+				crd.Labels["cluster.x-k8s.io/provider"] = "infrastructure-azure"
+				return []apiextensions.CustomResourceDefinition{crd}
+			}(),
+			existing: func() []apiextensions.CustomResourceDefinition {
+				crd := makeBasicCRDWithVersion("test", "v1.0.0")
+				crd.Labels["cluster.x-k8s.io/provider"] = "stale-value"
+				return []apiextensions.CustomResourceDefinition{crd}
+			}(),
+			patterns: "testrp.azure.com/*",
+			validate: func(g *WithT, instructions []*crdmanagement.CRDInstallationInstruction) {
+				g.Expect(instructions).To(HaveLen(1))
+				g.Expect(instructions[0].DiffResult).To(Equal(crdmanagement.MetadataDifferent))
+				apply, _ := instructions[0].ShouldApply()
+				g.Expect(apply).To(BeTrue())
+			},
+		},
+		{
+			name: "Does not apply CRD when the desired label is already present",
+			goal: func() []apiextensions.CustomResourceDefinition {
+				crd := makeBasicCRDWithVersion("test", "v1.0.0")
+				crd.Labels["cluster.x-k8s.io/provider"] = "infrastructure-azure"
+				return []apiextensions.CustomResourceDefinition{crd}
+			}(),
+			existing: func() []apiextensions.CustomResourceDefinition {
+				crd := makeBasicCRDWithVersion("test", "v1.0.0")
+				crd.Labels["cluster.x-k8s.io/provider"] = "infrastructure-azure"
+				return []apiextensions.CustomResourceDefinition{crd}
+			}(),
+			patterns: "testrp.azure.com/*",
+			validate: func(g *WithT, instructions []*crdmanagement.CRDInstallationInstruction) {
+				g.Expect(instructions).To(HaveLen(1))
+				g.Expect(instructions[0].DiffResult).To(Equal(crdmanagement.NoDifference))
+				apply, _ := instructions[0].ShouldApply()
+				g.Expect(apply).To(BeFalse())
+			},
+		},
+		{
+			name: "Does not apply CRD when an extra label exists only on the existing CRD",
+			goal: []apiextensions.CustomResourceDefinition{makeBasicCRDWithVersion("test", "v1.0.0")},
+			existing: func() []apiextensions.CustomResourceDefinition {
+				crd := makeBasicCRDWithVersion("test", "v1.0.0")
+				crd.Labels["externally-applied"] = "preserved"
+				return []apiextensions.CustomResourceDefinition{crd}
+			}(),
+			patterns: "testrp.azure.com/*",
+			validate: func(g *WithT, instructions []*crdmanagement.CRDInstallationInstruction) {
+				g.Expect(instructions).To(HaveLen(1))
+				g.Expect(instructions[0].DiffResult).To(Equal(crdmanagement.NoDifference))
+				apply, _ := instructions[0].ShouldApply()
+				g.Expect(apply).To(BeFalse())
+			},
+		},
+		{
 			name:     "Pattern matches subset of CRDs from group, only that subset is installed",
 			goal:     []apiextensions.CustomResourceDefinition{makeBasicCRDWithVersion("test1", "v1.0.0"), makeBasicCRDWithVersion("test2", "v1.0.0")},
 			existing: nil,
@@ -308,8 +398,8 @@ func Test_ListCRDs_ListsOnlyCRDsMatchingLabel(t *testing.T) {
 	crd3 := makeBasicCRD("test3")
 
 	crd3.Labels = map[string]string{
-		crdmanagement.ServiceOperatorVersionLabel: "123",
-		crdmanagement.ServiceOperatorAppLabel:     crdmanagement.ServiceOperatorAppValue,
+		asolabels.ServiceOperatorVersionLabel: "123",
+		asolabels.ServiceOperatorAppLabel:     asolabels.ServiceOperatorAppValue,
 	}
 
 	g.Expect(kubeClient.Create(ctx, &crd1)).To(Succeed())
@@ -529,9 +619,38 @@ func makeBasicCRD(name string) apiextensions.CustomResourceDefinition {
 func makeBasicCRDWithVersion(name string, version string) apiextensions.CustomResourceDefinition {
 	crd := makeBasicCRD(name)
 	crd.Labels = map[string]string{
-		crdmanagement.ServiceOperatorVersionLabel: version,
-		crdmanagement.ServiceOperatorAppLabel:     crdmanagement.ServiceOperatorAppValue,
+		asolabels.ServiceOperatorVersionLabel: version,
+		asolabels.ServiceOperatorAppLabel:     asolabels.ServiceOperatorAppValue,
 	}
 
 	return crd
+}
+
+func TestIsReservedLabel(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		key      string
+		expected bool
+	}{
+		"app label":                    {key: asolabels.ServiceOperatorAppLabel, expected: true},
+		"version label":                {key: asolabels.ServiceOperatorVersionLabel, expected: true},
+		"old version label":            {key: asolabels.ServiceOperatorVersionLabelOld, expected: true},
+		"reserved prefix":              {key: asolabels.ServiceOperatorLabelPrefix + "anything", expected: true},
+		"leading whitespace":           {key: " " + asolabels.ServiceOperatorAppLabel, expected: true},
+		"trailing whitespace":          {key: asolabels.ServiceOperatorVersionLabel + " ", expected: true},
+		"surrounding whitespace":       {key: "\t" + asolabels.ServiceOperatorLabelPrefix + "anything\n", expected: true},
+		"unreserved app.kubernetes.io": {key: "app.kubernetes.io/part-of", expected: false},
+		"unreserved prefixed":          {key: "example.com/owner", expected: false},
+		"unreserved bare":              {key: "environment", expected: false},
+		"differing case is distinct":   {key: "app.kubernetes.io/Version", expected: false},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			g.Expect(crdmanagement.IsReservedLabel(c.key)).To(Equal(c.expected))
+		})
+	}
 }

--- a/v2/internal/crdmanagement/metadata.go
+++ b/v2/internal/crdmanagement/metadata.go
@@ -1,0 +1,54 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package crdmanagement
+
+import (
+	"github.com/samber/lo"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// DesiredMetadataEqual returns true when all labels and annotations specified by the desired CRD are present on the existing CRD.
+// Additional metadata on the existing CRD is intentionally ignored and preserved during updates.
+func DesiredMetadataEqual(existing apiextensions.CustomResourceDefinition, desired apiextensions.CustomResourceDefinition) bool {
+	return metadataContains(existing.Labels, desired.Labels) && metadataContains(existing.Annotations, desired.Annotations)
+}
+
+func metadataContains(existing map[string]string, desired map[string]string) bool {
+	for key, value := range desired {
+		// Use a two-value lookup so that a desired empty value is distinguished from a missing key;
+		// a single-value lookup would treat an absent key as matching an empty desired value.
+		existingValue, found := existing[key]
+		if !found || existingValue != value {
+			return false
+		}
+	}
+
+	return true
+}
+
+// mergeMetadata preserves existing metadata while allowing desired metadata to take precedence.
+func mergeMetadata(existing map[string]string, desired map[string]string) map[string]string {
+	return lo.Assign(existing, desired)
+}
+
+func mergeCRDMetadata(existing metav1.ObjectMeta, desired *apiextensions.CustomResourceDefinition) {
+	desired.Labels = mergeMetadata(existing.Labels, desired.Labels)
+	desired.Annotations = mergeMetadata(existing.Annotations, desired.Annotations)
+}
+
+// applyCRDLabels merges the user configured labels into the labels of the CRDs loaded from disk.
+// Labels reserved for ASO's own use are never overwritten, as doing so would break CRD discovery and
+// upgrade detection.
+func applyCRDLabels(crds []apiextensions.CustomResourceDefinition, configuredLabels map[string]string) {
+	safeLabels := lo.OmitBy(configuredLabels, func(key string, _ string) bool {
+		return IsReservedLabel(key)
+	})
+
+	for i := range crds {
+		crds[i].Labels = mergeMetadata(crds[i].Labels, safeLabels)
+	}
+}

--- a/v2/internal/crdmanagement/metadata_test.go
+++ b/v2/internal/crdmanagement/metadata_test.go
@@ -1,0 +1,198 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package crdmanagement
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	asolabels "github.com/Azure/azure-service-operator/v2/pkg/common/labels"
+)
+
+func TestMergeCRDMetadata(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	desired := &apiextensions.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"managed-label": "desired",
+			},
+			Annotations: map[string]string{
+				"managed-annotation": "desired",
+			},
+		},
+	}
+	existing := metav1.ObjectMeta{
+		Labels: map[string]string{
+			"external-label": "preserved",
+			"managed-label":  "old",
+		},
+		Annotations: map[string]string{
+			"external-annotation": "preserved",
+			"managed-annotation":  "old",
+		},
+	}
+
+	mergeCRDMetadata(existing, desired)
+
+	g.Expect(desired.Labels).To(HaveLen(2))
+	g.Expect(desired.Labels).To(HaveKeyWithValue("external-label", "preserved"))
+	g.Expect(desired.Labels).To(HaveKeyWithValue("managed-label", "desired"))
+	g.Expect(desired.Annotations).To(HaveLen(2))
+	g.Expect(desired.Annotations).To(HaveKeyWithValue("external-annotation", "preserved"))
+	g.Expect(desired.Annotations).To(HaveKeyWithValue("managed-annotation", "desired"))
+}
+
+func TestDesiredMetadataEqual(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		existing metav1.ObjectMeta
+		desired  metav1.ObjectMeta
+		want     bool
+	}{
+		{
+			name: "desired metadata is present alongside unknown metadata",
+			existing: metav1.ObjectMeta{
+				Labels:      map[string]string{"configured": "value", "external": "preserved"},
+				Annotations: map[string]string{"configured": "value", "external": "preserved"},
+			},
+			desired: metav1.ObjectMeta{
+				Labels:      map[string]string{"configured": "value"},
+				Annotations: map[string]string{"configured": "value"},
+			},
+			want: true,
+		},
+		{
+			name:     "configured label is missing",
+			existing: metav1.ObjectMeta{},
+			desired:  metav1.ObjectMeta{Labels: map[string]string{"configured": "value"}},
+			want:     false,
+		},
+		{
+			name:     "managed annotation has a different value",
+			existing: metav1.ObjectMeta{Annotations: map[string]string{"configured": "old"}},
+			desired:  metav1.ObjectMeta{Annotations: map[string]string{"configured": "value"}},
+			want:     false,
+		},
+		{
+			name:     "empty valued label is missing",
+			existing: metav1.ObjectMeta{Labels: map[string]string{"external": "preserved"}},
+			desired:  metav1.ObjectMeta{Labels: map[string]string{"configured": ""}},
+			want:     false,
+		},
+		{
+			name:     "empty valued annotation is missing",
+			existing: metav1.ObjectMeta{},
+			desired:  metav1.ObjectMeta{Annotations: map[string]string{"configured": ""}},
+			want:     false,
+		},
+		{
+			name:     "empty valued label is present",
+			existing: metav1.ObjectMeta{Labels: map[string]string{"configured": ""}},
+			desired:  metav1.ObjectMeta{Labels: map[string]string{"configured": ""}},
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			existing := apiextensions.CustomResourceDefinition{ObjectMeta: tt.existing}
+			desired := apiextensions.CustomResourceDefinition{ObjectMeta: tt.desired}
+			g.Expect(DesiredMetadataEqual(existing, desired)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestApplyCRDLabels(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	crds := []apiextensions.CustomResourceDefinition{
+		{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"bundled": "preserved", "configured": "old"}}},
+		{},
+	}
+
+	applyCRDLabels(crds, map[string]string{"configured": "new"})
+
+	g.Expect(crds[0].Labels).To(HaveLen(2))
+	g.Expect(crds[0].Labels).To(HaveKeyWithValue("bundled", "preserved"))
+	g.Expect(crds[0].Labels).To(HaveKeyWithValue("configured", "new"))
+	g.Expect(crds[1].Labels).To(HaveLen(1))
+	g.Expect(crds[1].Labels).To(HaveKeyWithValue("configured", "new"))
+}
+
+func TestApplyCRDLabelsIgnoresReservedLabels(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	bundledLabels := map[string]string{
+		asolabels.ServiceOperatorAppLabel:     asolabels.ServiceOperatorAppValue,
+		asolabels.ServiceOperatorVersionLabel: "v2.0.0",
+	}
+	crds := []apiextensions.CustomResourceDefinition{
+		{ObjectMeta: metav1.ObjectMeta{Labels: bundledLabels}},
+	}
+
+	configuredLabels := map[string]string{
+		asolabels.ServiceOperatorAppLabel:        "hijacked",
+		asolabels.ServiceOperatorVersionLabel:    "pinned",
+		asolabels.ServiceOperatorVersionLabelOld: "pinned",
+		"example.com/owner":                      "aso",
+	}
+	configuredLabels[asolabels.ServiceOperatorLabelPrefix+"anything"] = "hijacked"
+
+	applyCRDLabels(crds, configuredLabels)
+
+	g.Expect(crds[0].Labels).To(HaveLen(3))
+	g.Expect(crds[0].Labels).To(HaveKeyWithValue(asolabels.ServiceOperatorAppLabel, asolabels.ServiceOperatorAppValue))
+	g.Expect(crds[0].Labels).To(HaveKeyWithValue(asolabels.ServiceOperatorVersionLabel, "v2.0.0"))
+	g.Expect(crds[0].Labels).To(HaveKeyWithValue("example.com/owner", "aso"))
+}
+
+// TestApplyCRDLabelsRemovalIsNotPropagated documents that removing a label from --crd-labels does not
+// remove it from CRDs already in the cluster; mergeCRDMetadata intentionally preserves existing metadata.
+func TestApplyCRDLabelsRemovalIsNotPropagated(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	existing := metav1.ObjectMeta{Labels: map[string]string{"bundled": "preserved", "removed": "old"}}
+	desired := apiextensions.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"bundled": "preserved"}},
+	}
+
+	mergeCRDMetadata(existing, &desired)
+
+	g.Expect(desired.Labels).To(HaveLen(2))
+	g.Expect(desired.Labels).To(HaveKeyWithValue("bundled", "preserved"))
+	g.Expect(desired.Labels).To(HaveKeyWithValue("removed", "old"))
+}
+
+// TestDesiredMetadataEqualDetectsCertManagerNamespaceDrift pins the behaviour that the annotation half of
+// DesiredMetadataEqual is load bearing: ASO ships cert-manager.io/inject-ca-from on every conversion webhook
+// CRD and fixCRDNamespace rewrites its namespace at load time, so a redeploy into a different namespace must
+// be detected as a metadata difference even when the ASO version is unchanged.
+func TestDesiredMetadataEqualDetectsCertManagerNamespaceDrift(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	const annotation = "cert-manager.io/inject-ca-from"
+	existing := apiextensions.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{annotation: "old-namespace/azureserviceoperator-serving-cert"},
+		},
+	}
+	desired := apiextensions.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{annotation: "new-namespace/azureserviceoperator-serving-cert"},
+		},
+	}
+
+	g.Expect(DesiredMetadataEqual(existing, desired)).To(BeFalse())
+	g.Expect(DesiredMetadataEqual(desired, desired)).To(BeTrue())
+}

--- a/v2/internal/labels/parse.go
+++ b/v2/internal/labels/parse.go
@@ -6,18 +6,72 @@
 package labels
 
 import (
+	"strings"
+
 	"github.com/rotisserie/eris"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/Azure/azure-service-operator/v2/internal/annotations"
 )
+
+// Separators are the characters accepted between individual labels by ParseMap. ',' is the canonical
+// separator for label lists, but ';' is accepted too so that label flags can be written the same way as
+// flags which take a ';' delimited list.
+const Separators = ",;"
 
 type Label struct {
 	Key   string
 	Value string
 }
 
+// ParseMap parses a delimited string of key=value labels into a map, validating each label against the
+// Kubernetes label syntax rules. Entries may be separated by any of the characters in Separators, and
+// blank entries are ignored. Whitespace surrounding each key and value is trimmed, so that lists may be
+// written with spaces after the separators. An error is returned if a label is malformed, invalid, or
+// specified twice.
+//
+// Unlike Parse, this applies label validation rather than the more permissive annotation rules.
+func ParseMap(value string) (map[string]string, error) {
+	result := make(map[string]string)
+	if value == "" {
+		return result, nil
+	}
+
+	assignments := strings.FieldsFunc(value, func(r rune) bool {
+		return strings.ContainsRune(Separators, r)
+	})
+
+	for _, assignment := range assignments {
+		if strings.TrimSpace(assignment) == "" {
+			continue
+		}
+
+		key, labelValue, found := strings.Cut(assignment, "=")
+		key = strings.TrimSpace(key)
+		labelValue = strings.TrimSpace(labelValue)
+		if !found || key == "" {
+			return nil, eris.Errorf("label %q must be in key=value form", assignment)
+		}
+		if errs := validation.IsQualifiedName(key); len(errs) > 0 {
+			return nil, eris.Errorf("invalid label key %q: %s", key, strings.Join(errs, "; "))
+		}
+		if errs := validation.IsValidLabelValue(labelValue); len(errs) > 0 {
+			return nil, eris.Errorf("invalid value for label %q: %s", key, strings.Join(errs, "; "))
+		}
+		if _, exists := result[key]; exists {
+			return nil, eris.Errorf("label %q was specified more than once", key)
+		}
+		result[key] = labelValue
+	}
+
+	return result, nil
+}
+
 // Parse parses a label. Amazingly there doesn't seem to be a function in client-go or similar that does this.
 // There does exist an apimachinery labels.Parse but it parses label selectors not labels themselves.
+//
+// Note that this currently applies annotation validation rules, which are more permissive than the rules
+// Kubernetes applies to labels. Prefer ParseMap where strict label validation is wanted.
 func Parse(s string) (Label, error) {
 	// Currently the label restrictions are exactly the same as annotations,
 	// so we can just re-use annotation parse here

--- a/v2/internal/labels/parse_test.go
+++ b/v2/internal/labels/parse_test.go
@@ -50,3 +50,86 @@ func TestParse(t *testing.T) {
 		})
 	}
 }
+
+func TestParseMap(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		value         string
+		expected      map[string]string
+		expectedError string
+	}{
+		"empty": {
+			value:    "",
+			expected: map[string]string{},
+		},
+		"empty label value": {
+			value:    "example.com/owner=",
+			expected: map[string]string{"example.com/owner": ""},
+		},
+		"missing equals": {
+			value:         "example.com/owner",
+			expectedError: `label "example.com/owner" must be in key=value form`,
+		},
+		"selector operator": {
+			value:         "environment!=production",
+			expectedError: `invalid label key "environment!"`,
+		},
+		"invalid key": {
+			value:         "not a label=value",
+			expectedError: `invalid label key "not a label"`,
+		},
+		"invalid value": {
+			value:         "example.com/owner=not a value",
+			expectedError: `invalid value for label "example.com/owner"`,
+		},
+		"duplicate key": {
+			value:         "environment=production,environment=staging",
+			expectedError: `label "environment" was specified more than once`,
+		},
+		"semicolon separated": {
+			value:    "environment=production;example.com/owner=aso",
+			expected: map[string]string{"environment": "production", "example.com/owner": "aso"},
+		},
+		"mixed separators": {
+			value:    "environment=production,example.com/owner=aso;example.com/team=platform",
+			expected: map[string]string{"environment": "production", "example.com/owner": "aso", "example.com/team": "platform"},
+		},
+		"blank entries are ignored": {
+			value:    ",environment=production;; ,",
+			expected: map[string]string{"environment": "production"},
+		},
+		"whitespace around keys and values is trimmed": {
+			value:    " environment = production , example.com/owner = aso ",
+			expected: map[string]string{"environment": "production", "example.com/owner": "aso"},
+		},
+		"duplicate key across separators": {
+			value:         "environment=production;environment=staging",
+			expectedError: `label "environment" was specified more than once`,
+		},
+		"long prefixed key is accepted": {
+			value:    "aaaaaaaaaa.bbbbbbbbbb.cccccccccc.dddddddddd.eeeeeeeeee.ffffffffff.gggg.example.com/owner=aso",
+			expected: map[string]string{"aaaaaaaaaa.bbbbbbbbbb.cccccccccc.dddddddddd.eeeeeeeeee.ffffffffff.gggg.example.com/owner": "aso"},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			actual, err := labels.ParseMap(c.value)
+
+			if c.expectedError != "" {
+				g.Expect(err).To(MatchError(ContainSubstring(c.expectedError)))
+				return
+			}
+
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(actual).To(HaveLen(len(c.expected)))
+			for key, value := range c.expected {
+				g.Expect(actual).To(HaveKeyWithValue(key, value))
+			}
+		})
+	}
+}

--- a/v2/pkg/common/labels/labels.go
+++ b/v2/pkg/common/labels/labels.go
@@ -20,6 +20,21 @@ const (
 	LastReconciledVersionLabel = "serviceoperator.azure.com/last-reconciled-version"
 )
 
+// ServiceOperatorLabelPrefix is the label domain reserved for ASO's own use.
+const ServiceOperatorLabelPrefix = "serviceoperator.azure.com/"
+
+// Labels applied to the CRDs ASO manages. These values must match the values injected by config/crd/labels.yaml.
+const (
+	// ServiceOperatorVersionLabelOld is the legacy label the CRDs have on them containing the ASO version.
+	ServiceOperatorVersionLabelOld = ServiceOperatorLabelPrefix + "version"
+	// ServiceOperatorVersionLabel is the label the CRDs have on them containing the ASO version.
+	ServiceOperatorVersionLabel = "app.kubernetes.io/version"
+	// ServiceOperatorAppLabel is the label used to identify the CRDs managed by ASO.
+	ServiceOperatorAppLabel = "app.kubernetes.io/name"
+	// ServiceOperatorAppValue is the value of ServiceOperatorAppLabel on CRDs managed by ASO.
+	ServiceOperatorAppValue = "azure-service-operator"
+)
+
 // SetOwnerNameLabel sets the owner name label on the given object, or truncates it to 63 characters if it exceeds the character limit.
 func SetOwnerNameLabel(logger logr.Logger, obj genruntime.ARMMetaObject) {
 	if obj.Owner() != nil && obj.Owner().Name != "" {


### PR DESCRIPTION
## What this PR does

Adds a `--crd-labels` flag (`crdLabels` in the Helm chart) so additional labels can be applied to all CRDs ASO manages. Labels not managed by ASO are preserved across CRD upgrades, and labels reserved by ASO (`app.kubernetes.io/name`, `app.kubernetes.io/version`, and the `serviceoperator.azure.com/` prefix) are rejected at startup.

This lets CAPZ label ASO's CRDs with `cluster.x-k8s.io/provider=infrastructure-azure` so they're included in the provider's cached informers, working around the CRD watch timeouts described in kubernetes-sigs/cluster-api-provider-azure#6492.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/3o7abKhOpu0NwenH3O/giphy.gif)

## Checklist

- [x] this PR contains documentation
- [x] this PR contains tests
