### PR TITLE
Add cooldown for github actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -73,3 +73,5 @@ updates:
       codeql-action:
         patterns:
           - "github/codeql-action/*"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## What this PR does

Pulls out the only useful change from PR #5654, configuring a cooldown for dependabot GitHub action updates.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExaTBjcXY0cTE2NmlmM3Zqb3lqbWYwNTU2bGMxaDBpcXowazZuc2R2cyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/l46C8qYKF0QxKXK5G/giphy.gif)
