### PR TITLE
feat: Remove deny-list for pre-deletion check

### DIFF
--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -19,7 +19,6 @@ import (
 	"github.com/rotisserie/eris"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -1031,10 +1030,6 @@ func ConvertToARMResourceImpl(
 	return result, nil
 }
 
-// skipDeletionPrecheck is a set of resource groups for which we skip the pre-deletion existence check.
-// This is to bypass the need to re-record every test in one go - we enable the extra check group by group.
-var skipDeletionPrecheck = sets.NewString()
-
 // deleteResource deletes a resource in ARM. This function is used as the default deletion handler and can
 // have its behavior modified by resources implementing the genruntime.Deleter extension
 func (r *azureDeploymentReconcilerInstance) deleteResource(
@@ -1057,16 +1052,11 @@ func (r *azureDeploymentReconcilerInstance) deleteResource(
 	}
 
 	// Check to see if the resource has already been deleted from Azure - if so, we're done.
-	// But, first check to see if this resource is in a deny group, and skip the check if so.
-	// This is to allow us to fix up remaining issues one by one instead of all at once.
-	group := obj.GetObjectKind().GroupVersionKind().Group
-	if !skipDeletionPrecheck.Has(group) {
-		if _, _, err := r.getStatus(ctx, obj, resourceID); err != nil {
-			if genericarmclient.IsNotFoundError(err) {
-				// Resource no longer exists
-				log.V(Info).Info("Resource is already gone, skipping issue of DELETE to Azure")
-				return ctrl.Result{}, nil
-			}
+	if _, _, err := r.getStatus(ctx, obj, resourceID); err != nil {
+		if genericarmclient.IsNotFoundError(err) {
+			// Resource no longer exists
+			log.V(Info).Info("Resource is already gone, skipping issue of DELETE to Azure")
+			return ctrl.Result{}, nil
 		}
 	}
 


### PR DESCRIPTION
## What this PR does

Now that we've enabled the pre-deletion existence check for all groups, we can remove the deny-list infrastructure that enabled gradual migration.

Closes #5108 

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdHF1dHdxeWNkM2FvbW9zN3puZGtwc2t4dXhyMGd4OHozN2tkenpnaSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/26tOZ42Mg6pbTUPHW/giphy.gif)
