### PR TITLE
fix: ensure enum values in golden tests are quoted

### DIFF
--- a/v2/tools/generator/internal/codegen/pipeline/convert_allof_and_oneof_to_objects_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/convert_allof_and_oneof_to_objects_test.go
@@ -36,7 +36,7 @@ var emptyObject = astmodel.NewObjectType()
 func defineEnum(strings ...string) astmodel.Type {
 	values := make([]astmodel.EnumValue, 0, len(strings))
 	for _, value := range strings {
-		values = append(values, astmodel.MakeEnumValue(value, value))
+		values = append(values, astmodel.MakeEnumValue(value, `"`+value+`"`))
 	}
 
 	return astmodel.NewEnumType(
@@ -662,8 +662,8 @@ func Test_ConversionWithNestedAllOfs_ReturnsExpectedResult(t *testing.T) {
 				astmodel.NewPropertyDefinition(
 					"Kind", "kind", astmodel.NewOptionalType(astmodel.NewEnumType(
 						astmodel.StringType,
-						astmodel.MakeEnumValue("MultiStep", "multistep"),
-						astmodel.MakeEnumValue("Ping", "ping"),
+						astmodel.MakeEnumValue("MultiStep", `"multistep"`),
+						astmodel.MakeEnumValue("Ping", `"ping"`),
 					)),
 				),
 				astmodel.NewPropertyDefinition("Properties", "properties", webTestProperties.Name()),
@@ -783,7 +783,7 @@ func TestConversionOfAllOf_WhenContainingOneOf_ReturnsExpectedResult(t *testing.
 				astmodel.NewPropertyDefinition(
 					"Kind",
 					"kind",
-					astmodel.NewEnumType(astmodel.StringType, astmodel.MakeEnumValue("ReadWriteDatabase", "ReadWriteDatabase")),
+					astmodel.NewEnumType(astmodel.StringType, astmodel.MakeEnumValue("ReadWriteDatabase", `"ReadWriteDatabase"`)),
 				),
 				astmodel.NewPropertyDefinition(
 					"Location",
@@ -810,7 +810,7 @@ func TestConversionOfAllOf_WhenContainingOneOf_ReturnsExpectedResult(t *testing.
 				astmodel.NewPropertyDefinition(
 					"Kind",
 					"kind",
-					astmodel.NewEnumType(astmodel.StringType, astmodel.MakeEnumValue("ReadOnlyFollowingDatabase", "ReadOnlyFollowingDatabase")),
+					astmodel.NewEnumType(astmodel.StringType, astmodel.MakeEnumValue("ReadOnlyFollowingDatabase", `"ReadOnlyFollowingDatabase"`)),
 				),
 				astmodel.NewPropertyDefinition(
 					"Location",

--- a/v2/tools/generator/internal/codegen/pipeline/remove_embedded_resources_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/remove_embedded_resources_test.go
@@ -105,15 +105,15 @@ var (
 
 	LionPrideTypeEnumDef = astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(LionsPkg, "LionPrideType"),
-		astmodel.NewEnumType(astmodel.StringType, astmodel.MakeEnumValue("type", "Microsoft.Lions/lionPride")),
+		astmodel.NewEnumType(astmodel.StringType, astmodel.MakeEnumValue("type", `"Microsoft.Lions/lionPride"`)),
 	)
 	LionTypeEnumDef = astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(LionsPkg, "LionType"),
-		astmodel.NewEnumType(astmodel.StringType, astmodel.MakeEnumValue("type", "Microsoft.Lions/lion")),
+		astmodel.NewEnumType(astmodel.StringType, astmodel.MakeEnumValue("type", `"Microsoft.Lions/lion"`)),
 	)
 	LionCubTypeEnumDef = astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(LionsPkg, "LionCubType"),
-		astmodel.NewEnumType(astmodel.StringType, astmodel.MakeEnumValue("type", "Microsoft.Lions/cub")),
+		astmodel.NewEnumType(astmodel.StringType, astmodel.MakeEnumValue("type", `"Microsoft.Lions/cub"`)),
 	)
 	APIVersionTypeEnumDef = astmodel.MakeTypeDefinition(
 		astmodel.MakeInternalTypeName(LionsPkg, "APIVersion"),

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestConversionOfAllOf_WhenContainingOneOf_ReturnsExpectedResult/structure.txt.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestConversionOfAllOf_WhenContainingOneOf_ReturnsExpectedResult/structure.txt.golden
@@ -16,7 +16,7 @@ ReadOnlyFollowingDatabase: Object (5 properties)
 ├── DatabaseShareOrigin: string
 ├── HotCachePeriod: string
 ├── Kind: Enum (1 value)
-│   └── ReadOnlyFollowingDatabase
+│   └── "ReadOnlyFollowingDatabase"
 ├── Location: string
 └── Name: Validated<string> (1 rule)
     └── Rule 0: MaxLength: 96
@@ -25,7 +25,7 @@ ReadWriteDatabase: Object (5 properties)
 ├── HotCachePeriod: string
 ├── KeyVaultURL: string
 ├── Kind: Enum (1 value)
-│   └── ReadWriteDatabase
+│   └── "ReadWriteDatabase"
 ├── Location: string
 └── Name: Validated<string> (1 rule)
     └── Rule 0: MaxLength: 96

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_EmbeddedResourceWithCyclesAndResourceLookalikes_RemovesCycles/lions-v20200601.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_EmbeddedResourceWithCyclesAndResourceLookalikes_RemovesCycles/lions-v20200601.golden
@@ -98,14 +98,14 @@ type LionPrideProperties struct {
 	Right Right_SubResourceEmbedded_1 `json:"right,omitempty"`
 }
 
-// +kubebuilder:validation:Enum={Microsoft.Lions/lionPride}
+// +kubebuilder:validation:Enum={"Microsoft.Lions/lionPride"}
 type LionPrideType string
 
-const LionPrideType_type = LionPrideType(Microsoft.Lions/lionPride)
+const LionPrideType_type = LionPrideType("Microsoft.Lions/lionPride")
 
 // Mapping from string to LionPrideType
 var lionPrideType_Values = map[string]LionPrideType{
-	microsoft.lions/lionpride: LionPrideType_type,
+	"microsoft.lions/lionpride": LionPrideType_type,
 }
 
 type LionProperties struct {
@@ -113,14 +113,14 @@ type LionProperties struct {
 	Right Right `json:"right,omitempty"`
 }
 
-// +kubebuilder:validation:Enum={Microsoft.Lions/lion}
+// +kubebuilder:validation:Enum={"Microsoft.Lions/lion"}
 type LionType string
 
-const LionType_type = LionType(Microsoft.Lions/lion)
+const LionType_type = LionType("Microsoft.Lions/lion")
 
 // Mapping from string to LionType
 var lionType_Values = map[string]LionType{
-	microsoft.lions/lion: LionType_type,
+	"microsoft.lions/lion": LionType_type,
 }
 
 type Left struct {

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_EmbeddedResource_IsRemovedRetainsId/lions-v20200601.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_EmbeddedResource_IsRemovedRetainsId/lions-v20200601.golden
@@ -97,28 +97,28 @@ type LionPrideProperties struct {
 	Lions []LionRef `json:"lions,omitempty"`
 }
 
-// +kubebuilder:validation:Enum={Microsoft.Lions/lionPride}
+// +kubebuilder:validation:Enum={"Microsoft.Lions/lionPride"}
 type LionPrideType string
 
-const LionPrideType_type = LionPrideType(Microsoft.Lions/lionPride)
+const LionPrideType_type = LionPrideType("Microsoft.Lions/lionPride")
 
 // Mapping from string to LionPrideType
 var lionPrideType_Values = map[string]LionPrideType{
-	microsoft.lions/lionpride: LionPrideType_type,
+	"microsoft.lions/lionpride": LionPrideType_type,
 }
 
 type LionProperties struct {
 	RoarVolumeDecibels int `json:"roarVolumeDecibels,omitempty"`
 }
 
-// +kubebuilder:validation:Enum={Microsoft.Lions/lion}
+// +kubebuilder:validation:Enum={"Microsoft.Lions/lion"}
 type LionType string
 
-const LionType_type = LionType(Microsoft.Lions/lion)
+const LionType_type = LionType("Microsoft.Lions/lion")
 
 // Mapping from string to LionType
 var lionType_Values = map[string]LionType{
-	microsoft.lions/lion: LionType_type,
+	"microsoft.lions/lion": LionType_type,
 }
 
 type LionRef struct {

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_EmbeddedResourcesWithMultipleEmbeddings_AllEmbeddingsAreRemovedAndRetainOnlyId/lions-v20200601.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_EmbeddedResourcesWithMultipleEmbeddings_AllEmbeddingsAreRemovedAndRetainOnlyId/lions-v20200601.golden
@@ -137,14 +137,14 @@ type LionCubProperties struct {
 	Cuteness int `json:"cuteness,omitempty"`
 }
 
-// +kubebuilder:validation:Enum={Microsoft.Lions/cub}
+// +kubebuilder:validation:Enum={"Microsoft.Lions/cub"}
 type LionCubType string
 
-const LionCubType_type = LionCubType(Microsoft.Lions/cub)
+const LionCubType_type = LionCubType("Microsoft.Lions/cub")
 
 // Mapping from string to LionCubType
 var lionCubType_Values = map[string]LionCubType{
-	microsoft.lions/cub: LionCubType_type,
+	"microsoft.lions/cub": LionCubType_type,
 }
 
 type LionPrideProperties struct {
@@ -152,14 +152,14 @@ type LionPrideProperties struct {
 	Lions []LionRef `json:"lions,omitempty"`
 }
 
-// +kubebuilder:validation:Enum={Microsoft.Lions/lionPride}
+// +kubebuilder:validation:Enum={"Microsoft.Lions/lionPride"}
 type LionPrideType string
 
-const LionPrideType_type = LionPrideType(Microsoft.Lions/lionPride)
+const LionPrideType_type = LionPrideType("Microsoft.Lions/lionPride")
 
 // Mapping from string to LionPrideType
 var lionPrideType_Values = map[string]LionPrideType{
-	microsoft.lions/lionpride: LionPrideType_type,
+	"microsoft.lions/lionpride": LionPrideType_type,
 }
 
 type LionProperties struct {
@@ -167,14 +167,14 @@ type LionProperties struct {
 	RoarVolumeDecibels int          `json:"roarVolumeDecibels,omitempty"`
 }
 
-// +kubebuilder:validation:Enum={Microsoft.Lions/lion}
+// +kubebuilder:validation:Enum={"Microsoft.Lions/lion"}
 type LionType string
 
-const LionType_type = LionType(Microsoft.Lions/lion)
+const LionType_type = LionType("Microsoft.Lions/lion")
 
 // Mapping from string to LionType
 var lionType_Values = map[string]LionType{
-	microsoft.lions/lion: LionType_type,
+	"microsoft.lions/lion": LionType_type,
 }
 
 type LionCubRef struct {

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_EmbeddedSubresource_IsRemoved/lions-v20200601.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_EmbeddedSubresource_IsRemoved/lions-v20200601.golden
@@ -96,28 +96,28 @@ type LionPrideProperties struct {
 	Hunts int `json:"hunts,omitempty"`
 }
 
-// +kubebuilder:validation:Enum={Microsoft.Lions/lionPride}
+// +kubebuilder:validation:Enum={"Microsoft.Lions/lionPride"}
 type LionPrideType string
 
-const LionPrideType_type = LionPrideType(Microsoft.Lions/lionPride)
+const LionPrideType_type = LionPrideType("Microsoft.Lions/lionPride")
 
 // Mapping from string to LionPrideType
 var lionPrideType_Values = map[string]LionPrideType{
-	microsoft.lions/lionpride: LionPrideType_type,
+	"microsoft.lions/lionpride": LionPrideType_type,
 }
 
 type LionProperties struct {
 	RoarVolumeDecibels int `json:"roarVolumeDecibels,omitempty"`
 }
 
-// +kubebuilder:validation:Enum={Microsoft.Lions/lion}
+// +kubebuilder:validation:Enum={"Microsoft.Lions/lion"}
 type LionType string
 
-const LionType_type = LionType(Microsoft.Lions/lion)
+const LionType_type = LionType("Microsoft.Lions/lion")
 
 // Mapping from string to LionType
 var lionType_Values = map[string]LionType{
-	microsoft.lions/lion: LionType_type,
+	"microsoft.lions/lion": LionType_type,
 }
 
 func init() {

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/Test_ConversionWithNestedAllOfs_ReturnsExpectedResult/WebTest.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/Test_ConversionWithNestedAllOfs_ReturnsExpectedResult/WebTest.golden
@@ -2,8 +2,8 @@ github.com/Azure/azure-service-operator/testing/person/v20200101
 ----------------------------------------------------------------
 WebTest: Object (4 properties)
 ├── Kind: *Enum (2 values)
-│   ├── multistep
-│   └── ping
+│   ├── "multistep"
+│   └── "ping"
 ├── Location: *string
 ├── Properties: WebTestProperties
 └── Tags: *interface{}

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/Test_ConversionWithNestedAllOfs_ReturnsExpectedResult/WebTestResource.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/Test_ConversionWithNestedAllOfs_ReturnsExpectedResult/WebTestResource.golden
@@ -4,8 +4,8 @@ WebTestResource: Resource
 ├── Spec: Object (6 properties)
 │   ├── AzureName: string
 │   ├── Kind: *Enum (2 values)
-│   │   ├── multistep
-│   │   └── ping
+│   │   ├── "multistep"
+│   │   └── "ping"
 │   ├── Location: *string
 │   ├── Name: string
 │   ├── Properties: WebTestProperties


### PR DESCRIPTION
This matches the behavior in the actual generated code - these values are all quoted if they are strings.

## Checklist

<!--
_Delete any that don't apply. For completed items, change [ ] to [x]._
-->

- [ ] this PR contains documentation
- [x] this PR contains tests
- [ ] this PR contains YAML Samples
