### PR TITLE
feat: Enhance the Deleter resource extension interface

### DIFF
--- a/docs/hugo/.htmltest.yml
+++ b/docs/hugo/.htmltest.yml
@@ -25,6 +25,7 @@ IgnoreURLs:
   - "https://stackoverflow.com/questions/55503893/helm-patch-default-service-account" # Returns 403, even though valid. Checked 2025-05-06
   - "https://stackoverflow.com/questions/53866196/how-best-to-say-a-value-is-required-in-a-helm-chart" # Returns 403, even though valid. Checked 2025-05-06
   - "https://pkg.go.dev/k8s.io/code-generator/cmd/conversion-gen" # Consistently times out, but works through the browser. Checked 2026-07-28
+  - "https://kubernetes.slack.com/archives/C0NH30761/p1677110151888539" # Returns 403 even though valid. Checked 2026-08-12
   # These suppressions no longer seem to be required, but keeping them here for easy reinstatement if required
   #  - "https://code.visualstudio.com/docs/devcontainers/containers" # Returns 403 even though valid. Checked 2025-02-14
 LogLevel: 3

--- a/docs/hugo/content/contributing/extension-points/deleter.md
+++ b/docs/hugo/content/contributing/extension-points/deleter.md
@@ -6,13 +6,39 @@ weight: 30
 
 ## Description
 
-`Deleter` allows resources to customize how the reconciler deletes them from Azure. This extension is invoked when a resource has a deletion timestamp in Kubernetes (indicating the user wants to delete it) and gives the resource control over the deletion process.
+`Deleter` allows a resource to customize how ASO deletes it from Azure. ASO invokes the extension after Kubernetes sets the resource's deletion timestamp and before issuing the standard ARM DELETE request.
 
-The interface is called after Kubernetes marks the resource for deletion but before the standard ARM DELETE operation. This allows resources to perform cleanup, handle special deletion scenarios, or coordinate multiple deletion operations.
+The extension returns an `extensions.DeleteResult` describing what ASO should do next. This allows the extension to complete or block deletion, delegate to the standard ARM deletion path, or start a long-running operation that ASO monitors.
 
 ## Interface Definition
 
