### PR TITLE
Fix Taskfile versioning when Git is unavailable

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -33,10 +33,10 @@ vars:
 
   VERSION:
     # Version tags for the v2 controller must start with "v2", e.g. "v2.0.0-alpha.0".
-    sh: "{{.SCRIPTS_ROOT}}/build_version.py v2"
+    sh: 'if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then {{.SCRIPTS_ROOT}}/build_version.py v2; else echo dev; fi'
 
   LATEST_VERSION_TAG:
-    sh: git describe --tags $(git rev-list --tags='v2*' --max-count=1) --match 'v2*'
+    sh: 'if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then git describe --tags $(git rev-list --tags=''v2*'' --max-count=1) --match ''v2*''; else echo dev; fi'
 
   VERSION_FLAGS: '"-X {{.PACKAGE}}/internal/version.BuildVersion={{.VERSION}}"'
   LDFLAGS: -ldflags {{.VERSION_FLAGS}}


### PR DESCRIPTION
🤖 TheUnrepentantRobot says:

## What this PR does

Devcontainers opened from Git worktrees may not have access to the worktree's Git metadata, causing Taskfile version evaluation to fail before tasks can run.

This checks whether Git can recognize the checkout before deriving `VERSION` and `LATEST_VERSION_TAG`. When it cannot, both values fall back to the existing local development version, `dev`; normal Git-based versioning remains unchanged.

<!--  

Here are some tips:

If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. 
Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.

Closes #[issue number]
-->

<!--
### Special notes

_If there's anything complex or unusual about this PR that would help us review it, let us know here. Otherwise delete this section._
-->

## How does this PR make you feel?

N/A

## Checklist

<!--
_Delete any that don't apply. For completed items, change [ ] to [x]._
-->

- [ ] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples