### PR TITLE
Make the reconcile policy in effect available to resource extensions

### DIFF
--- a/docs/hugo/content/contributing/extension-points/post-reconciliation-checker.md
+++ b/docs/hugo/content/contributing/extension-points/post-reconciliation-checker.md
@@ -231,6 +231,11 @@ When testing `PostReconciliationChecker` extensions:
 
 - **Call `next()` if appropriate**: Allows for check chaining (rarely needed)
 - **Don't modify the resource**: This is for validation only
+- **Respect the reconcile policy**: This check runs even when the policy forbids modification, since the
+  skip path still updates status, so an extension that acts on Azure must first call
+  `reconcilers.ReconcilePolicyFromContext`. To act on *another* resource, check that one too with
+  `reconcilers.ReconcilePolicyForAnnotation(ctx, itsAnnotation)`. Resolve it there rather than by hand: an
+  unusable annotation falls back to the operator's policy, not the namespace's
 - **Be patient**: Checks may run many times before succeeding
 - **Use factory methods**: Always uses the factory methods for `PostReconcileCheckResult` to ensure consistency
 - **Provide clear reasons**: Failure messages shown to users

--- a/v2/internal/reconcilers/generic/generic_reconciler.go
+++ b/v2/internal/reconcilers/generic/generic_reconciler.go
@@ -237,8 +237,9 @@ func (gr *GenericReconciler) createOrUpdate(ctx context.Context, log logr.Logger
 	}
 
 	genruntime.AddLabel(metaObj, labels.LastReconciledVersionLabel, version.BuildVersion)
