### PR TITLE
feat: support unhealthyPodEvictionPolicy on the PodDisruptionBudget

### DIFF
--- a/v2/charts/azure-service-operator/templates/policy_v1_poddisruptionbudget_azureserviceoperator-pdb.yaml
+++ b/v2/charts/azure-service-operator/templates/policy_v1_poddisruptionbudget_azureserviceoperator-pdb.yaml
@@ -12,4 +12,7 @@ spec:
     matchLabels:
       control-plane: controller-manager
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- with .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end }}

--- a/v2/charts/azure-service-operator/values.yaml
+++ b/v2/charts/azure-service-operator/values.yaml
@@ -206,6 +206,9 @@ podAnnotations: {}
 podDisruptionBudget:
   enabled: true
   minAvailable: 50%
+  # Policy for evicting unhealthy pods, either IfHealthyBudget or AlwaysAllow
+  # Defaults to IfHealthyBudget if unset
+  unhealthyPodEvictionPolicy: ""
 
 # Labels to be added to the pod
 podLabels: {}


### PR DESCRIPTION
## What this PR does

Adds `podDisruptionBudget.unhealthyPodEvictionPolicy` to the operator's PodDisruptionBudget. Only rendered when set, so existing releases keep the Kubernetes default of `IfHealthyBudget`. Setting it to `AlwaysAllow` lets a not-Ready replica be evicted during a node drain instead of blocking it, per the [Kubernetes drain recommendation](https://kubernetes.io/docs/tasks/run-application/configure-pdb/#pdb-unhealthy-pod-eviction-policy).

Without it, a single crash-looping operator replica takes `disruptionsAllowed` to 0 and blocks a node drain indefinitely, even though the pod is Not Ready and serving nothing.

### Special notes

The value defaults to `""` and is guarded by a falsy check in the template, following the existing `azureOperatorMode` pattern in this chart, so `helm template` output is byte-identical to `main` with default values and `controller:validate-helm` still matches the kustomize output.

There is no unit-test harness for this chart, so the checklist item for tests is left unticked rather than deleted — happy to add coverage if you'd like it somewhere.

## Checklist

- [x] this PR contains documentation
- [ ] this PR contains tests