-See the [Deleter interface definition](https://github.com/Azure/azure-service-operator/blob/main/v2/pkg/genruntime/extensions/deleter.go) in the source code.
+See the [Deleter interface definition](https://github.com/Azure/azure-service-operator/blob/main/v2/pkg/genruntime/extensions/deleter.go) and [DeleteResult definition](https://github.com/Azure/azure-service-operator/blob/main/v2/pkg/genruntime/extensions/delete_result.go) in the source code.
+
+`Delete()` has the following signature:
+
+```go
+Delete(
+    ctx context.Context,
+    log logr.Logger,
+    resolver *resolver.Resolver,
+    armClient *genericarmclient.GenericClient,
+    obj genruntime.ARMMetaObject,
+    next extensions.DeleteFunc,
+) (extensions.DeleteResult, error)
+```
+
+## Deletion Results
+
+Return one of the following results to describe the deletion state:
+
+| Result | Meaning |
+| --- | --- |
+| `extensions.ProceedWithDelete()` | Continue a composed deletion flow. Most extensions should call `next()` and return its result instead. |
+| `extensions.BlockDelete(message)` | Keep the finalizer and retry later. ASO exposes `message` in the resource's Ready condition. |
+| `extensions.DeleteCompleted()` | Deletion is complete. ASO can remove the finalizer without issuing another ARM DELETE request. |
+| `extensions.MonitorDelete(pollerResponse)` | A long-running deletion operation has started. ASO stores its resume token and requeues until it completes. |
+
+Return `extensions.DeleteResult{}` with an error. ASO ignores the result when the error is non-nil and retries reconciliation according to the error classification.
 
 ## Motivation
 
@@ -29,19 +55,19 @@ The `Deleter` extension exists to handle cases where:
 
 Implement `Deleter` when:
 
-- ✅ Pre-deletion operations must be performed (e.g., canceling, disabling)
-- ✅ Multiple Azure API calls are needed for complete deletion
-- ✅ Deletion order matters across related resources
-- ✅ Custom error handling is needed during deletion
-- ✅ Soft-delete or purge operations require special logic
-- ✅ The resource should be preserved in Azure in some scenarios
+- Pre-deletion operations must be performed, such as canceling or disabling a resource.
+- Multiple Azure API calls are needed for complete deletion.
+- Deletion order matters across related resources.
+- Custom error handling is needed during deletion.
+- Soft-delete or purge operations require special logic.
+- The resource should be preserved in Azure in some scenarios.
 
 Do **not** use `Deleter` when:
 
-- ❌ The standard DELETE operation works correctly
-- ❌ You only need to clean up Kubernetes resources (use finalizers)
-- ❌ The logic should apply to all resources (modify the controller)
-- ❌ You're working around an Azure API bug (fix/report the bug)
+- The standard DELETE operation works correctly.
+- You only need to clean up Kubernetes resources; use finalizers instead.
+- The logic should apply to all resources; modify the controller instead.
+- You're working around an Azure API bug; fix or report the bug instead.
 
 ## Example: Subscription Alias Deletion
 
@@ -68,13 +94,13 @@ func (ex *ResourceExtension) Delete(
     armClient *genericarmclient.GenericClient,
     obj genruntime.ARMMetaObject,
     next extensions.DeleteFunc,
-) (ctrl.Result, error) {
+) (extensions.DeleteResult, error) {
     resource := obj.(*myservice.MyResource)
 
     // Perform cleanup operation
     log.V(Status).Info("Performing pre-deletion cleanup")
     if err := ex.performCleanup(ctx, resource, armClient); err != nil {
-        return ctrl.Result{}, eris.Wrap(err, "cleanup failed")
+        return extensions.DeleteResult{}, eris.Wrap(err, "cleanup failed")
     }
 
     // Proceed with standard deletion
@@ -92,14 +118,14 @@ func (ex *ResourceExtension) Delete(
     armClient *genericarmclient.GenericClient,
     obj genruntime.ARMMetaObject,
     next extensions.DeleteFunc,
-) (ctrl.Result, error) {
+) (extensions.DeleteResult, error) {
     resource := obj.(*myservice.MyResource)
 
     // Check if resource should be preserved in Azure
     if ex.shouldPreserve(resource) {
         log.V(Status).Info("Skipping Azure deletion, resource marked for preservation")
-        // Return success without calling next() - finalizer will be removed
-        return ctrl.Result{}, nil
+        // Report completion without calling next(), allowing ASO to remove the finalizer.
+        return extensions.DeleteCompleted(), nil
     }
 
     // Proceed with normal deletion
@@ -107,7 +133,9 @@ func (ex *ResourceExtension) Delete(
 }
 ```
 
-### Pattern 3: Soft Delete with Purge Option
+### Pattern 3: Temporarily Block Deletion
+
+Use `BlockDelete()` when a prerequisite can become ready later. ASO keeps the finalizer, updates the Ready condition with the supplied message, and retries the deletion.
 
 ```go
 func (ex *ResourceExtension) Delete(
@@ -117,26 +145,59 @@ func (ex *ResourceExtension) Delete(
     armClient *genericarmclient.GenericClient,
     obj genruntime.ARMMetaObject,
     next extensions.DeleteFunc,
-) (ctrl.Result, error) {
+) (extensions.DeleteResult, error) {
     resource := obj.(*myservice.MyResource)
 
-    // Perform standard deletion (moves to soft-deleted state)
+    ready, err := ex.dependentsAreDeleted(ctx, resource, armClient)
+    if err != nil {
+        return extensions.DeleteResult{}, eris.Wrap(err, "checking dependent resources")
+    }
+
+    if !ready {
+        return extensions.BlockDelete("Waiting for dependent resources to be deleted"), nil
+    }
+
+    return next(ctx, log, resolver, armClient, obj)
+}
+```
+
+### Pattern 4: Soft Delete with a Long-running Purge
+
+This pattern applies when the standard soft-delete operation completes synchronously and the subsequent purge returns an ARM long-running operation. Return the purge poller response through `MonitorDelete()` so ASO persists and resumes the operation.
+
+```go
+func (ex *ResourceExtension) Delete(
+    ctx context.Context,
+    log logr.Logger,
+    resolver *resolver.Resolver,
+    armClient *genericarmclient.GenericClient,
+    obj genruntime.ARMMetaObject,
+    next extensions.DeleteFunc,
+) (extensions.DeleteResult, error) {
+    resource := obj.(*myservice.MyResource)
+
+    // For this resource type, standard deletion moves the resource into its
+    // soft-deleted state synchronously.
     result, err := next(ctx, log, resolver, armClient, obj)
     if err != nil {
         return result, err
     }
 
-    // If purge is requested, purge the soft-deleted resource
-    if resource.Spec.DeleteMode != nil && *resource.Spec.DeleteMode == "Purge" {
-        log.V(Status).Info("Purging soft-deleted resource")
-        if err := ex.purgeResource(ctx, resource, armClient); err != nil {
-            return ctrl.Result{}, eris.Wrap(err, "failed to purge resource")
-        }
+    if resource.Spec.DeleteMode == nil || *resource.Spec.DeleteMode != "Purge" {
+        return result, nil
     }
 
-    return ctrl.Result{}, nil
+    log.V(Status).Info("Purging soft-deleted resource")
+    pollerResponse, err := ex.beginPurge(ctx, resource, armClient)
+    if err != nil {
+        return extensions.DeleteResult{}, eris.Wrap(err, "starting purge")
+    }
+
+    return extensions.MonitorDelete(pollerResponse), nil
 }
 ```
+
+Do not start the purge until the soft-delete operation has completed. If the standard DELETE operation for a resource can return a long-running operation, model the soft-delete and purge as separate idempotent stages.
 
 ## Deletion Lifecycle
 
@@ -146,11 +207,12 @@ Understanding the deletion process:
 2. **Finalizer blocks deletion**: ASO finalizer prevents immediate removal from Kubernetes
 3. **Deleter invoked**: Custom `Delete()` method is called
 4. **Pre-deletion logic**: Extension performs custom operations
-5. **Standard deletion**: `next()` sends DELETE to ARM
-6. **ARM deletion completes**: Azure resource is removed
-7. **Finalizer removed**: Kubernetes removes the resource
+5. **Result returned**: The extension returns a `DeleteResult` or delegates to `next()`.
+6. **Deletion handled**: ASO blocks, completes, or monitors deletion based on the result.
+7. **Operation monitored**: For `MonitorDelete()`, ASO stores the resume token and requeues until Azure reports completion.
+8. **Finalizer removed**: ASO removes the finalizer after deletion completes, allowing Kubernetes to remove the resource.
 
-If any step fails, the process pauses and will retry on the next reconciliation.
+If any step returns an error or blocks deletion, ASO keeps the finalizer and retries on a later reconciliation.
 
 ## Error Handling
 
@@ -158,19 +220,25 @@ Proper error handling in deleters is critical:
 
 ```go
 // Transient error - will retry
-return ctrl.Result{}, eris.Wrap(err, "temporary failure")
+return extensions.DeleteResult{}, eris.Wrap(err, "temporary failure")
 
 // Permanent error with condition
-return ctrl.Result{}, conditions.NewReadyConditionImpactingError(
+return extensions.DeleteResult{}, conditions.NewReadyConditionImpactingError(
     err,
     conditions.ConditionSeverityError,
     conditions.ReasonFailed)
 
-// Requeue for later retry
-return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+// Prerequisite not ready - Ready condition is updated and deletion retries later
+return extensions.BlockDelete("Waiting for dependent resources to be deleted"), nil
 
-// Success
-return ctrl.Result{}, nil
+// Custom deletion completed - finalizer can be removed
+return extensions.DeleteCompleted(), nil
+
+// Long-running deletion started - ASO stores and resumes the poller
+return extensions.MonitorDelete(pollerResponse), nil
+
+// Run the standard ARM deletion path
+return next(ctx, log, resolver, armClient, obj)
 ```
 
 ## Testing
@@ -182,13 +250,15 @@ When testing `Deleter` extensions:
 3. **Test error scenarios**: Verify error handling prevents finalizer removal
 4. **Test idempotency**: Multiple calls should be safe
 5. **Test conditional paths**: Cover all branching logic
-6. **Test requeue behavior**: Verify multi-step deletions requeue correctly
+6. **Test each result**: Verify completed, blocked, and monitored deletion paths.
+7. **Test poller handling**: Verify long-running operations return the expected poller response.
 
 ## Important Notes
 
 - **Always call `next()` unless**: You have a very specific reason to skip Azure deletion
 - **Handle missing IDs gracefully**: Resource might not have been created in Azure yet
-- **Return appropriate Results**: Use `RequeueAfter` for async operations
+- **Return the correct result**: Use `DeleteCompleted()`, `BlockDelete()`, or `MonitorDelete()` rather than constructing a controller result.
+- **Let ASO monitor operations**: Return the poller response instead of storing resume tokens or scheduling retries in the extension.
 - **Log clearly**: Deletion issues are hard to debug, good logging helps
 - **Be idempotent**: Deletion might be called multiple times
 - **Don't leak resources**: Ensure Azure resources are eventually deleted

--- a/docs/hugo/content/contributing/extension-points/deleter.md
+++ b/docs/hugo/content/contributing/extension-points/deleter.md
@@ -33,12 +33,13 @@ Return one of the following results to describe the deletion state:
 
 | Result | Meaning |
 | --- | --- |
-| `extensions.ProceedWithDelete()` | Continue a composed deletion flow. Most extensions should call `next()` and return its result instead. |
 | `extensions.BlockDelete(message)` | Keep the finalizer and retry later. ASO exposes `message` in the resource's Ready condition. |
 | `extensions.DeleteCompleted()` | Deletion is complete. ASO can remove the finalizer without issuing another ARM DELETE request. |
 | `extensions.MonitorDelete(pollerResponse)` | A long-running deletion operation has started. ASO stores its resume token and requeues until it completes. |
 
 Return `extensions.DeleteResult{}` with an error. ASO ignores the result when the error is non-nil and retries reconciliation according to the error classification.
+
+If you want the deletion to proceed, call the `next()` function, which invokes the standard ARM DELETE operation. The result from `next()` can be returned directly or modified before returning.
 
 ## Motivation
 

--- a/v2/api/apimanagement/customizations/product_extensions.go
+++ b/v2/api/apimanagement/customizations/product_extensions.go
@@ -45,8 +45,9 @@ func (extension *ProductExtension) Delete(
 	}
 
 	if id.Parent == nil {
-		return extensions.DeleteResult{}, eris.Wrapf(err, ". APIM Product had no parent ID: %s", id.String())
+		return extensions.DeleteResult{}, eris.Errorf("APIM Product has no parent ID: %s", id.String())
 	}
+
 	parentName := id.Parent.Name
 
 	// Using armClient.ClientOptions() here ensures we share the same HTTP connection, so this is not opening a new

--- a/v2/api/apimanagement/customizations/product_extensions.go
+++ b/v2/api/apimanagement/customizations/product_extensions.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/apimanagement/armapimanagement/v2"
 	"github.com/go-logr/logr"
 	"github.com/rotisserie/eris"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	storage "github.com/Azure/azure-service-operator/v2/api/apimanagement/v20240501/storage"
@@ -29,10 +28,10 @@ func (extension *ProductExtension) Delete(
 	armClient *genericarmclient.GenericClient,
 	obj genruntime.ARMMetaObject,
 	next extensions.DeleteFunc,
-) (ctrl.Result, error) {
+) (extensions.DeleteResult, error) {
 	typedObj, ok := obj.(*storage.Product)
 	if !ok {
-		return ctrl.Result{}, eris.Errorf("cannot run on unknown resource type %T, expected *apiManagement.Product", obj)
+		return extensions.DeleteResult{}, eris.Errorf("cannot run on unknown resource type %T, expected *apiManagement.Product", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -42,11 +41,11 @@ func (extension *ProductExtension) Delete(
 	productName := typedObj.GetName()
 	id, err := genruntime.GetAndParseResourceID(typedObj)
 	if err != nil {
-		return ctrl.Result{}, eris.Wrapf(err, "failed to get the ARM ResourceId for %s", productName)
+		return extensions.DeleteResult{}, eris.Wrapf(err, "failed to get the ARM ResourceId for %s", productName)
 	}
 
 	if id.Parent == nil {
-		return ctrl.Result{}, eris.Wrapf(err, ". APIM Product had no parent ID: %s", id.String())
+		return extensions.DeleteResult{}, eris.Wrapf(err, ". APIM Product had no parent ID: %s", id.String())
 	}
 	parentName := id.Parent.Name
 
@@ -54,7 +53,7 @@ func (extension *ProductExtension) Delete(
 	// connection each time through
 	clientFactory, err := armapimanagement.NewClientFactory(id.SubscriptionID, armClient.Creds(), armClient.ClientOptions())
 	if err != nil {
-		return ctrl.Result{}, eris.Wrapf(err, "failed to create new apimClient")
+		return extensions.DeleteResult{}, eris.Wrapf(err, "failed to create new apimClient")
 	}
 
 	// This is a synchronous operation
@@ -71,9 +70,10 @@ func (extension *ProductExtension) Delete(
 	if err != nil {
 		// If the product (or its parent) is already gone, treat as success
 		if genericarmclient.IsNotFoundError(err) {
-			return next(ctx, log, resolver, armClient, obj)
+			return extensions.DeleteCompleted(), nil
 		}
-		return ctrl.Result{}, eris.Wrapf(err, "failed to delete product %q", productName)
+
+		return extensions.DeleteResult{}, eris.Wrapf(err, "failed to delete product %q", productName)
 	}
 
 	return next(ctx, log, resolver, armClient, obj)

--- a/v2/api/subscription/customizations/alias_extensions.go
+++ b/v2/api/subscription/customizations/alias_extensions.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/subscription/armsubscription"
 	"github.com/go-logr/logr"
 	"github.com/rotisserie/eris"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	storage "github.com/Azure/azure-service-operator/v2/api/subscription/v20211001/storage"
@@ -28,11 +27,11 @@ func (extension *AliasExtension) Delete(
 	armClient *genericarmclient.GenericClient,
 	obj genruntime.ARMMetaObject,
 	next extensions.DeleteFunc,
-) (ctrl.Result, error) {
+) (extensions.DeleteResult, error) {
 	// First cancel the subscription, then delete the alias
 	typedObj, ok := obj.(*storage.Alias)
 	if !ok {
-		return ctrl.Result{}, eris.Errorf("cannot run on unknown resource type %T, expected *subscription.Alias", obj)
+		return extensions.DeleteResult{}, eris.Errorf("cannot run on unknown resource type %T, expected *subscription.Alias", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -50,7 +49,7 @@ func (extension *AliasExtension) Delete(
 	// connection each time through
 	subscriptionClient, err := armsubscription.NewClient(armClient.Creds(), armClient.ClientOptions())
 	if err != nil {
-		return ctrl.Result{}, eris.Wrapf(err, "failed to create new workspaceClient")
+		return extensions.DeleteResult{}, eris.Wrapf(err, "failed to create new subscriptionClient")
 	}
 
 	// Don't need to do anything with the response here so just ignore it.
@@ -58,7 +57,7 @@ func (extension *AliasExtension) Delete(
 	_, err = subscriptionClient.Cancel(ctx, subscriptionID, nil)
 	if err != nil {
 		// TODO: May need to set condition error here
-		return ctrl.Result{}, eris.Wrapf(err, "failed to cancel subscription %q", subscriptionID)
+		return extensions.DeleteResult{}, eris.Wrapf(err, "failed to cancel subscription %q", subscriptionID)
 	}
 
 	return next(ctx, log, resolver, armClient, obj)

--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -224,9 +224,11 @@ func (r *azureDeploymentReconcilerInstance) StartDeleteOfResource(ctx context.Co
 		}
 
 	default:
-		// Deletion completed successfully
-		return ctrl.Result{}, nil
+		// Fall-through
 	}
+
+	// Deletion completed successfully
+	return ctrl.Result{}, nil
 }
 
 // MonitorDelete will call Azure to check if the resource still exists. If so, it will requeue, else,

--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -189,7 +189,9 @@ func (r *azureDeploymentReconcilerInstance) StartDeleteOfResource(ctx context.Co
 		return ctrl.Result{}, err
 	}
 
-	if result.MonitorDeletion() {
+	switch {
+
+	case result.MonitorDeletion():
 		token, err := result.OperationToken()
 		if err != nil {
 			return ctrl.Result{},
@@ -208,21 +210,23 @@ func (r *azureDeploymentReconcilerInstance) StartDeleteOfResource(ctx context.Co
 			Requeue:      true,
 			RequeueAfter: result.RetryAfter(),
 		}, nil
+
+	case result.BlockDeletion():
+		if result.BlockDeletion() {
+			msg := fmt.Sprintf(
+				"Resource deletion blocked: %s",
+				result.Message(),
+			)
+
+			r.Log.V(Verbose).Info(msg)
+
+			return ctrl.Result{}, result.CreateConditionError()
+		}
+
+	default:
+		// Deletion completed successfully
+		return ctrl.Result{}, nil
 	}
-
-	if result.BlockDeletion() {
-		msg := fmt.Sprintf(
-			"Resource deletion blocked: %s",
-			result.Message(),
-		)
-
-		r.Log.V(Verbose).Info(msg)
-
-		return ctrl.Result{}, result.CreateConditionError()
-	}
-
-	// Deletion completed successfully
-	return ctrl.Result{}, nil
 }
 
 // MonitorDelete will call Azure to check if the resource still exists. If so, it will requeue, else,

--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -184,7 +184,6 @@ func (r *azureDeploymentReconcilerInstance) StartDeleteOfResource(ctx context.Co
 
 	deleter := extensions.CreateDeleter(r.Extension, r.deleteResource)
 	result, err := deleter(ctx, r.Log, r.ResourceResolver, r.ARMConnection.Client(), r.Obj)
-
 	if err != nil {
 		// Something went wrong
 		return ctrl.Result{}, err

--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -212,16 +212,14 @@ func (r *azureDeploymentReconcilerInstance) StartDeleteOfResource(ctx context.Co
 		}, nil
 
 	case result.BlockDeletion():
-		if result.BlockDeletion() {
-			msg := fmt.Sprintf(
-				"Resource deletion blocked: %s",
-				result.Message(),
-			)
+		msg := fmt.Sprintf(
+			"Resource deletion blocked: %s",
+			result.Message(),
+		)
 
-			r.Log.V(Verbose).Info(msg)
+		r.Log.V(Verbose).Info(msg)
 
-			return ctrl.Result{}, result.CreateConditionError()
-		}
+		return ctrl.Result{}, result.CreateConditionError()
 
 	default:
 		// Fall-through

--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -184,7 +184,46 @@ func (r *azureDeploymentReconcilerInstance) StartDeleteOfResource(ctx context.Co
 
 	deleter := extensions.CreateDeleter(r.Extension, r.deleteResource)
 	result, err := deleter(ctx, r.Log, r.ResourceResolver, r.ARMConnection.Client(), r.Obj)
-	return result, err
+
+	if err != nil {
+		// Something went wrong
+		return ctrl.Result{}, err
+	}
+
+	if result.MonitorDeletion() {
+		token, err := result.OperationToken()
+		if err != nil {
+			return ctrl.Result{},
+				eris.Wrapf(err, "couldn't create DELETE resume token for resource %q", r.Obj.AzureName())
+		}
+
+		operationId, ok := result.OperationID()
+		if !ok {
+			return ctrl.Result{}, eris.Errorf("couldn't get operation ID for resource %q", r.Obj.AzureName())
+		}
+
+		SetPollerResumeToken(r.Obj, operationId, token)
+
+		// Normally don't need to set both of these fields but because retryAfter can be 0 we do
+		return ctrl.Result{
+			Requeue:      true,
+			RequeueAfter: result.RetryAfter(),
+		}, nil
+	}
+
+	if result.BlockDeletion() {
+		msg := fmt.Sprintf(
+			"Resource deletion blocked: %s",
+			result.Message(),
+		)
+
+		r.Log.V(Verbose).Info(msg)
+
+		return ctrl.Result{}, result.CreateConditionError()
+	}
+
+	// Deletion completed successfully
+	return ctrl.Result{}, nil
 }
 
 // MonitorDelete will call Azure to check if the resource still exists. If so, it will requeue, else,
@@ -1038,17 +1077,17 @@ func (r *azureDeploymentReconcilerInstance) deleteResource(
 	resolver *resolver.Resolver,
 	armClient *genericarmclient.GenericClient,
 	obj genruntime.ARMMetaObject,
-) (ctrl.Result, error) {
+) (extensions.DeleteResult, error) {
 	// If we have no resourceID to begin with, the Azure resource was never created
 	resourceID := genruntime.GetResourceIDOrDefault(obj)
 	if resourceID == "" {
 		log.V(Status).Info("Not issuing ARM delete as resource had no ResourceID annotation")
-		return ctrl.Result{}, nil
+		return extensions.DeleteCompleted(), nil
 	}
 
 	err := r.checkSubscription(resourceID)
 	if err != nil {
-		return ctrl.Result{}, err
+		return extensions.DeleteResult{}, err
 	}
 
 	// Check to see if the resource has already been deleted from Azure - if so, we're done.
@@ -1056,7 +1095,7 @@ func (r *azureDeploymentReconcilerInstance) deleteResource(
 		if genericarmclient.IsNotFoundError(err) {
 			// Resource no longer exists
 			log.V(Info).Info("Resource is already gone, skipping issue of DELETE to Azure")
-			return ctrl.Result{}, nil
+			return extensions.DeleteCompleted(), nil
 		}
 	}
 
@@ -1070,31 +1109,23 @@ func (r *azureDeploymentReconcilerInstance) deleteResource(
 	// retryAfter = ARM can tell us how long to wait for a DELETE
 	originalAPIVersion, err := genruntime.GetAPIVersion(obj, resolver.Scheme())
 	if err != nil {
-		return ctrl.Result{}, err
+		return extensions.DeleteResult{}, err
 	}
 	pollerResp, err := armClient.BeginDeleteByID(ctx, resourceID, originalAPIVersion)
 	if err != nil {
 		if genericarmclient.IsNotFoundError(err) {
 			log.V(Info).Info("Successfully issued DELETE to Azure - resource was already gone")
-			return ctrl.Result{}, nil
+			return extensions.DeleteCompleted(), nil
 		}
-		return ctrl.Result{}, r.handleDeleteFailed(err)
+		return extensions.DeleteResult{}, r.handleDeleteFailed(err)
 	}
 	log.V(Info).Info("Successfully issued DELETE to Azure")
 
 	// If we are done here it means delete succeeded immediately. It can't have failed because if it did
 	// we would have taken the error path, above.
 	if pollerResp.Poller.Done() {
-		return ctrl.Result{}, nil
+		return extensions.DeleteCompleted(), nil
 	}
 
-	retryAfter := genericarmclient.GetRetryAfter(pollerResp.RawResponse)
-	resumeToken, err := pollerResp.Poller.ResumeToken()
-	if err != nil {
-		return ctrl.Result{}, eris.Wrapf(err, "couldn't create DELETE resume token for resource %q", resourceID)
-	}
-	SetPollerResumeToken(obj, pollerResp.ID, resumeToken)
-
-	// Normally don't need to set both of these fields but because retryAfter can be 0 we do
-	return ctrl.Result{Requeue: true, RequeueAfter: retryAfter}, nil
+	return extensions.MonitorDelete(pollerResp), nil
 }

--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -182,7 +182,18 @@ func (r *azureDeploymentReconcilerInstance) StartDeleteOfResource(ctx context.Co
 	r.Log.V(Status).Info(msg)
 	r.Recorder.Event(r.Obj, v1.EventTypeNormal, string(DeleteActionBeginDelete), msg)
 
+	// Ensure that we call any user implementation of extensions.Deleter if present;
+	// by default we issues a DELETE via ARM
 	deleter := extensions.CreateDeleter(r.Extension, r.deleteResource)
+	return r.executeDeletion(ctx, deleter)
+}
+
+// executeDeletion executes the deletion of a resource using the provided deleter function.
+// It handles the result of the deletion, including monitoring for completion or handling errors.
+func (r *azureDeploymentReconcilerInstance) executeDeletion(
+	ctx context.Context,
+	deleter extensions.DeleteFunc,
+) (ctrl.Result, error) {
 	result, err := deleter(ctx, r.Log, r.ResourceResolver, r.ARMConnection.Client(), r.Obj)
 	if err != nil {
 		// Something went wrong
@@ -282,27 +293,28 @@ func (r *azureDeploymentReconcilerInstance) DeleteNotPossibleInAzure(ctx context
 		return ctrl.Result{}, nil
 	}
 
+	// Ensure that we call any user implementation of extensions.Deleter if present;
+	// by default we return an error saying that deletion is not possible in Azure.
+	deleter := extensions.CreateDeleter(r.Extension, r.cannotDeleteResource)
+	return r.executeDeletion(ctx, deleter)
+}
+
+func (r *azureDeploymentReconcilerInstance) cannotDeleteResource(
+	_ context.Context,
+	log logr.Logger,
+	_ *resolver.Resolver,
+	_ *genericarmclient.GenericClient,
+	obj genruntime.ARMMetaObject,
+) (extensions.DeleteResult, error) {
 	msg := fmt.Sprintf(
 		"Resource does not support deletion in Azure; set annotation '%s: %s' to permit deletion in Kubernetes",
 		annotations.ReconcilePolicy,
 		annotations.ReconcilePolicyDetachOnDelete,
 	)
-	r.Log.V(Verbose).Info(msg)
-	r.Recorder.Event(r.Obj, v1.EventTypeNormal, string(DeleteActionNotPossibleInAzure), msg)
+	log.V(Verbose).Info(msg)
+	r.Recorder.Event(obj, v1.EventTypeNormal, string(DeleteActionNotPossibleInAzure), msg)
 
-	// Return a meaningful error so that the Ready condition is updated to show the user why the resource can't yet be deleted.
-	if err == nil {
-		err = eris.New(msg)
-	} else {
-		err = eris.Wrap(err, msg)
-	}
-
-	return ctrl.Result{},
-		conditions.NewReadyConditionImpactingError(
-			err,
-			conditions.ConditionSeverityWarning,
-			conditions.ReasonDeletionNotSupported,
-		)
+	return extensions.BlockDelete(msg), nil
 }
 
 func (r *azureDeploymentReconcilerInstance) BeginCreateOrUpdateResource(

--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -214,6 +214,19 @@ func (r *azureDeploymentReconcilerInstance) executeDeletion(
 			return ctrl.Result{}, eris.Errorf("couldn't get operation ID for resource %q", r.Obj.AzureName())
 		}
 
+		// Safety catch - currently DetermineDeleteAction requires a specific pollerID which _should_ be the one
+		// used in almost every case, but _just in case_ it's not, we want to catch it here:
+		//
+		// If you're troubleshooting this as a part of a custom extension, you need to change BOTH the check here
+		// and the resurrection of the poller in DetermineDeleteAction()
+		if operationId != genericarmclient.DeletePollerID {
+			return ctrl.Result{}, eris.Errorf(
+				"unexpected poller ID for resource %q: %s, expected %s",
+				r.Obj.AzureName(),
+				operationId,
+				genericarmclient.DeletePollerID)
+		}
+
 		SetPollerResumeToken(r.Obj, operationId, token)
 
 		// Normally don't need to set both of these fields but because retryAfter can be 0 we do

--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -232,12 +232,15 @@ func (r *azureDeploymentReconcilerInstance) executeDeletion(
 
 		return ctrl.Result{}, result.CreateConditionError()
 
+	case result.Completed():
+		return ctrl.Result{}, nil
+
 	default:
 		// Fall-through
 	}
 
-	// Deletion completed successfully
-	return ctrl.Result{}, nil
+	// Should never get here, return an error that something went awry
+	return ctrl.Result{}, eris.Errorf("unexpected result for deletion %q", result.String())
 }
 
 // MonitorDelete will call Azure to check if the resource still exists. If so, it will requeue, else,

--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -304,9 +304,14 @@ func (r *azureDeploymentReconcilerInstance) DeleteNotPossibleInAzure(ctx context
 	}
 
 	_, _, err := r.getStatus(ctx, r.Obj, resourceID)
-	if err != nil && genericarmclient.IsNotFoundError(err) {
-		// Resource no longer exists
-		return ctrl.Result{}, nil
+	if err != nil {
+		if genericarmclient.IsNotFoundError(err) {
+			// Resource no longer exists
+			return ctrl.Result{}, nil
+		}
+
+		// something else went wrong
+		return ctrl.Result{}, err
 	}
 
 	// Ensure that we call any user implementation of extensions.Deleter if present;
@@ -330,7 +335,7 @@ func (r *azureDeploymentReconcilerInstance) cannotDeleteResource(
 	log.V(Verbose).Info(msg)
 	r.Recorder.Event(obj, v1.EventTypeNormal, string(DeleteActionNotPossibleInAzure), msg)
 
-	return extensions.BlockDelete(msg), nil
+	return extensions.BlockDelete(msg, conditions.ReasonDeletionNotSupported), nil
 }
 
 func (r *azureDeploymentReconcilerInstance) BeginCreateOrUpdateResource(

--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -224,7 +224,8 @@ func (r *azureDeploymentReconcilerInstance) executeDeletion(
 				"unexpected poller ID for resource %q: %s, expected %s",
 				r.Obj.AzureName(),
 				operationId,
-				genericarmclient.DeletePollerID)
+				genericarmclient.DeletePollerID,
+			)
 		}
 
 		SetPollerResumeToken(r.Obj, operationId, token)

--- a/v2/pkg/genruntime/extensions/delete_result.go
+++ b/v2/pkg/genruntime/extensions/delete_result.go
@@ -22,14 +22,6 @@ type DeleteResult struct {
 	pollerResponse *genericarmclient.PollerResponse[genericarmclient.GenericDeleteResponse]
 }
 
-// ProceedWithDelete is returned if normal deletion of the resource should proceed.
-// with action `Proceed`.
-func ProceedWithDelete() DeleteResult {
-	return DeleteResult{
-		action: deleteResultTypeProceed,
-	}
-}
-
 // BlockDelete is returned if deletion of the resource should be blocked for now, but can be retried later
 // The deletion will automatically be retried after a short delay.
 // message is an explanatory reason to show to the user via a warning condition on the resource.
@@ -80,7 +72,7 @@ func (r DeleteResult) Message() string {
 
 // OperationID returns the operation ID associated monitoring the deletion operation, if any.
 func (r DeleteResult) OperationID() (string, bool) {
-	if r.pollerResponse == nil {
+	if r.pollerResponse == nil || r.pollerResponse.ID == "" {
 		return "", false
 	}
 

--- a/v2/pkg/genruntime/extensions/delete_result.go
+++ b/v2/pkg/genruntime/extensions/delete_result.go
@@ -35,8 +35,10 @@ func ProceedWithDelete() DeleteResult {
 // message is an explanatory reason to show to the user via a warning condition on the resource.
 func BlockDelete(message string) DeleteResult {
 	return DeleteResult{
-		action:  deleteResultTypeBlock,
-		message: message,
+		action:   deleteResultTypeBlock,
+		message:  message,
+		severity: conditions.ConditionSeverityWarning,
+		reason:   conditions.ReasonReconcileBlocked,
 	}
 }
 

--- a/v2/pkg/genruntime/extensions/delete_result.go
+++ b/v2/pkg/genruntime/extensions/delete_result.go
@@ -16,12 +16,9 @@ import (
 
 type DeleteResult struct {
 	action         deleteResultType
-	operationID    string
-	operationToken string
 	severity       conditions.ConditionSeverity
 	reason         conditions.Reason
 	message        string
-	retryAfter     time.Duration
 	pollerResponse *genericarmclient.PollerResponse[genericarmclient.GenericDeleteResponse]
 }
 

--- a/v2/pkg/genruntime/extensions/delete_result.go
+++ b/v2/pkg/genruntime/extensions/delete_result.go
@@ -34,12 +34,12 @@ func DeleteCompleted() DeleteResult {
 // BlockDelete is returned if deletion of the resource should be blocked for now, but can be retried later
 // The deletion will automatically be retried after a short delay.
 // message is an explanatory reason to show to the user via a warning condition on the resource.
-func BlockDelete(message string) DeleteResult {
+func BlockDelete(message string, reason conditions.Reason) DeleteResult {
 	return DeleteResult{
 		action:   deleteResultTypeBlock,
 		message:  message,
 		severity: conditions.ConditionSeverityWarning,
-		reason:   conditions.ReasonReconcileBlocked,
+		reason:   reason,
 	}
 }
 

--- a/v2/pkg/genruntime/extensions/delete_result.go
+++ b/v2/pkg/genruntime/extensions/delete_result.go
@@ -99,6 +99,10 @@ func (r DeleteResult) OperationToken() (string, error) {
 }
 
 func (r DeleteResult) RetryAfter() time.Duration {
+	if r.pollerResponse == nil {
+		return 0
+	}
+
 	return genericarmclient.GetRetryAfter(r.pollerResponse.RawResponse)
 }
 

--- a/v2/pkg/genruntime/extensions/delete_result.go
+++ b/v2/pkg/genruntime/extensions/delete_result.go
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package extensions
+
+import (
+	"time"
+
+	"github.com/rotisserie/eris"
+
+	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+)
+
+type DeleteResult struct {
+	action         deleteResultType
+	operationID    string
+	operationToken string
+	severity       conditions.ConditionSeverity
+	reason         conditions.Reason
+	message        string
+	retryAfter     time.Duration
+	pollerResponse *genericarmclient.PollerResponse[genericarmclient.GenericDeleteResponse]
+}
+
+// ProceedWithDelete is returned if normal deletion of the resource should proceed.
+// with action `Proceed`.
+func ProceedWithDelete() DeleteResult {
+	return DeleteResult{
+		action: deleteResultTypeProceed,
+	}
+}
+
+// BlockDelete is returned if deletion of the resource should be blocked for now, but can be retried later
+// The deletion will automatically be retried after a short delay.
+// message is an explanatory reason to show to the user via a warning condition on the resource.
+func BlockDelete(message string) DeleteResult {
+	return DeleteResult{
+		action:  deleteResultTypeBlock,
+		message: message,
+	}
+}
+
+// DeleteCompleted is returned if deletion of the resource in Azure has completed successfully.
+// No further action is needed.
+func DeleteCompleted() DeleteResult {
+	return DeleteResult{
+		action: deleteResultTypeComplete,
+	}
+}
+
+// MonitorDelete is returned if deletion of a resource in Azure is in progress.
+// pollerResponse is the response from the initial delete request,
+// which will be used to monitor the status of the deletion operation.
+func MonitorDelete(
+	pollerResponse *genericarmclient.PollerResponse[genericarmclient.GenericDeleteResponse],
+) DeleteResult {
+	return DeleteResult{
+		action:         deleteResultTypeMonitor,
+		pollerResponse: pollerResponse,
+	}
+}
+
+// BlockDeletion returns true if the deletion of the resource is currently blocked, false otherwise.
+func (r DeleteResult) BlockDeletion() bool {
+	return r.action == deleteResultTypeBlock
+}
+
+// MonitorDeletion returns true if deletion of the resource has started and needs to be monitored, false otherwise.
+func (r DeleteResult) MonitorDeletion() bool {
+	return r.action == deleteResultTypeMonitor
+}
+
+// Message returns the message associated with the DeleteResult, if any.
+// This is typically used to provide an explanatory reason to show to the user via a warning condition on the resource.
+func (r DeleteResult) Message() string {
+	return r.message
+}
+
+// OperationID returns the operation ID associated monitoring the deletion operation, if any.
+func (r DeleteResult) OperationID() (string, bool) {
+	if r.pollerResponse == nil {
+		return "", false
+	}
+
+	return r.pollerResponse.ID, true
+}
+
+// OperationToken returns the operation token associated with monitoring the deletion operation, if any.
+func (r DeleteResult) OperationToken() (string, error) {
+	if r.pollerResponse == nil {
+		return "", eris.New("no poller response available")
+	}
+
+	token, err := r.pollerResponse.Poller.ResumeToken()
+	return token, eris.Wrap(err, "unable to create resume token")
+}
+
+func (r DeleteResult) RetryAfter() time.Duration {
+	return genericarmclient.GetRetryAfter(r.pollerResponse.RawResponse)
+}
+
+func (r DeleteResult) Reason() conditions.Reason {
+	return r.reason
+}
+
+func (r DeleteResult) CreateConditionError() error {
+	return conditions.NewReadyConditionImpactingError(
+		eris.New(r.message),
+		r.severity,
+		r.reason,
+	)
+}
+
+type deleteResultType string
+
+const (
+	deleteResultTypeBlock    deleteResultType = "Block"
+	deleteResultTypeProceed  deleteResultType = "Proceed"
+	deleteResultTypeComplete deleteResultType = "Complete"
+	deleteResultTypeMonitor  deleteResultType = "Monitor"
+)

--- a/v2/pkg/genruntime/extensions/delete_result.go
+++ b/v2/pkg/genruntime/extensions/delete_result.go
@@ -6,6 +6,7 @@
 package extensions
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/rotisserie/eris"
@@ -22,6 +23,14 @@ type DeleteResult struct {
 	pollerResponse *genericarmclient.PollerResponse[genericarmclient.GenericDeleteResponse]
 }
 
+// DeleteCompleted is returned if deletion of the resource has completed successfully.
+// No further action is needed.
+func DeleteCompleted() DeleteResult {
+	return DeleteResult{
+		action: deleteResultTypeComplete,
+	}
+}
+
 // BlockDelete is returned if deletion of the resource should be blocked for now, but can be retried later
 // The deletion will automatically be retried after a short delay.
 // message is an explanatory reason to show to the user via a warning condition on the resource.
@@ -31,14 +40,6 @@ func BlockDelete(message string) DeleteResult {
 		message:  message,
 		severity: conditions.ConditionSeverityWarning,
 		reason:   conditions.ReasonReconcileBlocked,
-	}
-}
-
-// DeleteCompleted is returned if deletion of the resource in Azure has completed successfully.
-// No further action is needed.
-func DeleteCompleted() DeleteResult {
-	return DeleteResult{
-		action: deleteResultTypeComplete,
 	}
 }
 
@@ -52,6 +53,11 @@ func MonitorDelete(
 		action:         deleteResultTypeMonitor,
 		pollerResponse: pollerResponse,
 	}
+}
+
+// Completed returns true if the deletion of the resource has completed successfully, false otherwise.
+func (r DeleteResult) Completed() bool {
+	return r.action == deleteResultTypeComplete
 }
 
 // BlockDeletion returns true if the deletion of the resource is currently blocked, false otherwise.
@@ -106,6 +112,16 @@ func (r DeleteResult) CreateConditionError() error {
 		eris.New(r.message),
 		r.severity,
 		r.reason,
+	)
+}
+
+func (r DeleteResult) String() string {
+	return fmt.Sprintf(
+		"DeleteResult{action=%s, severity=%s, reason=%s, message=%s}",
+		r.action,
+		r.severity,
+		r.reason,
+		r.message,
 	)
 }
 

--- a/v2/pkg/genruntime/extensions/delete_result_test.go
+++ b/v2/pkg/genruntime/extensions/delete_result_test.go
@@ -32,10 +32,6 @@ func TestDeleteResultFactories(t *testing.T) {
 		hasOperation       bool
 		expectedRetryAfter time.Duration
 	}{
-		"proceed": {
-			result:         ProceedWithDelete(),
-			expectedAction: deleteResultTypeProceed,
-		},
 		"block": {
 			result:          BlockDelete("waiting for dependents"),
 			expectedAction:  deleteResultTypeBlock,
@@ -77,16 +73,6 @@ func TestDeleteResultFactories(t *testing.T) {
 			g.Expect(operationID).To(Equal(c.expectedOperation))
 		})
 	}
-}
-
-func TestDeleteResult_OperationTokenWithoutPollerResponse_ReturnsError(t *testing.T) {
-	t.Parallel()
-	g := NewGomegaWithT(t)
-
-	token, err := ProceedWithDelete().OperationToken()
-
-	g.Expect(token).To(BeEmpty())
-	g.Expect(err).To(MatchError("no poller response available"))
 }
 
 func TestDeleteResult_OperationToken(t *testing.T) {

--- a/v2/pkg/genruntime/extensions/delete_result_test.go
+++ b/v2/pkg/genruntime/extensions/delete_result_test.go
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package extensions
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	azcoreruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+
+	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+)
+
+func TestDeleteResultFactories(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		result             DeleteResult
+		expectedAction     deleteResultType
+		expectedBlock      bool
+		expectedMonitor    bool
+		expectedMessage    string
+		expectedOperation  string
+		hasOperation       bool
+		expectedRetryAfter time.Duration
+	}{
+		"proceed": {
+			result:         ProceedWithDelete(),
+			expectedAction: deleteResultTypeProceed,
+		},
+		"block": {
+			result:          BlockDelete("waiting for dependents"),
+			expectedAction:  deleteResultTypeBlock,
+			expectedBlock:   true,
+			expectedMessage: "waiting for dependents",
+		},
+		"complete": {
+			result:         DeleteCompleted(),
+			expectedAction: deleteResultTypeComplete,
+		},
+		"monitor": {
+			result: MonitorDelete(&genericarmclient.PollerResponse[genericarmclient.GenericDeleteResponse]{
+				ID: "delete-operation",
+				RawResponse: &http.Response{
+					Header: http.Header{"Retry-After": []string{"15"}},
+				},
+			}),
+			expectedAction:     deleteResultTypeMonitor,
+			expectedMonitor:    true,
+			expectedOperation:  "delete-operation",
+			hasOperation:       true,
+			expectedRetryAfter: 15 * time.Second,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			g.Expect(c.result.action).To(Equal(c.expectedAction))
+			g.Expect(c.result.BlockDeletion()).To(Equal(c.expectedBlock))
+			g.Expect(c.result.MonitorDeletion()).To(Equal(c.expectedMonitor))
+			g.Expect(c.result.Message()).To(Equal(c.expectedMessage))
+			g.Expect(c.result.RetryAfter()).To(Equal(c.expectedRetryAfter))
+
+			operationID, ok := c.result.OperationID()
+			g.Expect(ok).To(Equal(c.hasOperation))
+			g.Expect(operationID).To(Equal(c.expectedOperation))
+		})
+	}
+}
+
+func TestDeleteResult_OperationTokenWithoutPollerResponse_ReturnsError(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	token, err := ProceedWithDelete().OperationToken()
+
+	g.Expect(token).To(BeEmpty())
+	g.Expect(err).To(MatchError("no poller response available"))
+}
+
+func TestDeleteResult_OperationToken(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+	requestURL, err := url.Parse("https://example.com/resource")
+	g.Expect(err).ToNot(HaveOccurred())
+	response := &http.Response{
+		Body:       http.NoBody,
+		StatusCode: http.StatusAccepted,
+		Header: http.Header{
+			"Operation-Location": []string{"https://example.com/operations/1"},
+		},
+		Request: &http.Request{
+			Method: http.MethodDelete,
+			URL:    requestURL,
+		},
+	}
+	pipeline := azcoreruntime.NewPipeline("test", "v0.0.0", azcoreruntime.PipelineOptions{}, nil)
+	poller, err := azcoreruntime.NewPoller[genericarmclient.GenericDeleteResponse](response, pipeline, nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	result := MonitorDelete(&genericarmclient.PollerResponse[genericarmclient.GenericDeleteResponse]{Poller: poller})
+
+	token, err := result.OperationToken()
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(token).ToNot(BeEmpty())
+}
+
+func TestDeleteResult_CreateConditionError(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+	reason := conditions.ReasonReconcileBlocked
+	result := DeleteResult{
+		message:  "deletion is blocked",
+		severity: conditions.ConditionSeverityWarning,
+		reason:   reason,
+	}
+
+	g.Expect(result.Reason()).To(Equal(reason))
+
+	conditionErr, ok := conditions.AsReadyConditionImpactingError(result.CreateConditionError())
+	g.Expect(ok).To(BeTrue())
+	g.Expect(conditionErr.Severity).To(Equal(conditions.ConditionSeverityWarning))
+	g.Expect(conditionErr.Reason).To(Equal(reason.Name))
+	g.Expect(conditionErr.Cause()).To(MatchError("deletion is blocked"))
+}

--- a/v2/pkg/genruntime/extensions/delete_result_test.go
+++ b/v2/pkg/genruntime/extensions/delete_result_test.go
@@ -33,7 +33,7 @@ func TestDeleteResultFactories(t *testing.T) {
 		expectedRetryAfter time.Duration
 	}{
 		"block": {
-			result:          BlockDelete("waiting for dependents"),
+			result:          BlockDelete("waiting for dependents", conditions.ReasonReconcileBlocked),
 			expectedAction:  deleteResultTypeBlock,
 			expectedBlock:   true,
 			expectedMessage: "waiting for dependents",

--- a/v2/pkg/genruntime/extensions/deleter.go
+++ b/v2/pkg/genruntime/extensions/deleter.go
@@ -32,7 +32,7 @@ type Deleter interface {
 	// armClient allows making ARM API calls.
 	// obj is the Kubernetes resource being deleted.
 	// next is the default deletion implementation - call this to perform standard ARM DELETE.
-	// Returns a reconciliation result (e.g., requeue timing) and an error if deletion fails.
+	// Returns a DeleteResult indicating the status of deletion, or an error if deletion fails.
 	Delete(
 		ctx context.Context,
 		log logr.Logger,

--- a/v2/pkg/genruntime/extensions/deleter.go
+++ b/v2/pkg/genruntime/extensions/deleter.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/Azure/azure-service-operator/v2/internal/logging"
 
 	"github.com/go-logr/logr"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
 	"github.com/Azure/azure-service-operator/v2/internal/resolver"
@@ -40,7 +39,7 @@ type Deleter interface {
 		resolver *resolver.Resolver,
 		armClient *genericarmclient.GenericClient,
 		obj genruntime.ARMMetaObject,
-		next DeleteFunc) (ctrl.Result, error)
+		next DeleteFunc) (DeleteResult, error)
 }
 
 // DeleteFunc is the signature of a function that can be used to create a default Deleter
@@ -49,7 +48,7 @@ type DeleteFunc = func(
 	log logr.Logger,
 	resolver *resolver.Resolver,
 	armClient *genericarmclient.GenericClient,
-	obj genruntime.ARMMetaObject) (ctrl.Result, error)
+	obj genruntime.ARMMetaObject) (DeleteResult, error)
 
 // CreateDeleter creates a DeleteFunc. If the resource in question has not implemented the Deleter interface
 // the provided default DeleteFunc is run by default.
@@ -62,7 +61,13 @@ func CreateDeleter(
 		return next
 	}
 
-	return func(ctx context.Context, log logr.Logger, resolver *resolver.Resolver, armClient *genericarmclient.GenericClient, obj genruntime.ARMMetaObject) (ctrl.Result, error) {
+	return func(
+		ctx context.Context,
+		log logr.Logger,
+		resolver *resolver.Resolver,
+		armClient *genericarmclient.GenericClient,
+		obj genruntime.ARMMetaObject,
+	) (DeleteResult, error) {
 		log.V(Status).Info("Running customized deletion")
 		return impl.Delete(ctx, log, resolver, armClient, obj, next)
 	}


### PR DESCRIPTION
## What this PR does

Modifies the existing `extensions.Deleter` extension point by introducing a dedicated `DeleteResponse` struct that allows extensions to integrate with greater nuance.

As a part of this, handling for long-running-operations (those returning a PollerResponse) is now accessible by extensions, instead of being supported only for internal controller actions.

Closes #3471 

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPWVjZjA1ZTQ3eGYzaGY3MG56bGNqcWZmMmR4bjg4aHJnYTZsejU1a2o0Mjk0dWUzdSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/FO2ALAo2bwU1Vq45bJ/giphy.gif)

## Checklist

- [x] this PR contains documentation
- [x] this PR contains tests
