### PR TITLE
fix: break in main

### DIFF
--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -82,7 +82,7 @@ write-error() {
 # Configure behaviour for devcontainer mode or not
 
 if [ "$DEVCONTAINER" = true ]; then 
-    TOOL_DEST=/usr/local/bin
+    TOOL_DEST=/go/bin
     KUBEBUILDER_DEST=/usr/local/kubebuilder
     BUILDX_DEST=/usr/lib/docker/cli-plugins
 else

--- a/v2/test/perf/perf_helpers_test.go
+++ b/v2/test/perf/perf_helpers_test.go
@@ -106,7 +106,7 @@ type Result struct {
 // It automatically collects CPU and memory metrics from the ASO controller pod
 // and writes a CSV report to the output directory. The test fails immediately
 // if metrics-server is not available on the cluster.
-func RunPerfTest(t *testing.T, tc *testcommon.KubePerTestContext, cfg Config) (result Result, err error) {
+func RunPerfTest(t *testing.T, tc *testcommon.KubePerTestContext, cfg Config) (Result, error) {
 	t.Helper()
 
 	// Set up metrics collection
@@ -198,7 +198,7 @@ func runStaticPattern(
 	tc *testcommon.KubePerTestContext,
 	factory ResourceFactory,
 	cfg *StaticConfig,
-) (Result, error) {
+) (Result, error) { //nolint:unparam
 	result := Result{}
 	start := time.Now()
 


### PR DESCRIPTION
* Container tool install path allowed built-in container tools to have precedence over our tools, meaning we were running unexpected versions of things (especially golangci-lint).
* Fix nolint:unparam on perf_helpers file due to the above.

## Checklist

<!--
_Delete any that don't apply. For completed items, change [ ] to [x]._
-->

- [ ] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