-	reconcilePolicy := gr.mergeReconcilePolicy(ctx, log, metaObj)
-	if !reconcilePolicy.AllowsModify() {
+	reconcilePolicies := gr.mergeReconcilePolicy(ctx, log, metaObj)
+	ctx = reconcilers.WithReconcilePolicies(ctx, reconcilePolicies)
+	if !reconcilePolicies.Effective.AllowsModify() {
 		return ctrl.Result{}, gr.handleSkipReconcile(ctx, log, metaObj)
 	}
 
@@ -249,9 +250,10 @@ func (gr *GenericReconciler) createOrUpdate(ctx context.Context, log logr.Logger
 
 func (gr *GenericReconciler) delete(ctx context.Context, log logr.Logger, metaObj genruntime.MetaObject) (ctrl.Result, error) {
 	// Check the reconcile policy to ensure we're allowed to issue a delete
-	reconcilePolicy := gr.mergeReconcilePolicy(ctx, log, metaObj)
-	if !reconcilePolicy.AllowsDelete() {
-		log.V(Info).Info("Bypassing delete of resource due to policy", "policy", reconcilePolicy)
+	reconcilePolicies := gr.mergeReconcilePolicy(ctx, log, metaObj)
+	ctx = reconcilers.WithReconcilePolicies(ctx, reconcilePolicies)
+	if !reconcilePolicies.Effective.AllowsDelete() {
+		log.V(Info).Info("Bypassing delete of resource due to policy", "policy", reconcilePolicies.Effective)
 		controllerutil.RemoveFinalizer(metaObj, genruntime.ReconcilerFinalizer)
 		log.V(Status).Info("Deleted resource")
 		return ctrl.Result{}, nil
@@ -355,11 +357,9 @@ func (gr *GenericReconciler) CommitUpdate(
 }
 
 func (gr *GenericReconciler) handleSkipReconcile(ctx context.Context, log logr.Logger, obj genruntime.MetaObject) error {
-	reconcilePolicy := gr.mergeReconcilePolicy(ctx, log, obj)
-
 	log.V(Status).Info(
 		"Skipping creation/update of resource due to policy",
-		annotations.ReconcilePolicy, reconcilePolicy,
+		annotations.ReconcilePolicy, reconcilers.ReconcilePolicyFromContext(ctx),
 	)
 
 	err := gr.Reconciler.UpdateStatus(ctx, log, gr.Recorder, obj)
@@ -389,31 +389,33 @@ func (gr *GenericReconciler) writeReadyConditionErrorOrDefault(ctx context.Conte
 	return err
 }
 
-func (gr *GenericReconciler) mergeReconcilePolicy(ctx context.Context, log logr.Logger, obj genruntime.MetaObject) annotations.ReconcilePolicyValue {
-	// We initially get the reconcile policy from the object itself
-	source := "default" // assume the source is the default policy for now - this source field is used only for logging purposes
-	policyStr := obj.GetAnnotations()[annotations.ReconcilePolicy]
-
-	// If the policy is not defined at object level, then we check if it's defined at namespace level
-	if policyStr == "" {
-		namespaceObject, err := gr.KubeClient.GetObject(ctx, types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetNamespace()}, schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"})
-		// if we cannot get the namespace, we return default reconcile policy
-		if err != nil {
-			log.V(Verbose).Info("Error while retrieving namespace object", "error", err)
-			return gr.Config.DefaultReconcilePolicy // return default in case of error
-		}
-		policyStr = namespaceObject.GetAnnotations()[annotations.ReconcilePolicy]
-		if policyStr != "" {
-			source = "namespace"
-		}
-	} else {
-		source = "object" // used to track where the policy was taken from for logging purposes
-	}
-
+func (gr *GenericReconciler) mergeReconcilePolicy(
+	ctx context.Context,
+	log logr.Logger,
+	obj genruntime.MetaObject,
+) reconcilers.ReconcilePolicies {
 	// If no configured default policy, we set it to 'manage'
 	defaultReconcilePolicy := gr.Config.DefaultReconcilePolicy
 	if defaultReconcilePolicy == "" {
 		defaultReconcilePolicy = annotations.ReconcilePolicyManage
+	}
+
+	// We initially get the reconcile policy from the object itself
+	source := "object" // this source field is used only for logging purposes
+	policyStr := obj.GetAnnotations()[annotations.ReconcilePolicy]
+
+	namespacePolicyStr, namespaceRead := gr.namespaceReconcilePolicy(ctx, log, obj.GetNamespace())
+
+	// If the policy is not defined at object level, then we use the one defined at namespace level
+	if policyStr == "" {
+		if namespaceRead {
+			policyStr = namespacePolicyStr
+			source = "namespace"
+		}
+
+		if policyStr == "" {
+			source = "default"
+		}
 	}
 
 	reconcilePolicy, err := reconcilers.ParseReconcilePolicy(policyStr, defaultReconcilePolicy)
@@ -425,6 +427,44 @@ func (gr *GenericReconciler) mergeReconcilePolicy(ctx context.Context, log logr.
 			"policyAnnotation", policyStr,
 		)
 	}
+
+	// What a resource in this namespace carrying no annotation of its own would get. Unlike the policy
+	// above this fails closed, since a namespace we couldn't read may say to skip
+	inheritedPolicy := annotations.ReconcilePolicySkip
+	if namespaceRead {
+		inheritedPolicy, err = reconcilers.ParseReconcilePolicy(namespacePolicyStr, defaultReconcilePolicy)
+		if err != nil {
+			log.V(Verbose).Info(
+				"Namespace has an unusable reconcile policy. Applying default policy instead",
+				"policyAnnotation", namespacePolicyStr,
+			)
+		}
+	}
+
 	log.V(Verbose).Info("Retrieved reconcile policy", "policy", reconcilePolicy, "source", source)
-	return reconcilePolicy
+
+	return reconcilers.ReconcilePolicies{
+		Effective: reconcilePolicy,
+		Inherited: inheritedPolicy,
+		Default:   defaultReconcilePolicy,
+	}
+}
+
+// namespaceReconcilePolicy returns the reconcile-policy annotation of the given namespace, and whether
+// the namespace could be read at all.
+func (gr *GenericReconciler) namespaceReconcilePolicy(
+	ctx context.Context,
+	log logr.Logger,
+	namespace string,
+) (string, bool) {
+	namespaceObject, err := gr.KubeClient.GetObject(
+		ctx,
+		types.NamespacedName{Name: namespace},
+		schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"})
+	if err != nil {
+		log.V(Verbose).Info("Error while retrieving namespace object", "error", err)
+		return "", false
+	}
+
+	return namespaceObject.GetAnnotations()[annotations.ReconcilePolicy], true
 }

--- a/v2/internal/reconcilers/generic/generic_reconciler.go
+++ b/v2/internal/reconcilers/generic/generic_reconciler.go
@@ -460,7 +460,8 @@ func (gr *GenericReconciler) namespaceReconcilePolicy(
 	namespaceObject, err := gr.KubeClient.GetObject(
 		ctx,
 		types.NamespacedName{Name: namespace},
-		schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"})
+		schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"},
+	)
 	if err != nil {
 		log.V(Verbose).Info("Error while retrieving namespace object", "error", err)
 		return "", false

--- a/v2/internal/reconcilers/generic/generic_reconciler_test.go
+++ b/v2/internal/reconcilers/generic/generic_reconciler_test.go
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package generic
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	resources "github.com/Azure/azure-service-operator/v2/api/resources/v1api20200601"
+	"github.com/Azure/azure-service-operator/v2/internal/config"
+	"github.com/Azure/azure-service-operator/v2/internal/util/kubeclient"
+	"github.com/Azure/azure-service-operator/v2/pkg/common/annotations"
+)
+
+// Inherited decides whether a resource other than the one being reconciled may be touched, so unlike the
+// effective policy it has to fail closed
+func Test_MergeReconcilePolicy_givenAnnotations_returnsExpectedPolicies(t *testing.T) {
+	t.Parallel()
+
+	const namespace = "test-namespace"
+
+	cases := map[string]struct {
+		objectPolicy      string
+		namespacePolicy   string
+		namespaceMissing  bool
+		expectedEffective annotations.ReconcilePolicyValue
+		expectedInherited annotations.ReconcilePolicyValue
+	}{
+		"Nothing annotated": {
+			expectedEffective: annotations.ReconcilePolicyManage,
+			expectedInherited: annotations.ReconcilePolicyManage,
+		},
+		"Namespace says skip": {
+			namespacePolicy:   string(annotations.ReconcilePolicySkip),
+			expectedEffective: annotations.ReconcilePolicySkip,
+			expectedInherited: annotations.ReconcilePolicySkip,
+		},
+		"Object overrides a namespace that says skip": {
+			objectPolicy:      string(annotations.ReconcilePolicyManage),
+			namespacePolicy:   string(annotations.ReconcilePolicySkip),
+			expectedEffective: annotations.ReconcilePolicyManage,
+			expectedInherited: annotations.ReconcilePolicySkip,
+		},
+		"Unreadable namespace, object annotated": {
+			objectPolicy:      string(annotations.ReconcilePolicyManage),
+			namespaceMissing:  true,
+			expectedEffective: annotations.ReconcilePolicyManage,
+			expectedInherited: annotations.ReconcilePolicySkip,
+		},
+		// The namespace we cannot read may be the one that says to leave everything alone
+		"Unreadable namespace, nothing annotated": {
+			namespaceMissing:  true,
+			expectedEffective: annotations.ReconcilePolicyManage,
+			expectedInherited: annotations.ReconcilePolicySkip,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			s := runtime.NewScheme()
+			g.Expect(corev1.AddToScheme(s)).To(Succeed())
+
+			builder := fake.NewClientBuilder().WithScheme(s)
+			if !c.namespaceMissing {
+				builder = builder.WithObjects(&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        namespace,
+						Annotations: policyAnnotation(c.namespacePolicy),
+					},
+				})
+			}
+
+			reconciler := &GenericReconciler{
+				KubeClient: kubeclient.NewClient(builder.Build()),
+				Config: config.Values{
+					DefaultReconcilePolicy: annotations.ReconcilePolicyManage,
+				},
+			}
+
+			obj := &resources.ResourceGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "rg",
+					Namespace:   namespace,
+					Annotations: policyAnnotation(c.objectPolicy),
+				},
+			}
+
+			policies := reconciler.mergeReconcilePolicy(context.Background(), logr.Discard(), obj)
+
+			g.Expect(policies.Effective).To(Equal(c.expectedEffective))
+			g.Expect(policies.Inherited).To(Equal(c.expectedInherited))
+		})
+	}
+}
+
+func policyAnnotation(policy string) map[string]string {
+	if policy == "" {
+		return nil
+	}
+
+	return map[string]string{annotations.ReconcilePolicy: policy}
+}

--- a/v2/internal/reconcilers/reconcile_policy_context.go
+++ b/v2/internal/reconcilers/reconcile_policy_context.go
@@ -1,0 +1,73 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package reconcilers
+
+import (
+	"context"
+
+	"github.com/Azure/azure-service-operator/v2/pkg/common/annotations"
+)
+
+type reconcilePoliciesContextKey struct{}
+
+// ReconcilePolicies are the reconcile policies in effect during a reconcile, none of which a resource
+// extension can work out on its own. Read them with ReconcilePolicyFromContext or
+// ReconcilePolicyForAnnotation rather than combining them.
+type ReconcilePolicies struct {
+	// Effective is the policy for the resource being reconciled, resolved from its own annotation, its
+	// namespace, and the operator's configuration.
+	Effective annotations.ReconcilePolicyValue
+
+	// Inherited is the policy a resource in this namespace carrying no annotation of its own would get.
+	Inherited annotations.ReconcilePolicyValue
+
+	// Default is the policy the operator is configured with, which an unusable annotation falls back to.
+	Default annotations.ReconcilePolicyValue
+}
+
+// WithReconcilePolicies returns a context carrying the reconcile policies in effect.
+func WithReconcilePolicies(ctx context.Context, policies ReconcilePolicies) context.Context {
+	return context.WithValue(ctx, reconcilePoliciesContextKey{}, policies)
+}
+
+// ReconcilePolicyFromContext returns the policy for the resource being reconciled. A post-reconcile check
+// runs even when that policy forbids modification, since the skip path still updates status, so an
+// extension that acts on Azure has to ask before doing anything at all.
+func ReconcilePolicyFromContext(ctx context.Context) annotations.ReconcilePolicyValue {
+	return reconcilePoliciesFromContext(ctx).Effective
+}
+
+// ReconcilePolicyForAnnotation returns the reconcile policy for a resource other than the one being
+// reconciled, given that resource's own reconcile-policy annotation. An extension that modifies another
+// resource in Azure must respect the policy it is managed under, and can't resolve it alone: the resource
+// carries only its annotation, while the namespace and the operator supply the rest.
+func ReconcilePolicyForAnnotation(ctx context.Context, annotation string) annotations.ReconcilePolicyValue {
+	policies := reconcilePoliciesFromContext(ctx)
+	if annotation == "" {
+		return policies.Inherited
+	}
+
+	// The error belongs to the reconcile of the resource carrying the annotation; the policy returned
+	// with it is the fallback that reconcile will itself apply
+	policy, _ := ParseReconcilePolicy(annotation, policies.Default)
+
+	return policy
+}
+
+// reconcilePoliciesFromContext returns the policies recorded on the context, or manage when there are
+// none, which happens outside of a reconcile.
+func reconcilePoliciesFromContext(ctx context.Context) ReconcilePolicies {
+	policies, ok := ctx.Value(reconcilePoliciesContextKey{}).(ReconcilePolicies)
+	if !ok {
+		return ReconcilePolicies{
+			Effective: annotations.ReconcilePolicyManage,
+			Inherited: annotations.ReconcilePolicyManage,
+			Default:   annotations.ReconcilePolicyManage,
+		}
+	}
+
+	return policies
+}

--- a/v2/internal/reconcilers/reconcile_policy_context_test.go
+++ b/v2/internal/reconcilers/reconcile_policy_context_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package reconcilers_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/azure-service-operator/v2/internal/reconcilers"
+	"github.com/Azure/azure-service-operator/v2/pkg/common/annotations"
+)
+
+func Test_ReconcilePolicyForAnnotation_givenAnnotation_resolvesItAsTheReconcilerWould(t *testing.T) {
+	t.Parallel()
+
+	policies := reconcilers.ReconcilePolicies{
+		// Belongs to the resource being reconciled, and must not decide another resource's policy
+		Effective: annotations.ReconcilePolicyDetachOnDelete,
+		Inherited: annotations.ReconcilePolicySkip,
+		Default:   annotations.ReconcilePolicyManage,
+	}
+
+	cases := map[string]struct {
+		annotation string
+		expected   annotations.ReconcilePolicyValue
+	}{
+		"No annotation takes what the namespace and the operator say": {
+			expected: annotations.ReconcilePolicySkip,
+		},
+		"An annotation is taken at its word": {
+			annotation: string(annotations.ReconcilePolicyManage),
+			expected:   annotations.ReconcilePolicyManage,
+		},
+		"So is one that forbids modification": {
+			annotation: string(annotations.ReconcilePolicySkip),
+			expected:   annotations.ReconcilePolicySkip,
+		},
+		// A reconciler parses a non-empty annotation against the operator's policy, never the namespace's
+		"An unusable annotation falls back to the operator's policy, not the namespace's": {
+			annotation: "nonsense",
+			expected:   annotations.ReconcilePolicyManage,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			ctx := reconcilers.WithReconcilePolicies(context.Background(), policies)
+
+			g.Expect(reconcilers.ReconcilePolicyForAnnotation(ctx, c.annotation)).To(Equal(c.expected))
+		})
+	}
+}
+
+// The reverse of the case above: an operator configured to leave things alone must not have that
+// overridden by a namespace that permits management
+func Test_ReconcilePolicyForAnnotation_givenUnusableAnnotation_doesNotOverrideASkippingOperator(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	ctx := reconcilers.WithReconcilePolicies(context.Background(), reconcilers.ReconcilePolicies{
+		Effective: annotations.ReconcilePolicyManage,
+		Inherited: annotations.ReconcilePolicyManage,
+		Default:   annotations.ReconcilePolicySkip,
+	})
+
+	g.Expect(reconcilers.ReconcilePolicyForAnnotation(ctx, "nonsense")).
+		To(Equal(annotations.ReconcilePolicySkip))
+}
+
+func Test_ReconcilePolicyFromContext_givenPolicies_returnsTheEffectiveOne(t *testing.T) {
+	t.Parallel()
+
+	values := []annotations.ReconcilePolicyValue{
+		annotations.ReconcilePolicyManage,
+		annotations.ReconcilePolicySkip,
+		annotations.ReconcilePolicyDetachOnDelete,
+	}
+
+	for _, effective := range values {
+		t.Run(string(effective), func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			ctx := reconcilers.WithReconcilePolicies(context.Background(), reconcilers.ReconcilePolicies{
+				Effective: effective,
+				Inherited: annotations.ReconcilePolicySkip,
+				Default:   annotations.ReconcilePolicyManage,
+			})
+
+			g.Expect(reconcilers.ReconcilePolicyFromContext(ctx)).To(Equal(effective))
+		})
+	}
+}
+
+func Test_ReconcilePolicies_givenNoPolicies_areManage(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	// Nothing outside of a reconcile records a policy, and the operator's own default is to manage
+	g.Expect(reconcilers.ReconcilePolicyFromContext(context.Background())).
+		To(Equal(annotations.ReconcilePolicyManage))
+	g.Expect(reconcilers.ReconcilePolicyForAnnotation(context.Background(), "")).
+		To(Equal(annotations.ReconcilePolicyManage))
+	g.Expect(reconcilers.ReconcilePolicyForAnnotation(context.Background(), "nonsense")).
+		To(Equal(annotations.ReconcilePolicyManage))
+}


