### PR TITLE
fix: SQL injection in user managers via proper identifier escaping

### DIFF
--- a/v2/internal/util/azuresql/azuresql.go
+++ b/v2/internal/util/azuresql/azuresql.go
@@ -104,7 +104,7 @@ ELSE
 	BEGIN
 		ALTER USER %[2]s WITH PASSWORD=%[3]s;
 	END;
-`, escapeStringLiteral(username), escapeIdentifier(username), escapeStringLiteral(password))
+`, escapeStringLiteral(username), escapeBracketIdentifier(username), escapeStringLiteral(password))
 	_, err := db.ExecContext(ctx, tsql)
 	if err != nil {
 		return err
@@ -130,14 +130,13 @@ func CreateOrUpdateAADUser(ctx context.Context, db *sql.DB, username string) err
 	}
 
 	// TODO: There doesn't seem to be a need to update (and the FROM EXTERNAL PROVIDER syntax isn't valid for ALTER anyway).
-	tsql := `
-IF NOT EXISTS (SELECT name FROM sysusers WHERE name='%[1]s')
+	//nolint:gosec // SQL identifiers cannot be parameterized; values are escaped for their SQL contexts.
+	tsql := fmt.Sprintf(`
+IF NOT EXISTS (SELECT name FROM sysusers WHERE name=%[1]s)
 	BEGIN
-		CREATE USER [%[1]s] FROM EXTERNAL PROVIDER;
+		CREATE USER %[2]s FROM EXTERNAL PROVIDER;
 	END
