### PR TITLE
chore: Suppress checks for Slack links

### DIFF
--- a/docs/hugo/.htmltest.yml
+++ b/docs/hugo/.htmltest.yml
@@ -19,6 +19,7 @@ IgnoreURLs:
   - "/azure-workload-identity/docs/topics/service-account-labels-and-annotations.html#service-account" # Actually starts with 'https://azure.github.io' but gets treated as internal link, which fails. Checked 2025-02-14
   - "/azure-workload-identity/docs/installation/mutating-admission-webhook.html" # Actually starts with 'https://azure.github.io' but gets treated as internal link, which fails. Checked 2025-02-14
   - "https://slack.k8s.io/" # Causing timeouts as of 2025-02-14
+  - "https://kubernetes.slack.com" # Causing sporadic 403s, Checked 2026-08-17
   - "https://cert-manager.io/" # Causing timeouts as of 2025-04-14
   - "https://book.kubebuilder.io/" # Causing timeouts as of 2025-04-14
   - "https://github.com/" # GitHub is throttling harshly, causing 429 errors as of 2025-05-02


### PR DESCRIPTION
## What this PR does

We're consistently getting 403 errors verifying Slack links during our builds. They don't happen every time, but quite often - so I suspect we're being gated or throttled or some such.

I've manually verified the links and excluded them from automatic checking.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdThxaDQ3bnZmaWZsMDJ1OGowN3RxdTFna2sxZnhzNXIzNDRmcmx0ayZlcD12MV9naWZzX3NlYXJjaCZjdD1n/ftl1Bk9HaMuOmugNiZ/giphy.gif)