### PR DESCRIPTION
## What

Records the resolved reconcile policies on the context, and resolves against them in one place
rather than leaving each extension to combine the pieces.

- `reconcilers.ReconcilePolicyFromContext(ctx)` — the policy for the resource being reconciled.
- `reconcilers.ReconcilePolicyForAnnotation(ctx, annotation)` — the policy for some *other*
  resource, given that resource's own annotation.

## Why

A post-reconciliation check still runs when the policy forbids modification, because the skip
path updates status. An extension that acts on Azure — invokes an ARM action, say — currently
has no way to know that: it sees only the resource, while the namespace and the operator supply
the rest of the answer.

Resolution happens here rather than at the call site because it's easy to get backwards. An
annotation that can't be parsed falls back to the **operator's** configured policy, not the
namespace's; an absent annotation takes the **namespace's**. Getting that wrong either strands a
resource nobody acts on, or acts on one that was meant to be left alone.

## Behaviour changes

Both are in `mergeReconcilePolicy`, so worth a careful look:

1. **`Inherited` fails closed.** A namespace that can't be read may be the one saying to skip,
   and acting on a resource we were told to leave alone is worse than not acting on one we could
   have touched.
2. **A namespace read failure no longer returns a raw config value.** It previously returned
   `Config.DefaultReconcilePolicy` directly, which is `""` when unset. It now goes through the
   same fallback as every other path, so the answer is `manage` rather than an empty policy.

## Testing

First unit tests in `internal/reconcilers/generic` — five cases over `mergeReconcilePolicy`
covering object/namespace/default precedence and both unreadable-namespace paths, plus unit
tests for each accessor. The existing recorded `Test_ReconcilePolicy*` suite passes unchanged.

## Review notes

Addressed from the automated review:
- The namespace read used a namespaced key for a cluster-scoped `Namespace`. Corrected, and the
  unit test now exercises a real fake client instead of intercepting the call — reverting the fix
  makes that test fail.
- `handleSkipReconcile` no longer recomputes the policies; it reads the ones already on the
  context, dropping a redundant namespace read.

---

📚 **Standalone.** This does not depend on the `Microsoft.DatabaseWatcher` PRs and touches no
files belonging to them; it was initially opened stacked on #5607 by mistake, which made its diff
look far larger than it is. It is now based directly on `main`: 5 files, ~375 lines.

Its consumer is #5609, which needs to know whether it may invoke an ARM action, but this stands on
its own — the second behaviour change above is a latent correctness issue independent of that.