-`
-
-	tsql = fmt.Sprintf(tsql, username)
+`, escapeStringLiteral(username), escapeBracketIdentifier(username))
 	_, err := db.ExecContext(ctx, tsql)
 	if err != nil {
 		return err
@@ -165,7 +164,8 @@ func DropUser(ctx context.Context, db *sql.DB, username string) error {
 	if err := findBadChars(username); err != nil {
 		return eris.Wrap(err, "Problem found with username")
 	}
-	tsql := fmt.Sprintf("DROP USER [%s]", username)
+	// SQL identifiers cannot be parameterized; the value is escaped via escapeBracketIdentifier
+	tsql := fmt.Sprintf("DROP USER %s", escapeBracketIdentifier(username))
 	_, err := db.ExecContext(ctx, tsql)
 	return err
 }
@@ -176,10 +176,11 @@ func escapeStringLiteral(value string) string {
 	return "'" + escaped + "'"
 }
 
-// escapeIdentifier escapes and wraps a value for use as a double-quoted SQL identifier.
-func escapeIdentifier(value string) string {
-	escaped := strings.ReplaceAll(value, "\"", "\"\"")
-	return "\"" + escaped + "\""
+// escapeBracketIdentifier escapes and wraps a value for use as a bracket-delimited T-SQL identifier.
+// This is the standard quoting style for Azure SQL identifiers like AAD usernames.
+func escapeBracketIdentifier(value string) string {
+	escaped := strings.ReplaceAll(value, "]", "]]")
+	return "[" + escaped + "]"
 }
 
 func findBadChars(str string) error {

--- a/v2/internal/util/azuresql/azuresql_test.go
+++ b/v2/internal/util/azuresql/azuresql_test.go
@@ -114,7 +114,7 @@ func TestEscapeStringLiteral(t *testing.T) {
 	}
 }
 
-func TestEscapeIdentifier(t *testing.T) {
+func TestEscapeBracketIdentifier(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -125,17 +125,27 @@ func TestEscapeIdentifier(t *testing.T) {
 		{
 			name:     "no special chars",
 			input:    "username",
-			expected: "\"username\"",
+			expected: "[username]",
 		},
 		{
-			name:     "double quote is doubled",
-			input:    "user\"name",
-			expected: "\"user\"\"name\"",
+			name:     "closing bracket is doubled",
+			input:    "user]name",
+			expected: "[user]]name]",
+		},
+		{
+			name:     "multiple closing brackets",
+			input:    "user]]name]x",
+			expected: "[user]]]]name]]x]",
+		},
+		{
+			name:     "AAD username with at sign",
+			input:    "bob@contoso.com",
+			expected: "[bob@contoso.com]",
 		},
 		{
 			name:     "other special chars are preserved",
-			input:    "user;name",
-			expected: "\"user;name\"",
+			input:    "user;name--test",
+			expected: "[user;name--test]",
 		},
 	}
 
@@ -145,7 +155,7 @@ func TestEscapeIdentifier(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
-			result := escapeIdentifier(c.input)
+			result := escapeBracketIdentifier(c.input)
 			g.Expect(result).To(Equal(c.expected))
 		})
 	}

--- a/v2/internal/util/azuresql/role.go
+++ b/v2/internal/util/azuresql/role.go
@@ -147,7 +147,7 @@ func alterRoles(ctx context.Context, db *sql.DB, user string, roles set.Set[stri
 		if err := findBadChars(role); err != nil {
 			return eris.Wrap(err, "problem found with role")
 		}
-		_, err := builder.WriteString(fmt.Sprintf("ALTER ROLE %s %s MEMBER %s;\n", role, string(mode), user))
+		_, err := builder.WriteString(fmt.Sprintf("ALTER ROLE %s %s MEMBER %s;\n", escapeBracketIdentifier(role), string(mode), escapeBracketIdentifier(user)))
 		if err != nil {
 			return eris.Wrapf(err, "failed to build T-SQL ALTER ROLE %s statement", mode)
 		}

--- a/v2/internal/util/mysql/privilege.go
+++ b/v2/internal/util/mysql/privilege.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/rotisserie/eris"
@@ -16,6 +17,11 @@ import (
 
 	"github.com/Azure/azure-service-operator/v2/internal/set"
 )
+
+// MySQL privilege names cannot be parameterized, so allow only SQL keyword characters before interpolation.
+// See https://dev.mysql.com/doc/refman/8.4/en/grant.html (Privileges Supported by MySQL).
+// Note that while static privileges seem to never contain _, dynamic privileges can contain _
+var validPrivilegeName = regexp.MustCompile(`^[A-Za-z_ ]+$`)
 
 type SQLPrivilegeDelta struct {
 	AddedPrivileges   set.Set[string]
@@ -221,6 +227,10 @@ func addPrivileges(ctx context.Context, db *sql.DB, database string, user string
 		return nil
 	}
 
+	if err := validatePrivilegeNames(privileges); err != nil {
+		return err
+	}
+
 	toAdd := strings.Join(privileges.Values(), ",")
 	// TODO: Is there a way to just disable G201, which this violates?
 	// We say //nolint:gosec below because gosec is trying to tell us this is a dangerous SQL query with a risk of SQL
@@ -235,6 +245,10 @@ func deletePrivileges(ctx context.Context, db *sql.DB, database string, user str
 	if len(privileges) == 0 {
 		// Nothing to do
 		return nil
+	}
+
+	if err := validatePrivilegeNames(privileges); err != nil {
+		return err
 	}
 
 	toDelete := strings.Join(privileges.Values(), ",")
@@ -255,7 +269,22 @@ func asGrantTarget(database string) string {
 	if database == "" {
 		return "*.*"
 	}
-	return fmt.Sprintf("`%s`.*", database)
+	return fmt.Sprintf("%s.*", escapeBacktickIdentifier(database))
+}
+
+// escapeBacktickIdentifier escapes and wraps a value for use as a backtick-delimited MySQL identifier.
+func escapeBacktickIdentifier(value string) string {
+	escaped := strings.ReplaceAll(value, "`", "``")
+	return "`" + escaped + "`"
+}
+
+func validatePrivilegeNames(privileges set.Set[string]) error {
+	for _, priv := range privileges.Values() {
+		if !validPrivilegeName.MatchString(priv) {
+			return fmt.Errorf("invalid privilege name %q: must contain only letters, underscores, and spaces", priv)
+		}
+	}
+	return nil
 }
 
 func formatUser(user string, hostname string) string {

--- a/v2/internal/util/mysql/privilege_test.go
+++ b/v2/internal/util/mysql/privilege_test.go
@@ -82,3 +82,101 @@ func TestDiffCurrentAndExpectedSQLRoles(t *testing.T) {
 		})
 	}
 }
+
+func TestValidatePrivilegeNames(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		privileges  set.Set[string]
+		expectError bool
+	}{
+		{
+			name:        "valid single privilege",
+			privileges:  set.Make[string]("SELECT"),
+			expectError: false,
+		},
+		{
+			name:        "valid multi-word privilege",
+			privileges:  set.Make[string]("CREATE TEMPORARY TABLES"),
+			expectError: false,
+		},
+		{
+			name:        "valid dynamic privilege",
+			privileges:  set.Make[string]("BACKUP_ADMIN"),
+			expectError: false,
+		},
+		{
+			name:        "valid ALL",
+			privileges:  set.Make[string]("ALL"),
+			expectError: false,
+		},
+		{
+			name:        "semicolon rejected",
+			privileges:  set.Make[string]("SELECT; DROP TABLE users"),
+			expectError: true,
+		},
+		{
+			name:        "backtick rejected",
+			privileges:  set.Make[string]("SELECT`"),
+			expectError: true,
+		},
+		{
+			name:        "dash rejected",
+			privileges:  set.Make[string]("SELECT--comment"),
+			expectError: true,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			err := validatePrivilegeNames(c.privileges)
+			if c.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	}
+}
+
+func TestEscapeBacktickIdentifier(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no special chars",
+			input:    "mydb",
+			expected: "`mydb`",
+		},
+		{
+			name:     "backtick is doubled",
+			input:    "my`db",
+			expected: "`my``db`",
+		},
+		{
+			name:     "multiple backticks",
+			input:    "my`d`b",
+			expected: "`my``d``b`",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			result := escapeBacktickIdentifier(c.input)
+			g.Expect(result).To(Equal(c.expected))
+		})
+	}
+}

--- a/v2/internal/util/postgresql/postgresql.go
+++ b/v2/internal/util/postgresql/postgresql.go
@@ -7,11 +7,14 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"regexp"
 	"strings"
 
 	_ "github.com/jackc/pgx/v5/stdlib" // the pgx lib
 	"github.com/rotisserie/eris"
 )
+
+var validPermissionName = regexp.MustCompile(`^[A-Za-z]+$`)
 
 // PSqlServerPort is the default server port for sql server
 const PSqlServerPort = 5432
@@ -134,11 +137,14 @@ func CreateRoleWithPermissions(ctx context.Context, db *sql.DB, roleName string,
 		return eris.Wrap(err, "problem found with roleName")
 	}
 
-	permissionString := strings.Join(permissions, " ")
-	if err := FindBadChars(permissionString); err != nil {
-		return eris.Wrap(err, "problem found with permissions")
+	for _, perm := range permissions {
+		if !validPermissionName.MatchString(perm) {
+			return fmt.Errorf("invalid permission %q: must contain only letters", perm)
+		}
 	}
 
+	permissionString := strings.Join(permissions, " ")
+	// Permission words are validated above to contain only letters.
 	_, err := db.ExecContext(ctx, fmt.Sprintf("CREATE ROLE %s WITH %s", escapeIdentifier(roleName), permissionString))
 	if err != nil {
 		return eris.Wrap(err, "failed to create role")

--- a/v2/internal/util/postgresql/roles.go
+++ b/v2/internal/util/postgresql/roles.go
@@ -121,8 +121,9 @@ func addRoles(ctx context.Context, db *sql.DB, user SQLUser, roles set.Set[strin
 			return eris.Wrap(err, fmt.Sprintf("Role %q does not exists", role))
 		}
 	}
-	toAdd := strings.Join(roles.Values(), ",")
-	_, err := db.ExecContext(ctx, fmt.Sprintf("GRANT %q TO %q", toAdd, user.Name))
+	toAdd := escapeRoleList(roles)
+	// SQL identifiers cannot be parameterized; values are escaped via escapeIdentifier.
+	_, err := db.ExecContext(ctx, fmt.Sprintf("GRANT %s TO %s", toAdd, escapeIdentifier(user.Name)))
 	if err != nil {
 		errorStrings = append(errorStrings, err.Error())
 	}
@@ -138,8 +139,18 @@ func deleteRoles(ctx context.Context, db *sql.DB, user SQLUser, roles set.Set[st
 		return nil
 	}
 
-	toDelete := strings.Join(roles.Values(), ",")
-	_, err := db.ExecContext(ctx, fmt.Sprintf("REVOKE %q FROM %q", toDelete, user.Name))
+	toDelete := escapeRoleList(roles)
+	// SQL identifiers cannot be parameterized; values are escaped via escapeIdentifier.
+	_, err := db.ExecContext(ctx, fmt.Sprintf("REVOKE %s FROM %s", toDelete, escapeIdentifier(user.Name)))
 
 	return err
+}
+
+func escapeRoleList(roles set.Set[string]) string {
+	escapedRoles := make([]string, 0, len(roles))
+	for _, role := range roles.Values() {
+		escapedRoles = append(escapedRoles, escapeIdentifier(role))
+	}
+
+	return strings.Join(escapedRoles, ",")
 }


### PR DESCRIPTION
Replace blocklist-only sanitization with proper escaping

- azuresql: escape bracket identifiers in CreateOrUpdateAADUser, DropUser, and alterRoles via new escapeBracketIdentifier()
- mysql: validate privilege names against regex allowlist, escape backticks in database identifiers via escapeBacktickIdentifier()
- postgresql: use escapeIdentifier() for GRANT/REVOKE role names instead of Go %q verb, validate permission words in CreateRoleWithPermissions

## Checklist

<!--
_Delete any that don't apply. For completed items, change [ ] to [x]._
-->

- [ ] this PR contains documentation
- [x] this PR contains tests
- [ ] this PR contains YAML Samples
